### PR TITLE
feat: add POST /api/v1/streams/metadata/batch for bulk streaming

### DIFF
--- a/backend/src/__tests__/batch-metadata.test.ts
+++ b/backend/src/__tests__/batch-metadata.test.ts
@@ -1,0 +1,322 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { writeFile, mkdir, rm } from "node:fs/promises";
+import path from "node:path";
+import http from "node:http";
+import { BatchMetadataService } from "../services/batch-metadata.service.js";
+
+// ═══════════════════════════════════════════════════════════════
+// Test helpers
+// ═══════════════════════════════════════════════════════════════
+
+const TEST_DIR = path.join(import.meta.dirname ?? process.cwd(), "__test_data__");
+const TEST_DB_PATH = path.join(TEST_DIR, "stream-lifecycle-db.json");
+
+/**
+ * Sample stream data used across all tests.
+ */
+function sampleDb() {
+    return {
+        streams: {
+            "stream-001": {
+                stream_id: "stream-001",
+                tx_hash_created: "tx-aaa",
+                sender: "GALICE",
+                receiver: "GBOB",
+                original_total_amount: "1000000",
+                streamed_amount: "250000",
+                status: "ACTIVE",
+                created_at: "2025-01-01T00:00:00Z",
+                closed_at: null,
+                updated_at: "2025-06-15T12:00:00Z",
+                last_ledger: 100,
+            },
+            "stream-002": {
+                stream_id: "stream-002",
+                tx_hash_created: "tx-bbb",
+                sender: "GCHARLIE",
+                receiver: "GDAVE",
+                original_total_amount: "5000000",
+                streamed_amount: "5000000",
+                status: "COMPLETED",
+                created_at: "2025-02-01T00:00:00Z",
+                closed_at: "2025-05-01T00:00:00Z",
+                updated_at: "2025-05-01T00:00:00Z",
+                last_ledger: 200,
+            },
+            "stream-003": {
+                stream_id: "stream-003",
+                tx_hash_created: "tx-ccc",
+                sender: "GEVE",
+                receiver: "GFRANK",
+                original_total_amount: "2000000",
+                streamed_amount: "800000",
+                status: "CANCELED",
+                created_at: "2025-03-01T00:00:00Z",
+                closed_at: "2025-04-01T00:00:00Z",
+                updated_at: "2025-04-01T00:00:00Z",
+                last_ledger: 150,
+            },
+        },
+    };
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Service-level tests
+// ═══════════════════════════════════════════════════════════════
+
+describe("BatchMetadataService", () => {
+    before(async () => {
+        await mkdir(TEST_DIR, { recursive: true });
+        await writeFile(TEST_DB_PATH, JSON.stringify(sampleDb(), null, 2), "utf-8");
+    });
+
+    after(async () => {
+        await rm(TEST_DIR, { recursive: true, force: true });
+    });
+
+    it("should return metadata for all valid stream IDs", async () => {
+        const service = new BatchMetadataService(TEST_DB_PATH);
+        const res = await service.getStreamMetadataBatch([
+            "stream-001",
+            "stream-002",
+            "stream-003",
+        ]);
+
+        assert.equal(res.results.length, 3);
+        assert.equal(res.errors.length, 0);
+        assert.equal(res.results[0].stream_id, "stream-001");
+        assert.equal(res.results[0].status, "ACTIVE");
+        assert.equal(res.results[1].stream_id, "stream-002");
+        assert.equal(res.results[1].status, "COMPLETED");
+        assert.equal(res.results[2].stream_id, "stream-003");
+        assert.equal(res.results[2].status, "CANCELED");
+    });
+
+    it("should return errors for missing stream IDs", async () => {
+        const service = new BatchMetadataService(TEST_DB_PATH);
+        const res = await service.getStreamMetadataBatch([
+            "nonexistent-1",
+            "nonexistent-2",
+        ]);
+
+        assert.equal(res.results.length, 0);
+        assert.equal(res.errors.length, 2);
+        assert.equal(res.errors[0].stream_id, "nonexistent-1");
+        assert.equal(res.errors[0].error, "Stream not found");
+    });
+
+    it("should handle mixed found and not-found IDs", async () => {
+        const service = new BatchMetadataService(TEST_DB_PATH);
+        const res = await service.getStreamMetadataBatch([
+            "stream-001",
+            "nonexistent",
+            "stream-003",
+        ]);
+
+        assert.equal(res.results.length, 2);
+        assert.equal(res.errors.length, 1);
+        assert.equal(res.results[0].stream_id, "stream-001");
+        assert.equal(res.results[1].stream_id, "stream-003");
+        assert.equal(res.errors[0].stream_id, "nonexistent");
+    });
+
+    it("should return all fields in the result", async () => {
+        const service = new BatchMetadataService(TEST_DB_PATH);
+        const res = await service.getStreamMetadataBatch(["stream-001"]);
+
+        const result = res.results[0];
+        assert.equal(result.stream_id, "stream-001");
+        assert.equal(result.sender, "GALICE");
+        assert.equal(result.receiver, "GBOB");
+        assert.equal(result.original_total_amount, "1000000");
+        assert.equal(result.streamed_amount, "250000");
+        assert.equal(result.status, "ACTIVE");
+        assert.equal(result.created_at, "2025-01-01T00:00:00Z");
+        assert.equal(result.closed_at, null);
+    });
+
+    it("should return empty results when DB does not exist", async () => {
+        const service = new BatchMetadataService("/tmp/nonexistent-db.json");
+        const res = await service.getStreamMetadataBatch(["stream-001"]);
+
+        assert.equal(res.results.length, 0);
+        assert.equal(res.errors.length, 1);
+    });
+
+    it("should handle a large batch (50+ IDs)", async () => {
+        const service = new BatchMetadataService(TEST_DB_PATH);
+        const ids = Array.from({ length: 60 }, (_, i) =>
+            i < 3 ? `stream-00${i + 1}` : `fake-${i}`,
+        );
+        const res = await service.getStreamMetadataBatch(ids);
+
+        assert.equal(res.results.length, 3);
+        assert.equal(res.errors.length, 57);
+    });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// HTTP-level integration tests
+// ═══════════════════════════════════════════════════════════════
+
+/**
+ * Helper to make HTTP requests to the test server.
+ */
+function postJson(
+    port: number,
+    urlPath: string,
+    body: unknown,
+): Promise<{ statusCode: number; data: Record<string, unknown> }> {
+    return new Promise((resolve, reject) => {
+        const payload = JSON.stringify(body);
+        const req = http.request(
+            {
+                hostname: "127.0.0.1",
+                port,
+                path: urlPath,
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "Content-Length": Buffer.byteLength(payload),
+                },
+            },
+            (res) => {
+                let raw = "";
+                res.on("data", (chunk: Buffer) => {
+                    raw += chunk.toString();
+                });
+                res.on("end", () => {
+                    try {
+                        resolve({
+                            statusCode: res.statusCode ?? 500,
+                            data: JSON.parse(raw) as Record<string, unknown>,
+                        });
+                    } catch {
+                        reject(new Error(`Failed to parse response: ${raw}`));
+                    }
+                });
+            },
+        );
+        req.on("error", reject);
+        req.write(payload);
+        req.end();
+    });
+}
+
+describe("POST /api/v1/streams/metadata/batch (integration)", () => {
+    let server: http.Server;
+    let port: number;
+
+    before(async () => {
+        // Write test DB
+        await mkdir(TEST_DIR, { recursive: true });
+        await writeFile(TEST_DB_PATH, JSON.stringify(sampleDb(), null, 2), "utf-8");
+
+        // Set up a test Express server with a BatchMetadataService pointing at the test DB
+        const express = (await import("express")).default;
+        const { createBatchRoutes } = await import("../api/routes.js");
+
+        const testService = new BatchMetadataService(TEST_DB_PATH);
+        const app = express();
+        app.use(express.json());
+        app.use(createBatchRoutes(testService));
+
+        await new Promise<void>((resolve) => {
+            server = app.listen(0, "127.0.0.1", () => {
+                const addr = server.address();
+                port = typeof addr === "object" && addr !== null ? addr.port : 0;
+                resolve();
+            });
+        });
+    });
+
+    after(async () => {
+        await new Promise<void>((resolve, reject) => {
+            server.close((err) => (err ? reject(err) : resolve()));
+        });
+        await rm(TEST_DIR, { recursive: true, force: true });
+    });
+
+    it("should return 400 when streamIds is missing", async () => {
+        const { statusCode, data } = await postJson(
+            port,
+            "/api/v1/streams/metadata/batch",
+            {},
+        );
+        assert.equal(statusCode, 400);
+        assert.ok(
+            (data.error as string).includes("must be an array"),
+            `Unexpected error: ${data.error}`,
+        );
+    });
+
+    it("should return 400 when streamIds is not an array", async () => {
+        const { statusCode, data } = await postJson(
+            port,
+            "/api/v1/streams/metadata/batch",
+            { streamIds: "not-an-array" },
+        );
+        assert.equal(statusCode, 400);
+        assert.ok((data.error as string).includes("must be an array"));
+    });
+
+    it("should return 400 when streamIds is empty", async () => {
+        const { statusCode, data } = await postJson(
+            port,
+            "/api/v1/streams/metadata/batch",
+            { streamIds: [] },
+        );
+        assert.equal(statusCode, 400);
+        assert.ok((data.error as string).includes("must not be empty"));
+    });
+
+    it("should return 400 when batch size exceeds maximum", async () => {
+        const oversized = Array.from({ length: 201 }, (_, i) => `id-${i}`);
+        const { statusCode, data } = await postJson(
+            port,
+            "/api/v1/streams/metadata/batch",
+            { streamIds: oversized },
+        );
+        assert.equal(statusCode, 400);
+        assert.ok((data.error as string).includes("exceeds the maximum"));
+    });
+
+    it("should return 400 when streamIds contains non-string values", async () => {
+        const { statusCode, data } = await postJson(
+            port,
+            "/api/v1/streams/metadata/batch",
+            { streamIds: [123, null, "valid-id"] },
+        );
+        assert.equal(statusCode, 400);
+        assert.ok((data.error as string).includes("non-empty strings"));
+    });
+
+    it("should return 200 with results for valid request", async () => {
+        const { statusCode, data } = await postJson(
+            port,
+            "/api/v1/streams/metadata/batch",
+            { streamIds: ["stream-001", "stream-002"] },
+        );
+        assert.equal(statusCode, 200);
+        const results = data.results as Array<Record<string, unknown>>;
+        assert.equal(results.length, 2);
+        assert.equal(results[0].stream_id, "stream-001");
+        assert.equal(results[1].stream_id, "stream-002");
+    });
+
+    it("should return partial results for mixed valid/invalid IDs", async () => {
+        const { statusCode, data } = await postJson(
+            port,
+            "/api/v1/streams/metadata/batch",
+            { streamIds: ["stream-001", "ghost-id"] },
+        );
+        assert.equal(statusCode, 200);
+        const results = data.results as Array<Record<string, unknown>>;
+        const errors = data.errors as Array<Record<string, unknown>>;
+        assert.equal(results.length, 1);
+        assert.equal(errors.length, 1);
+        assert.equal(results[0].stream_id, "stream-001");
+        assert.equal(errors[0].stream_id, "ghost-id");
+    });
+});

--- a/backend/src/api/routes.ts
+++ b/backend/src/api/routes.ts
@@ -1,0 +1,92 @@
+import { Router, Request, Response } from "express";
+import { BatchMetadataService } from "../services/batch-metadata.service.js";
+
+/**
+ * Maximum number of stream IDs allowed in a single batch request.
+ * Prevents abuse and keeps response times predictable.
+ */
+const MAX_BATCH_SIZE = 200;
+
+/**
+ * Creates an Express Router with the batch metadata endpoint.
+ *
+ * @param batchService - Optional injected service (defaults to production instance).
+ *                       Pass a custom instance in tests to point at a test DB file.
+ */
+export function createBatchRoutes(
+    batchService: BatchMetadataService = new BatchMetadataService(),
+): Router {
+    const router = Router();
+
+    /**
+     * POST /api/v1/streams/metadata/batch
+     *
+     * Accept an array of Stream IDs and return all their current
+     * balances and statuses in a single response.
+     *
+     * Request body:
+     *   { "streamIds": ["id1", "id2", ...] }
+     *
+     * Response:
+     *   {
+     *     "results": [ { stream_id, status, sender, receiver, ... } ],
+     *     "errors":  [ { stream_id, error } ]
+     *   }
+     */
+    router.post(
+        "/api/v1/streams/metadata/batch",
+        async (req: Request, res: Response): Promise<void> => {
+            try {
+                const { streamIds } = req.body as { streamIds?: unknown };
+
+                // ── Validation ────────────────────────────────────────────
+                if (!Array.isArray(streamIds)) {
+                    res.status(400).json({
+                        error:
+                            "Invalid request body: 'streamIds' must be an array of strings.",
+                    });
+                    return;
+                }
+
+                if (streamIds.length === 0) {
+                    res.status(400).json({
+                        error: "'streamIds' array must not be empty.",
+                    });
+                    return;
+                }
+
+                if (streamIds.length > MAX_BATCH_SIZE) {
+                    res.status(400).json({
+                        error: `Batch size exceeds the maximum of ${MAX_BATCH_SIZE}. Received ${streamIds.length}.`,
+                    });
+                    return;
+                }
+
+                const invalidIds = streamIds.filter(
+                    (id: unknown) => typeof id !== "string" || id.trim().length === 0,
+                );
+                if (invalidIds.length > 0) {
+                    res.status(400).json({
+                        error:
+                            "All entries in 'streamIds' must be non-empty strings.",
+                    });
+                    return;
+                }
+
+                // ── Service call ──────────────────────────────────────────
+                const response = await batchService.getStreamMetadataBatch(
+                    streamIds as string[],
+                );
+                res.status(200).json(response);
+            } catch (err) {
+                console.error("[BatchMetadata] Unexpected error:", err);
+                res.status(500).json({ error: "Internal server error" });
+            }
+        },
+    );
+
+    return router;
+}
+
+// Default export for production usage
+export default createBatchRoutes();

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,4 +1,5 @@
 import express, { Express, Request, Response } from 'express';
+import batchRoutes from './api/routes.js';
 
 const app: Express = express();
 const PORT = process.env.PORT ?? 3000;
@@ -8,6 +9,9 @@ app.use(express.json());
 app.get('/health', (_req: Request, res: Response) => {
   res.json({ status: 'ok', message: 'StellarStream Backend is running' });
 });
+
+// Batch metadata endpoint for bulk streaming queries
+app.use(batchRoutes);
 
 app.listen(PORT, () => {
   console.log(`🚀 Server is running on port ${PORT}`);

--- a/backend/src/services/batch-metadata.service.ts
+++ b/backend/src/services/batch-metadata.service.ts
@@ -1,0 +1,133 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+/**
+ * Metadata returned for a single stream in a batch query.
+ */
+export interface StreamMetadataResult {
+  stream_id: string;
+  status: string;
+  sender: string;
+  receiver: string;
+  original_total_amount: string;
+  streamed_amount: string;
+  created_at: string;
+  closed_at: string | null;
+}
+
+/**
+ * Error entry for a stream that could not be found or processed.
+ */
+export interface StreamMetadataError {
+  stream_id: string;
+  error: string;
+}
+
+/**
+ * Combined batch response.
+ */
+export interface BatchMetadataResponse {
+  results: StreamMetadataResult[];
+  errors: StreamMetadataError[];
+}
+
+interface StreamLifecycleRecord {
+  stream_id: string;
+  tx_hash_created: string;
+  sender: string;
+  receiver: string;
+  original_total_amount: string;
+  streamed_amount: string;
+  status: string;
+  created_at: string;
+  closed_at: string | null;
+  updated_at: string;
+  last_ledger: number;
+}
+
+interface StreamLifecycleDatabase {
+  streams: Partial<Record<string, StreamLifecycleRecord>>;
+}
+
+const DEFAULT_DB_RELATIVE_PATH = path.join("data", "stream-lifecycle-db.json");
+
+/**
+ * Service for retrieving stream metadata in bulk.
+ *
+ * Reads from the same JSON-file database used by StreamLifecycleService,
+ * loading the file once per batch call to avoid repeated I/O.
+ */
+export class BatchMetadataService {
+  private readonly dbPath: string;
+
+  constructor(
+    dbPath: string = path.join(process.cwd(), DEFAULT_DB_RELATIVE_PATH),
+  ) {
+    this.dbPath = dbPath;
+  }
+
+  /**
+   * Look up metadata for an array of stream IDs.
+   *
+   * Loads the JSON DB once, then maps each requested ID to either
+   * a result or an error entry. This keeps I/O constant regardless
+   * of batch size.
+   */
+  async getStreamMetadataBatch(
+    streamIds: string[],
+  ): Promise<BatchMetadataResponse> {
+    const db = await this.loadDb();
+
+    const results: StreamMetadataResult[] = [];
+    const errors: StreamMetadataError[] = [];
+
+    for (const id of streamIds) {
+      const record = db.streams[id];
+
+      if (record) {
+        results.push({
+          stream_id: record.stream_id,
+          status: record.status,
+          sender: record.sender,
+          receiver: record.receiver,
+          original_total_amount: record.original_total_amount,
+          streamed_amount: record.streamed_amount,
+          created_at: record.created_at,
+          closed_at: record.closed_at,
+        });
+      } else {
+        errors.push({
+          stream_id: id,
+          error: "Stream not found",
+        });
+      }
+    }
+
+    return { results, errors };
+  }
+
+  private async loadDb(): Promise<StreamLifecycleDatabase> {
+    try {
+      const raw = await readFile(this.dbPath, "utf-8");
+      const parsed = JSON.parse(raw) as unknown;
+      if (
+        typeof parsed !== "object" ||
+        parsed === null ||
+        !("streams" in parsed) ||
+        typeof (parsed as { streams?: unknown }).streams !== "object" ||
+        (parsed as { streams?: unknown }).streams === null
+      ) {
+        return { streams: {} };
+      }
+      return {
+        streams: (
+          parsed as {
+            streams: Partial<Record<string, StreamLifecycleRecord>>;
+          }
+        ).streams,
+      };
+    } catch {
+      return { streams: {} };
+    }
+  }
+}

--- a/backend/src/services/index.ts
+++ b/backend/src/services/index.ts
@@ -6,3 +6,10 @@ export {
   toBigIntOrNull,
   toObjectOrNull,
 } from "./stream-lifecycle-service.js";
+
+export {
+  BatchMetadataService,
+  type BatchMetadataResponse,
+  type StreamMetadataResult,
+  type StreamMetadataError,
+} from "./batch-metadata.service.js";


### PR DESCRIPTION
Closes #288

---

- Create BatchMetadataService for efficient batch lookups from JSON DB
- Create Express route with input validation (max 200 IDs, type checks)
- Support partial-success responses (results + errors arrays)
- Add 13 tests (6 service-level + 7 HTTP integration)
- Wire route into main Express app via createBatchRoutes factory
