### PR TITLE
feat: implement contributor pull-request payments (#36)

### DIFF
--- a/contracts/src/errors.rs
+++ b/contracts/src/errors.rs
@@ -22,4 +22,5 @@ pub enum Error {
     PriceOutOfBounds = 17,
     FlashLoanNotRepaid = 18,
     FlashLoanInProgress = 19,
+    AlreadyExecuted = 20,
 }

--- a/contracts/src/storage.rs
+++ b/contracts/src/storage.rs
@@ -7,3 +7,4 @@ pub const RECEIPT: Symbol = symbol_short!("RECEIPT");
 pub const FLASH_LOAN_LOCK: Symbol = symbol_short!("FL_LOCK");
 #[allow(dead_code)]
 pub const FLASH_LOAN_FEE: Symbol = symbol_short!("FL_FEE");
+pub const REQUEST_COUNT: Symbol = symbol_short!("REQ_CNT");

--- a/contracts/src/types.rs
+++ b/contracts/src/types.rs
@@ -240,3 +240,51 @@ pub struct ReceiptMetadata {
     pub total_amount: i128,
     pub token: Address,
 }
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RequestStatus {
+    Pending,
+    Approved,
+    Rejected,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContributorRequest {
+    pub id: u64,
+    pub receiver: Address,
+    pub token: Address,
+    pub total_amount: i128,
+    pub duration: u64,
+    pub start_time: u64,
+    pub status: RequestStatus,
+    pub metadata: Option<BytesN<32>>,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RequestKey {
+    Request(u64),
+    RequestCount,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct RequestCreatedEvent {
+    pub request_id: u64,
+    pub receiver: Address,
+    pub token: Address,
+    pub total_amount: i128,
+    pub duration: u64,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct RequestExecutedEvent {
+    pub request_id: u64,
+    pub stream_id: u64,
+    pub executor: Address,
+    pub timestamp: u64,
+}


### PR DESCRIPTION
## Description
Implements contributor pull-request payments system. Contributors can now request a stream (like an invoice) on-chain, and the DAO treasury (Admin) can approve and execute the request to start the fund flow. No funds move until explicit DAO authorization.

## Related Issue
Fixes #36 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
