### PR TITLE
feat: impl metedata service

### DIFF
--- a/backend/src/services/syncMetadata.service.ts
+++ b/backend/src/services/syncMetadata.service.ts
@@ -1,0 +1,47 @@
+import { PrismaClient } from '../generated/client';
+
+const prisma = new PrismaClient();
+
+const SINGLETON_ID = 'singleton';
+
+/**
+ * Returns the last successfully processed ledger sequence from the DB.
+ * Returns 0 on first run (no checkpoint saved yet), so the indexer
+ * starts from the beginning of time exactly once.
+ */
+export async function getLastLedgerSequence(): Promise<number> {
+  try {
+    const record = await prisma.syncMetadata.findUnique({
+      where: { id: SINGLETON_ID },
+    });
+    return record?.lastLedgerSequence ?? 0;
+  } catch (err) {
+    console.error('[SyncMetadata] Failed to read checkpoint:', err);
+    throw err;
+  }
+}
+
+/**
+ * Persists the last successfully processed ledger sequence.
+ * Uses upsert so it works seamlessly on both first run and all
+ * subsequent runs without any manual DB seeding required.
+ *
+ * IMPORTANT: Call this ONLY after a batch has been fully processed
+ * and written to the DB. Never checkpoint before processing is done.
+ */
+export async function saveLastLedgerSequence(ledgerSequence: number): Promise<void> {
+  try {
+    await prisma.syncMetadata.upsert({
+      where: { id: SINGLETON_ID },
+      update: { lastLedgerSequence: ledgerSequence },
+      create: {
+        id: SINGLETON_ID,
+        lastLedgerSequence: ledgerSequence,
+      },
+    });
+    console.log(`[SyncMetadata] Checkpoint saved at ledger ${ledgerSequence}`);
+  } catch (err) {
+    console.error('[SyncMetadata] Failed to save checkpoint:', err);
+    throw err;
+  }
+}


### PR DESCRIPTION
## 🚀 PR: Indexer Checkpointing & Reliability

### 📝 Description
Implements persistent state tracking for the blockchain indexer to prevent data loss or re-indexing from genesis upon server failure. This PR addresses the requirement for the indexer to "remember" the last ledger processed.

Closes #252 

### 🛠️ Technical Changes

#### 1. Sync Metadata Service (`backend/src/services/syncmetadata.service.ts`)
- Implemented `getLastLedgerSequence()` to retrieve the checkpoint.
- Added `saveLastLedgerSequence()` using an `upsert` operation to maintain a single state record.
- Added fallback logic to return `0` if no checkpoint exists.

#### 2. Logic Implementation
```typescript
// Example of the implemented checkpoint logic
export async function getLastLedgerSequence(): Promise<number> {
  try {
    const record = await prisma.syncMetadata.findUnique({
      where: { id: SINGLETON_ID },
    });
    return record?.lastLedgerSequence ?? 0;
  } catch (err) {
    console.error('[SyncMetadata] Failed to read checkpoint:', err);
    throw err;
  }
}