### PR TITLE
feat(logger): integrate Winston with console and file transports

### DIFF
--- a/backend/src/logger.ts
+++ b/backend/src/logger.ts
@@ -1,63 +1,130 @@
 /**
- * Structured logging utility
+ * Structured logging utility — Winston integration (#246)
+ *
+ * Drop-in replacement for the previous console-based logger.
+ * Preserves the existing API: logger.debug / info / warn / error / event
+ *
+ * Transports:
+ *   1. Console  — always active, colorized + timestamped (dev feedback)
+ *   2. File     — activated in production or when LOG_TO_FILE=true
+ *                 errors.log  (error level only, 10 MB × 5 rotations)
+ *                 combined.log (all levels,     20 MB × 5 rotations)
+ *
+ * Env vars:
+ *   LOG_LEVEL    — override log level (default: "info" in prod, "debug" in dev)
+ *   LOG_TO_FILE  — set to "true" to enable file transport outside production
+ *   LOG_DIR      — directory for log files (default: <cwd>/logs)
  */
 
+import winston from "winston";
+import path from "path";
+
+// ─── Level type (keep backward compat with existing code) ────────────────────
 type LogLevel = "debug" | "info" | "warn" | "error";
 
-const LOG_LEVEL = (process.env.LOG_LEVEL ?? "info") as LogLevel;
+// ─── Console format: colorized, human-readable ────────────────────────────────
+const consoleFmt = winston.format.combine(
+  winston.format.timestamp({ format: "YYYY-MM-DD HH:mm:ss.SSS" }),
+  winston.format.errors({ stack: true }),
+  winston.format.colorize({ all: true }),
+  winston.format.printf(({ timestamp, level, message, stack, ...meta }) => {
+    const metaStr =
+      Object.keys(meta).length
+        ? ` ${JSON.stringify(meta)}`
+        : "";
+    const stackStr = stack ? `\n${stack}` : "";
+    return `[${timestamp}] [${level}] ${message}${metaStr}${stackStr}`;
+  })
+);
 
-const LEVELS: Record<LogLevel, number> = {
-  debug: 0,
-  info: 1,
-  warn: 2,
-  error: 3,
-};
+// ─── File format: clean JSON, no ANSI color codes ────────────────────────────
+const fileFmt = winston.format.combine(
+  winston.format.timestamp({ format: "YYYY-MM-DD HH:mm:ss.SSS" }),
+  winston.format.errors({ stack: true }),
+  winston.format.uncolorize(),
+  winston.format.json()
+);
 
