### PR TITLE
feat(backend): implement API key management for partner access

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -17,10 +17,6 @@ RETRY_DELAY_MS=2000
 # Rate limiting (required for /stats and /search)
 REDIS_URL=redis://localhost:6379
 
-# Optional: API key for higher rate limit (500/min vs 100/min for public)
-# Send as Authorization: Bearer <API_KEY> or X-API-Key: <API_KEY>
-# API_KEY=your-secret-key
-
 # Optional: Logging
 LOG_LEVEL=info
 

--- a/backend/prisma/migrations/add_api_key.sql
+++ b/backend/prisma/migrations/add_api_key.sql
@@ -1,0 +1,17 @@
+-- Migration: Add ApiKey table for partner API key management
+CREATE TABLE "ApiKey" (
+  "id"          TEXT        NOT NULL,
+  "keyHash"     TEXT        NOT NULL,
+  "name"        TEXT        NOT NULL,
+  "owner"       TEXT        NOT NULL,
+  "rateLimit"   INTEGER     NOT NULL DEFAULT 1000,
+  "isActive"    BOOLEAN     NOT NULL DEFAULT true,
+  "createdAt"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt"   TIMESTAMP(3) NOT NULL,
+  "lastUsedAt"  TIMESTAMP(3),
+
+  CONSTRAINT "ApiKey_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "ApiKey_keyHash_key" ON "ApiKey"("keyHash");
+CREATE INDEX "ApiKey_owner_idx" ON "ApiKey"("owner");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -150,6 +150,22 @@ enum StreamStatus {
   CANCELED
 }
 
+// API keys for 3rd-party partner dApps with elevated rate limits
+model ApiKey {
+  id          String    @id @default(cuid())
+  keyHash     String    @unique  // SHA-256 hash of the raw key (never store plaintext)
+  name        String             // Human-readable label, e.g. "Acme dApp"
+  owner       String             // Stellar address or contact identifier
+  rateLimit   Int       @default(1000) // requests per minute
+  isActive    Boolean   @default(true)
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+  lastUsedAt  DateTime?
+
+  @@index([keyHash])
+  @@index([owner])
+}
+
 // Stores ledger hashes for integrity verification
 model LedgerHash {
   sequence  Int      @id

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -83,7 +83,7 @@ app.use(cors({
   },
   credentials: true,
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
-  allowedHeaders: ['Content-Type', 'Authorization'],
+  allowedHeaders: ['Content-Type', 'Authorization', 'X-Api-Key'],
 }));
 
 app.use(bigintSerializer);

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,7 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
-import { timingSafeEqual, createHash } from 'crypto';
-
-const API_KEY = process.env.API_KEY;
+import { createHash } from 'crypto';
+import { prisma } from '../lib/db.js';
 
 function getApiKeyFromRequest(req: Request): string | null {
   const authHeader = req.headers.authorization;
@@ -15,36 +14,46 @@ function getApiKeyFromRequest(req: Request): string | null {
   return null;
 }
 
-/**
- * Constant-time comparison of two strings.
- * If expected is empty (API_KEY not set), returns false.
- */
-function secureCompare(actual: string, expected: string): boolean {
-  if (!expected || expected.length === 0) return false;
-  if (actual.length !== expected.length) return false;
-  try {
-    return timingSafeEqual(Buffer.from(actual, 'utf8'), Buffer.from(expected, 'utf8'));
-  } catch {
-    return false;
-  }
+function hashKey(raw: string): string {
+  return createHash('sha256').update(raw).digest('hex');
 }
 
 /**
- * Sets req.authenticated based on API_KEY header.
- * Does not block unauthenticated requests; rate limiter uses this for tier selection.
+ * Validates x-api-key (or Bearer token) against the ApiKey table.
+ * Sets req.authenticated, req.authenticatedKeyId, and req.apiKeyRateLimit.
+ * Does not block unauthenticated requests — rate limiter handles tiering.
  */
-export function authMiddleware(req: Request, _res: Response, next: NextFunction): void {
+export async function authMiddleware(req: Request, _res: Response, next: NextFunction): Promise<void> {
   req.authenticated = false;
-  if (!API_KEY) {
+
+  const raw = getApiKeyFromRequest(req);
+  if (!raw) {
     next();
     return;
   }
-  const provided = getApiKeyFromRequest(req);
-  if (provided !== null && secureCompare(provided, API_KEY)) {
-    req.authenticated = true;
-    req.authenticatedKeyId = createHash('sha256')
-      .update(provided)
-      .digest('hex');
+
+  const keyHash = hashKey(raw);
+
+  try {
+    const apiKey = await prisma.apiKey.findUnique({
+      where: { keyHash },
+      select: { id: true, isActive: true, rateLimit: true },
+    });
+
+    if (apiKey?.isActive) {
+      req.authenticated = true;
+      req.authenticatedKeyId = apiKey.id;
+      req.apiKeyRateLimit = apiKey.rateLimit;
+
+      // Fire-and-forget: update lastUsedAt without blocking the request
+      prisma.apiKey.update({
+        where: { id: apiKey.id },
+        data: { lastUsedAt: new Date() },
+      }).catch(() => { /* non-critical */ });
+    }
+  } catch {
+    // DB error: fail open (don't block traffic), treat as unauthenticated
   }
+
   next();
 }

--- a/backend/src/middleware/rateLimit.ts
+++ b/backend/src/middleware/rateLimit.ts
@@ -4,8 +4,8 @@ import { redis } from '../lib/redis.js';
 
 const PUBLIC_POINTS = 100;
 const PUBLIC_DURATION_SEC = 60;
-const AUTH_POINTS = 500;
-const AUTH_DURATION_SEC = 60;
+const DEFAULT_PARTNER_POINTS = 1000;
+const PARTNER_DURATION_SEC = 60;
 
 const publicLimiter = new RateLimiterRedis({
   storeClient: redis,
@@ -14,12 +14,24 @@ const publicLimiter = new RateLimiterRedis({
   duration: PUBLIC_DURATION_SEC,
 });
 
-const authLimiter = new RateLimiterRedis({
+// Default partner limiter — used when no per-key override is needed
+const defaultPartnerLimiter = new RateLimiterRedis({
   storeClient: redis,
-  keyPrefix: 'rl:auth',
-  points: AUTH_POINTS,
-  duration: AUTH_DURATION_SEC,
+  keyPrefix: 'rl:partner',
+  points: DEFAULT_PARTNER_POINTS,
+  duration: PARTNER_DURATION_SEC,
 });
+
+/** Returns a per-key limiter when the key has a custom rateLimit value. */
+function getPartnerLimiter(keyId: string, points: number): RateLimiterRedis {
+  if (points === DEFAULT_PARTNER_POINTS) return defaultPartnerLimiter;
+  return new RateLimiterRedis({
+    storeClient: redis,
+    keyPrefix: `rl:partner:${points}`,
+    points,
+    duration: PARTNER_DURATION_SEC,
+  });
+}
 
 function getRateLimitKey(req: Request): string {
   if (req.authenticated && req.authenticatedKeyId) {
@@ -29,18 +41,24 @@ function getRateLimitKey(req: Request): string {
 }
 
 /**
- * Tiered rate limit: 100/min public, 500/min authenticated.
- * Apply only to /stats and /search. Fail-closed on Redis errors (503).
+ * Tiered rate limit:
+ *   - Public (unauthenticated): 100 req/min by IP
+ *   - Partner (authenticated API key): per-key rateLimit from DB (default 1000 req/min)
  */
 export function rateLimitMiddleware(req: Request, res: Response, next: NextFunction): void {
   const key = getRateLimitKey(req);
-  const limiter = req.authenticated ? authLimiter : publicLimiter;
+
+  let limiter: RateLimiterRedis;
+  if (req.authenticated && req.authenticatedKeyId) {
+    const points = req.apiKeyRateLimit ?? DEFAULT_PARTNER_POINTS;
+    limiter = getPartnerLimiter(req.authenticatedKeyId, points);
+  } else {
+    limiter = publicLimiter;
+  }
 
   limiter
     .consume(key)
-    .then(() => {
-      next();
-    })
+    .then(() => next())
     .catch((rejRes) => {
       if (rejRes instanceof Error) {
         res.status(503).json({

--- a/backend/src/types/express.d.ts
+++ b/backend/src/types/express.d.ts
@@ -4,8 +4,10 @@ declare global {
   namespace Express {
     interface Request {
       authenticated?: boolean;
-      /** Set when authenticated; used by rate limiter for keying (hash of API key). */
+      /** Set when authenticated; the ApiKey.id from the database. */
       authenticatedKeyId?: string;
+      /** Per-key rate limit (requests/min) from the ApiKey table. */
+      apiKeyRateLimit?: number;
       /** Set by requireWalletAuth after successful signature verification (Stellar G... address). */
       walletAddress?: string;
       /** Set by requireWalletAuth when request is authenticated via wallet signature. */


### PR DESCRIPTION
closes #353 
feat(backend): implement API key management for partner access

- create ApiKey table for storing partner keys
- add middleware to validate x-api-key from request headers
- enable higher rate limits for authorized third-party dApps