-function shouldLog(level: LogLevel): boolean {
-  return LEVELS[level] >= LEVELS[LOG_LEVEL];
+// ─── Build transport list ─────────────────────────────────────────────────────
+const transports: winston.transport[] = [
+  // Transport 1 — Console (always on)
+  new winston.transports.Console({ format: consoleFmt }),
+];
+
+// Transport 2 — File (production or LOG_TO_FILE=true)
+if (
+  process.env.NODE_ENV === "production" ||
+  process.env.LOG_TO_FILE === "true"
+) {
+  const LOG_DIR = process.env.LOG_DIR ?? path.join(process.cwd(), "logs");
+
+  transports.push(
+    // Error-only file
+    new winston.transports.File({
+      filename: path.join(LOG_DIR, "errors.log"),
+      level:    "error",
+      format:   fileFmt,
+      maxsize:  10 * 1024 * 1024, // 10 MB
+      maxFiles: 5,
+    }),
+    // All levels combined
+    new winston.transports.File({
+      filename: path.join(LOG_DIR, "combined.log"),
+      format:   fileFmt,
+      maxsize:  20 * 1024 * 1024, // 20 MB
+      maxFiles: 5,
+    })
+  );
 }
 
-function formatTimestamp(): string {
-  return new Date().toISOString();
-}
+// ─── Winston instance ─────────────────────────────────────────────────────────
+const _winston = winston.createLogger({
+  level:       process.env.LOG_LEVEL ??
+               (process.env.NODE_ENV === "production" ? "info" : "debug"),
+  transports,
+  exitOnError: false,
+  silent:      process.env.NODE_ENV === "test",
+});
 
-function formatMessage(level: LogLevel, message: string, meta?: unknown): string {
-  const timestamp = formatTimestamp();
-  const metaStr = meta !== undefined ? ` ${JSON.stringify(meta)}` : "";
-  return `[${timestamp}] [${level.toUpperCase()}] ${message}${metaStr}`;
-}
-
+// ─── Public logger — identical API to the original logger.ts ─────────────────
 export const logger = {
   debug(message: string, meta?: unknown): void {
-    if (shouldLog("debug")) {
-      console.debug(formatMessage("debug", message, meta));
-    }
+    _winston.debug(message, meta !== undefined ? { meta } : {});
   },
 
   info(message: string, meta?: unknown): void {
-    if (shouldLog("info")) {
-      console.info(formatMessage("info", message, meta));
-    }
+    _winston.info(message, meta !== undefined ? { meta } : {});
   },
 
   warn(message: string, meta?: unknown): void {
-    if (shouldLog("warn")) {
-      console.warn(formatMessage("warn", message, meta));
-    }
+    _winston.warn(message, meta !== undefined ? { meta } : {});
   },
 
+  /**
+   * Mirrors original signature: error(message, error?, meta?)
+   * Automatically extracts Error.message + Error.stack for structured output.
+   */
   error(message: string, error?: unknown, meta?: unknown): void {
-    if (shouldLog("error")) {
-      const errorMeta = error instanceof Error
-        ? { message: error.message, stack: error.stack, ...(meta as object) }
-        : { error, ...(meta as object) };
-      console.error(formatMessage("error", message, errorMeta));
-    }
+    const errorMeta =
+      error instanceof Error
+        ? {
+            errorMessage: error.message,
+            stack:        error.stack,
+            ...(meta as object | undefined),
+          }
+        : { error, ...(meta as object | undefined) };
+
+    _winston.error(message, errorMeta);
   },
 
+  /**
+   * Blockchain event helper — mirrors original logger.event()
+   * Logs at INFO level with an EVENT: prefix so events are easily grep-able.
+   */
   event(eventType: string, data: unknown): void {
-    if (shouldLog("info")) {
-      console.log(formatMessage("info", `EVENT: ${eventType}`, data));
-    }
+    _winston.info(`EVENT: ${eventType}`, { data });
   },
 };
+
+// ─── Named export for direct Winston access (advanced use) ───────────────────
+export default _winston;


### PR DESCRIPTION
Closes #246

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## What Changed
Replaces the previous console-based `logger.ts` with a professional **Winston** 
implementation. The existing API is fully preserved — no other files need updating.

## Transports
| Transport | When Active | Output |
|-----------|-------------|--------|
| Console | Always | Colorized, timestamped, human-readable |
| File: `errors.log` | Production / `LOG_TO_FILE=true` | JSON, error level only, 10MB × 5 rotations |
| File: `combined.log` | Production / `LOG_TO_FILE=true` | JSON, all levels, 20MB × 5 rotations |

## API — Backward Compatible
All existing call sites continue to work unchanged:
```ts
logger.debug("message", meta?)
logger.info("message", meta?)
logger.warn("message", meta?)
logger.error("message", error?, meta?)
logger.event("EVENT_TYPE", data)
```

## What Improved vs Before
- ✅ Color-coded levels — cyan info, yellow warn, red error
- ✅ Timestamps in `YYYY-MM-DD HH:mm:ss.SSS` format
- ✅ Error stacks automatically captured and structured
- ✅ Persistent file logs in production with auto-rotation
- ✅ Silent in `NODE_ENV=test` — no noisy test output
- ✅ `LOG_LEVEL` env var controls verbosity without code changes

## Environment Variables
| Variable | Default | Description |
|----------|---------|-------------|
| `LOG_LEVEL` | `debug` (dev) / `info` (prod) | Minimum log level to output |
| `LOG_TO_FILE` | `false` | Enable file transport outside production |
| `LOG_DIR` | `<cwd>/logs` | Directory for log files |

## Checklist
- [x] I have read the `CONTRIBUTING.md` guidelines
- [x] My commits follow the Conventional Commits specification
- [x] My commits are atomic and represent singular logical changes
- [x] I have self-reviewed my own code
- [x] I have tested my changes locally and verified they pass linting and builds