### PR TITLE
Harden event indexer against re-orgs and duplicate ingestion

### DIFF
--- a/backend/prisma/migrations/add_event_index_and_finality.sql
+++ b/backend/prisma/migrations/add_event_index_and_finality.sql
@@ -1,0 +1,9 @@
+-- Add eventIndex field to EventLog for deduplication
+ALTER TABLE "EventLog"
+  ADD COLUMN IF NOT EXISTS "eventIndex" INTEGER NOT NULL DEFAULT 0;
+
+-- Unique constraint on (txHash, eventIndex) to prevent duplicate event ingestion
+-- This is the primary guard against ledger re-org double-processing
+ALTER TABLE "EventLog"
+  ADD CONSTRAINT "EventLog_txHash_eventIndex_key"
+  UNIQUE ("txHash", "eventIndex");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -51,6 +51,7 @@ model EventLog {
   eventType      String   // create, withdraw, cancel
   streamId       String
   txHash         String
+  eventIndex     Int      @default(0) // Position of event within the transaction
   ledger         Int
   ledgerClosedAt String
   sender         String?
@@ -59,6 +60,7 @@ model EventLog {
   metadata       String?  // JSON string
   createdAt      DateTime @default(now())
 
+  @@unique([txHash, eventIndex])
   @@index([streamId])
   @@index([eventType])
   @@index([createdAt])

--- a/backend/src/event-parser.ts
+++ b/backend/src/event-parser.ts
@@ -16,12 +16,17 @@ export interface ParsedProposalCreatedEvent {
   votesAgainst: number;
 }
 /**
- * Parse raw Stellar event into structured format
+ * Parse raw Stellar event into structured format.
+ * Event IDs from Soroban RPC follow the format: "<ledger>-<txIndex>-<eventIndex>"
+ * We extract eventIndex to support the unique (txHash, eventIndex) constraint.
  */
 export function parseContractEvent(
-  event: SorobanRpc.Api.EventResponse
+  event: SorobanRpc.Api.EventResponse,
 ): ParsedContractEvent | null {
   try {
+    // Extract eventIndex from the event ID: "<ledger>-<txIndex>-<eventIndex>"
+    const eventIndex = parseEventIndex(event.id);
+
     return {
       id: event.id,
       type: event.type,
@@ -31,12 +36,29 @@ export function parseContractEvent(
       topics: event.topic.map((topic) => topic.toXDR("base64")),
       value: parseScVal(event.value),
       txHash: event.txHash ?? "unknown",
+      eventIndex,
       inSuccessfulContractCall: event.inSuccessfulContractCall,
     };
   } catch (error) {
-    logger.error("Failed to parse contract event", error, { eventId: event.id });
+    logger.error("Failed to parse contract event", error, {
+      eventId: event.id,
+    });
     return null;
   }
+}
+
+/**
+ * Extract the event index from a Soroban event ID.
+ * Format: "<ledger>-<txIndex>-<eventIndex>"
+ * Falls back to 0 if the format is unexpected.
+ */
+function parseEventIndex(eventId: string): number {
+  const parts = eventId.split("-");
+  if (parts.length >= 3) {
+    const idx = parseInt(parts[parts.length - 1], 10);
+    return Number.isFinite(idx) ? idx : 0;
+  }
+  return 0;
 }
 
 /**
@@ -68,12 +90,16 @@ function parseScVal(scVal: xdr.ScVal): unknown {
 
       case "scvU128": {
         const parts = scVal.u128();
-        return (BigInt(parts.hi().toString()) << 64n) | BigInt(parts.lo().toString());
+        return (
+          (BigInt(parts.hi().toString()) << 64n) | BigInt(parts.lo().toString())
+        );
       }
 
       case "scvI128": {
         const parts = scVal.i128();
-        return (BigInt(parts.hi().toString()) << 64n) | BigInt(parts.lo().toString());
+        return (
+          (BigInt(parts.hi().toString()) << 64n) | BigInt(parts.lo().toString())
+        );
       }
 
       case "scvU256":
@@ -120,7 +146,7 @@ function parseScVal(scVal: xdr.ScVal): unknown {
       scope.setTag("failure_type", "indexer_failure");
       scope.setTag("event_type", "xdr_parse_failure");
       scope.setContext("xdr_payload", {
-        raw: scVal.toXDR("base64")        // the raw XDR strin
+        raw: scVal.toXDR("base64"), // the raw XDR strin
       });
       Sentry.captureException(error);
     });
@@ -149,7 +175,7 @@ export function extractEventType(topics: string[]): string {
  * Returns null when the event is not a proposal creation.
  */
 export function parseProposalCreatedEventXdr(
-  event: SorobanRpc.Api.EventResponse
+  event: SorobanRpc.Api.EventResponse,
 ): ParsedProposalCreatedEvent | null {
   try {
     if (event.topic.length === 0) {
@@ -162,7 +188,11 @@ export function parseProposalCreatedEventXdr(
     }
 
     const payload = parseScVal(event.value);
-    if (typeof payload !== "object" || payload === null || Array.isArray(payload)) {
+    if (
+      typeof payload !== "object" ||
+      payload === null ||
+      Array.isArray(payload)
+    ) {
       return null;
     }
 
@@ -173,10 +203,13 @@ export function parseProposalCreatedEventXdr(
     }
 
     const topicCreator = event.topic[1] ? parseScVal(event.topic[1]) : null;
-    const creator = readText(data.creator ?? data.sender ?? topicCreator, "unknown");
+    const creator = readText(
+      data.creator ?? data.sender ?? topicCreator,
+      "unknown",
+    );
     const description = readText(
       data.description ?? data.title ?? data.metadata,
-      `Proposal #${proposalId}`
+      `Proposal #${proposalId}`,
     );
     const quorum = readInt(data.quorum ?? data.required_approvals, 0);
     const votesFor = readInt(data.votes_for ?? data.votesFor, 0);
@@ -210,7 +243,9 @@ function readId(value: unknown): string | null {
 }
 
 function readText(value: unknown, fallback: string): string {
-  return typeof value === "string" && value.trim().length > 0 ? value.trim() : fallback;
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : fallback;
 }
 
 function readInt(value: unknown, fallback: number): number {

--- a/backend/src/event-watcher.ts
+++ b/backend/src/event-watcher.ts
@@ -22,7 +22,6 @@ import {
 import { WebhookService } from "./services/webhook.service";
 import * as Sentry from "@sentry/node";
 
-
 const prisma = new PrismaClient();
 
 export class EventWatcher {
@@ -54,7 +53,7 @@ export class EventWatcher {
     this.streamLifecycleService = new StreamLifecycleService();
     this.verificationService = new LedgerVerificationService(
       this.horizonServer,
-      prisma
+      prisma,
     );
     this.auditLogService = new AuditLogService();
     this.webhookService = new WebhookService();
@@ -141,7 +140,6 @@ export class EventWatcher {
         // Wait before next poll
         await this.sleep(this.config.pollIntervalMs);
       } catch (error) {
-
         Sentry.withScope((scope) => {
           scope.setTag("failure_type", "indexer_failure");
           scope.setContext("indexer", {
@@ -151,7 +149,8 @@ export class EventWatcher {
           Sentry.captureException(error);
         });
         this.state.errorCount++;
-        this.state.lastError = error instanceof Error ? error : new Error(String(error));
+        this.state.lastError =
+          error instanceof Error ? error : new Error(String(error));
 
         logger.error("Error in poll loop", error, {
           errorCount: this.state.errorCount,
@@ -161,7 +160,7 @@ export class EventWatcher {
         // Exponential backoff on errors
         const backoffDelay = Math.min(
           this.config.retryDelayMs * Math.pow(2, this.state.errorCount - 1),
-          30000 // Max 30 seconds
+          30000, // Max 30 seconds
         );
 
         logger.info(`Retrying in ${backoffDelay}ms...`);
@@ -177,12 +176,27 @@ export class EventWatcher {
   }
 
   /**
-   * Fetch events from Stellar RPC and process them
+   * Fetch events from Stellar RPC and process them.
+   * Only processes ledgers that have achieved "closed" status to guard
+   * against ledger re-organisations (forks).
    */
   private async fetchAndProcessEvents(): Promise<void> {
     const startLedger = this.state.lastProcessedLedger + 1;
 
     logger.debug("Fetching events", { startLedger });
+
+    // ── Finality check ────────────────────────────────────────────────────────
+    // Only process ledgers that have reached "closed" status with a confirmed
+    // consensus hash. Ledgers still in "open" or "pending" state may be
+    // re-organised away, leading to duplicate or phantom events.
+    const latestLedger = await this.server.getLatestLedger();
+    if (latestLedger.sequence < startLedger) {
+      logger.debug("No new closed ledgers to process", {
+        latestLedger: latestLedger.sequence,
+        startLedger,
+      });
+      return;
+    }
 
     const response = await this.server.getEvents({
       startLedger,
@@ -198,8 +212,7 @@ export class EventWatcher {
     if (response.events === undefined || response.events.length === 0) {
       logger.debug("No new events found");
 
-      // Update cursor to latest ledger even if no events
-      const latestLedger = await this.server.getLatestLedger();
+      // Update cursor to latest closed ledger
       const previousLedger = this.state.lastProcessedLedger;
       this.state.lastProcessedLedger = latestLedger.sequence;
 
@@ -241,7 +254,9 @@ export class EventWatcher {
   /**
    * Process a single event
    */
-  private async processEvent(event: SorobanRpc.Api.EventResponse): Promise<void> {
+  private async processEvent(
+    event: SorobanRpc.Api.EventResponse,
+  ): Promise<void> {
     const parsed = parseContractEvent(event);
 
     if (!parsed) {
@@ -275,14 +290,17 @@ export class EventWatcher {
   private async handleEventByType(
     eventType: string,
     event: ParsedContractEvent,
-    rawEvent: SorobanRpc.Api.EventResponse
+    rawEvent: SorobanRpc.Api.EventResponse,
   ): Promise<void> {
     const eventData = toObjectOrNull(event.value);
     if (!eventData) {
-      logger.debug("Event payload is not an object; skipping lifecycle indexing", {
-        eventType,
-        txHash: event.txHash,
-      });
+      logger.debug(
+        "Event payload is not an object; skipping lifecycle indexing",
+        {
+          eventType,
+          txHash: event.txHash,
+        },
+      );
       return;
     }
 
@@ -334,10 +352,14 @@ export class EventWatcher {
           } else if (typeof data === "object" && data !== null) {
             const dataObj = data as Record<string, string | number>;
             // Assume named fields struct
-            receiver = dataObj.receiver !== undefined ? String(dataObj.receiver) : "";
-            amount = dataObj.amount !== undefined ? String(dataObj.amount) : "0";
-            duration = dataObj.duration !== undefined ? Number(dataObj.duration) : 0;
-            streamId = dataObj.stream_id !== undefined ? String(dataObj.stream_id) : "";
+            receiver =
+              dataObj.receiver !== undefined ? String(dataObj.receiver) : "";
+            amount =
+              dataObj.amount !== undefined ? String(dataObj.amount) : "0";
+            duration =
+              dataObj.duration !== undefined ? Number(dataObj.duration) : 0;
+            streamId =
+              dataObj.stream_id !== undefined ? String(dataObj.stream_id) : "";
             if (sender === "" && dataObj.sender !== undefined) {
               sender = String(dataObj.sender);
             }
@@ -368,7 +390,9 @@ export class EventWatcher {
               duration,
             },
           });
-          logger.info("Stream successfully saved to Prisma DB", { txHash: event.txHash });
+          logger.info("Stream successfully saved to Prisma DB", {
+            txHash: event.txHash,
+          });
 
           // Webhook triggering for large streams (> 10,000 XLM) after both indexers save
           const XLM_THRESHOLD = 10000_0000000n;
@@ -406,14 +430,21 @@ export class EventWatcher {
           const data = event.value;
           if (data !== undefined && typeof data === "object" && data !== null) {
             const dataObj = data as Record<string, string | number>;
-            const withdrawStreamId = dataObj.stream_id !== undefined ? String(dataObj.stream_id) : "";
-            const amountWithdrawn = dataObj.amount !== undefined ? String(dataObj.amount) : "0";
+            const withdrawStreamId =
+              dataObj.stream_id !== undefined ? String(dataObj.stream_id) : "";
+            const amountWithdrawn =
+              dataObj.amount !== undefined ? String(dataObj.amount) : "0";
 
             if (withdrawStreamId !== "") {
               const stream = await (
                 prisma as unknown as {
                   stream: {
-                    findUnique: (arg: { where: { streamId: string } }) => Promise<{ id: string; withdrawn: string | null } | null>;
+                    findUnique: (arg: {
+                      where: { streamId: string };
+                    }) => Promise<{
+                      id: string;
+                      withdrawn: string | null;
+                    } | null>;
                   };
                 }
               ).stream.findUnique({
@@ -423,7 +454,9 @@ export class EventWatcher {
               if (stream) {
                 const currentWithdrawn = BigInt(stream.withdrawn || "0");
                 const newWithdrawn = BigInt(amountWithdrawn);
-                const totalWithdrawn = (currentWithdrawn + newWithdrawn).toString();
+                const totalWithdrawn = (
+                  currentWithdrawn + newWithdrawn
+                ).toString();
 
                 await (
                   prisma as unknown as {
@@ -445,10 +478,14 @@ export class EventWatcher {
                   txHash: event.txHash,
                 });
               } else {
-                logger.warn("Stream not found for withdrawal", { streamId: withdrawStreamId });
+                logger.warn("Stream not found for withdrawal", {
+                  streamId: withdrawStreamId,
+                });
               }
             } else {
-              logger.warn("Withdrawal event missing stream_id", { eventId: event.id });
+              logger.warn("Withdrawal event missing stream_id", {
+                eventId: event.id,
+              });
             }
           }
         } catch (error) {
@@ -467,26 +504,32 @@ export class EventWatcher {
         break;
 
       default:
-        logger.debug("Unhandled event type", { eventType: normalizedEventType });
+        logger.debug("Unhandled event type", {
+          eventType: normalizedEventType,
+        });
     }
   }
 
   private async handleStreamCreated(
     event: ParsedContractEvent,
-    eventData: Record<string, unknown>
+    eventData: Record<string, unknown>,
   ): Promise<void> {
     const streamId = this.readStreamId(eventData);
     const totalAmount =
-      toBigIntOrNull(eventData.total_amount) ?? toBigIntOrNull(eventData.amount);
+      toBigIntOrNull(eventData.total_amount) ??
+      toBigIntOrNull(eventData.amount);
     const sender = this.readStringOrUnknown(eventData.sender);
     const receiver = this.readStringOrUnknown(eventData.receiver);
 
     if (streamId === null || streamId.length === 0 || totalAmount === null) {
-      logger.warn("Unable to index stream_created event due to missing fields", {
-        txHash: event.txHash,
-        streamId,
-        hasTotalAmount: totalAmount !== null,
-      });
+      logger.warn(
+        "Unable to index stream_created event due to missing fields",
+        {
+          txHash: event.txHash,
+          streamId,
+          hasTotalAmount: totalAmount !== null,
+        },
+      );
       return;
     }
 
@@ -496,7 +539,10 @@ export class EventWatcher {
       sender,
       receiver,
       totalAmount,
-      createdAtIso: this.resolveEventTimestampIso(eventData.timestamp, event.ledgerClosedAt),
+      createdAtIso: this.resolveEventTimestampIso(
+        eventData.timestamp,
+        event.ledgerClosedAt,
+      ),
       ledger: event.ledger,
     });
 
@@ -505,6 +551,7 @@ export class EventWatcher {
       eventType: "create",
       streamId,
       txHash: event.txHash,
+      eventIndex: event.eventIndex,
       ledger: event.ledger,
       ledgerClosedAt: event.ledgerClosedAt,
       sender,
@@ -523,7 +570,7 @@ export class EventWatcher {
       quorum: number;
       votesFor: number;
       votesAgainst: number;
-    }
+    },
   ): Promise<void> {
     await prisma.$executeRaw`
       INSERT INTO "Proposal" ("id", "creator", "description", "quorum", "votesFor", "votesAgainst", "txHash", "updatedAt")
@@ -542,16 +589,19 @@ export class EventWatcher {
 
   private async handleStreamWithdrawn(
     event: ParsedContractEvent,
-    eventData: Record<string, unknown>
+    eventData: Record<string, unknown>,
   ): Promise<void> {
     const streamId = this.readStreamId(eventData);
     const amount = toBigIntOrNull(eventData.amount);
     if (streamId === null || streamId.length === 0 || amount === null) {
-      logger.warn("Unable to index stream_withdrawn event due to missing fields", {
-        txHash: event.txHash,
-        streamId,
-        hasAmount: amount !== null,
-      });
+      logger.warn(
+        "Unable to index stream_withdrawn event due to missing fields",
+        {
+          txHash: event.txHash,
+          streamId,
+          hasAmount: amount !== null,
+        },
+      );
       return;
     }
 
@@ -566,6 +616,7 @@ export class EventWatcher {
       eventType: "withdraw",
       streamId,
       txHash: event.txHash,
+      eventIndex: event.eventIndex,
       ledger: event.ledger,
       ledgerClosedAt: event.ledgerClosedAt,
       amount,
@@ -575,22 +626,33 @@ export class EventWatcher {
 
   private async handleStreamCancelled(
     event: ParsedContractEvent,
-    eventData: Record<string, unknown>
+    eventData: Record<string, unknown>,
   ): Promise<void> {
     const streamId = this.readStreamId(eventData);
     const toReceiver = toBigIntOrNull(eventData.to_receiver);
     const toSender = toBigIntOrNull(eventData.to_sender);
-    if (streamId === null || streamId.length === 0 || toReceiver === null || toSender === null) {
-      logger.warn("Unable to index stream_cancelled event due to missing fields", {
-        txHash: event.txHash,
-        streamId,
-        hasToReceiver: toReceiver !== null,
-        hasToSender: toSender !== null,
-      });
+    if (
+      streamId === null ||
+      streamId.length === 0 ||
+      toReceiver === null ||
+      toSender === null
+    ) {
+      logger.warn(
+        "Unable to index stream_cancelled event due to missing fields",
+        {
+          txHash: event.txHash,
+          streamId,
+          hasToReceiver: toReceiver !== null,
+          hasToSender: toSender !== null,
+        },
+      );
       return;
     }
 
-    const closedAtIso = this.resolveEventTimestampIso(eventData.timestamp, event.ledgerClosedAt);
+    const closedAtIso = this.resolveEventTimestampIso(
+      eventData.timestamp,
+      event.ledgerClosedAt,
+    );
     const summary = await this.streamLifecycleService.cancelStream({
       streamId,
       toReceiver,
@@ -613,6 +675,7 @@ export class EventWatcher {
       eventType: "cancel",
       streamId,
       txHash: event.txHash,
+      eventIndex: event.eventIndex,
       ledger: event.ledger,
       ledgerClosedAt: event.ledgerClosedAt,
       amount: toReceiver + toSender,
@@ -635,7 +698,7 @@ export class EventWatcher {
 
   private resolveEventTimestampIso(
     eventTimestamp: unknown,
-    fallbackIso: string
+    fallbackIso: string,
   ): string {
     const timestampSeconds = toBigIntOrNull(eventTimestamp);
     if (timestampSeconds === null) {
@@ -653,10 +716,7 @@ export class EventWatcher {
    */
   private async storeLedgerHash(sequence: number): Promise<void> {
     try {
-      const page = await this.horizonServer
-        .ledgers()
-        .ledger(sequence)
-        .call();
+      const page = await this.horizonServer.ledgers().ledger(sequence).call();
       const ledgerRecord = page.records?.[0];
       if (!ledgerRecord) {
         logger.warn("No ledger record returned", { sequence });
@@ -664,7 +724,17 @@ export class EventWatcher {
       }
       const hash = ledgerRecord.hash;
 
-      await (prisma as unknown as { ledgerHash: { upsert: (arg: { where: { sequence: number }; update: { hash: string }; create: { sequence: number; hash: string } }) => Promise<unknown> } }).ledgerHash.upsert({
+      await (
+        prisma as unknown as {
+          ledgerHash: {
+            upsert: (arg: {
+              where: { sequence: number };
+              update: { hash: string };
+              create: { sequence: number; hash: string };
+            }) => Promise<unknown>;
+          };
+        }
+      ).ledgerHash.upsert({
         where: { sequence },
         update: { hash },
         create: { sequence, hash },
@@ -696,16 +766,20 @@ export class EventWatcher {
     try {
       const result = await this.verificationService.verifyLedgers(
         fromSequence,
-        toSequence
+        toSequence,
       );
 
       if (!result.verified) {
-        logger.error("Ledger hash verification FAILED — data integrity mismatch", undefined, {
-          fromSequence,
-          toSequence,
-          mismatchCount: result.mismatches.length,
-          mismatches: result.mismatches,
-        });
+        logger.error(
+          "Ledger hash verification FAILED — data integrity mismatch",
+          undefined,
+          {
+            fromSequence,
+            toSequence,
+            mismatchCount: result.mismatches.length,
+            mismatches: result.mismatches,
+          },
+        );
       } else {
         logger.info("Ledger hash verification passed", {
           fromSequence,

--- a/backend/src/services/audit-log.service.ts
+++ b/backend/src/services/audit-log.service.ts
@@ -12,6 +12,8 @@ export interface EventLogEntry {
   eventType: string;
   streamId: string;
   txHash: string;
+  /** Zero-based index of this event within its transaction */
+  eventIndex?: number;
   ledger: number;
   ledgerClosedAt: string;
   sender?: string;
@@ -36,21 +38,42 @@ export interface AuditLogItem {
 
 export class AuditLogService {
   /**
-   * Log an event to the audit log
+   * Log an event to the audit log.
+   * Uses upsert on (txHash, eventIndex) to guarantee idempotency —
+   * re-processing the same on-chain event (e.g. after a re-org recovery)
+   * will update the existing row rather than creating a duplicate.
    */
   async logEvent(entry: EventLogEntry): Promise<void> {
     try {
-      await prisma.eventLog.create({
-        data: {
-          eventType: entry.eventType,
-          streamId: entry.streamId,
-          txHash: entry.txHash,
-          ledger: entry.ledger,
-          ledgerClosedAt: entry.ledgerClosedAt,
-          sender: entry.sender ?? null,
-          receiver: entry.receiver ?? null,
-          amount: entry.amount ?? null,
-          metadata: entry.metadata ? JSON.stringify(entry.metadata) : null,
+      const eventIndex = entry.eventIndex ?? 0;
+      const data = {
+        eventType: entry.eventType,
+        streamId: entry.streamId,
+        txHash: entry.txHash,
+        eventIndex,
+        ledger: entry.ledger,
+        ledgerClosedAt: entry.ledgerClosedAt,
+        sender: entry.sender ?? null,
+        receiver: entry.receiver ?? null,
+        amount: entry.amount ?? null,
+        metadata: entry.metadata ? JSON.stringify(entry.metadata) : null,
+      };
+
+      await prisma.eventLog.upsert({
+        where: {
+          txHash_eventIndex: { txHash: entry.txHash, eventIndex },
+        },
+        create: data,
+        update: {
+          // On re-org recovery, refresh mutable fields but preserve createdAt
+          eventType: data.eventType,
+          streamId: data.streamId,
+          ledger: data.ledger,
+          ledgerClosedAt: data.ledgerClosedAt,
+          sender: data.sender,
+          receiver: data.receiver,
+          amount: data.amount,
+          metadata: data.metadata,
         },
       });
 
@@ -58,6 +81,7 @@ export class AuditLogService {
         eventType: entry.eventType,
         streamId: entry.streamId,
         txHash: entry.txHash,
+        eventIndex,
       });
     } catch (error) {
       logger.error("Failed to log event to audit log", error, {
@@ -79,31 +103,33 @@ export class AuditLogService {
         take: limit,
       });
 
-      return events.map((event: {
-        id: string;
-        eventType: string;
-        streamId: string;
-        txHash: string;
-        ledger: number;
-        ledgerClosedAt: string;
-        sender: string | null;
-        receiver: string | null;
-        amount: bigint | null;
-        metadata: string | null;
-        createdAt: Date;
-      }) => ({
-        id: event.id,
-        eventType: event.eventType,
-        streamId: event.streamId,
-        txHash: event.txHash,
-        ledger: event.ledger,
-        ledgerClosedAt: event.ledgerClosedAt,
-        sender: event.sender,
-        receiver: event.receiver,
-        amount: event.amount?.toString() ?? null,
-        metadata: event.metadata ? JSON.parse(event.metadata) : null,
-        createdAt: event.createdAt,
-      }));
+      return events.map(
+        (event: {
+          id: string;
+          eventType: string;
+          streamId: string;
+          txHash: string;
+          ledger: number;
+          ledgerClosedAt: string;
+          sender: string | null;
+          receiver: string | null;
+          amount: bigint | null;
+          metadata: string | null;
+          createdAt: Date;
+        }) => ({
+          id: event.id,
+          eventType: event.eventType,
+          streamId: event.streamId,
+          txHash: event.txHash,
+          ledger: event.ledger,
+          ledgerClosedAt: event.ledgerClosedAt,
+          sender: event.sender,
+          receiver: event.receiver,
+          amount: event.amount?.toString() ?? null,
+          metadata: event.metadata ? JSON.parse(event.metadata) : null,
+          createdAt: event.createdAt,
+        }),
+      );
     } catch (error) {
       logger.error("Failed to retrieve audit log", error);
       throw error;
@@ -124,31 +150,33 @@ export class AuditLogService {
         },
       });
 
-      return events.map((event: {
-        id: string;
-        eventType: string;
-        streamId: string;
-        txHash: string;
-        ledger: number;
-        ledgerClosedAt: string;
-        sender: string | null;
-        receiver: string | null;
-        amount: bigint | null;
-        metadata: string | null;
-        createdAt: Date;
-      }) => ({
-        id: event.id,
-        eventType: event.eventType,
-        streamId: event.streamId,
-        txHash: event.txHash,
-        ledger: event.ledger,
-        ledgerClosedAt: event.ledgerClosedAt,
-        sender: event.sender,
-        receiver: event.receiver,
-        amount: event.amount?.toString() ?? null,
-        metadata: event.metadata ? JSON.parse(event.metadata) : null,
-        createdAt: event.createdAt,
-      }));
+      return events.map(
+        (event: {
+          id: string;
+          eventType: string;
+          streamId: string;
+          txHash: string;
+          ledger: number;
+          ledgerClosedAt: string;
+          sender: string | null;
+          receiver: string | null;
+          amount: bigint | null;
+          metadata: string | null;
+          createdAt: Date;
+        }) => ({
+          id: event.id,
+          eventType: event.eventType,
+          streamId: event.streamId,
+          txHash: event.txHash,
+          ledger: event.ledger,
+          ledgerClosedAt: event.ledgerClosedAt,
+          sender: event.sender,
+          receiver: event.receiver,
+          amount: event.amount?.toString() ?? null,
+          metadata: event.metadata ? JSON.parse(event.metadata) : null,
+          createdAt: event.createdAt,
+        }),
+      );
     } catch (error) {
       logger.error("Failed to retrieve stream events", error, { streamId });
       throw error;

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -29,6 +29,8 @@ export interface ParsedContractEvent {
   topics: string[];
   value: unknown;
   txHash: string;
+  /** Zero-based index of this event within its transaction, extracted from event.id */
+  eventIndex: number;
   inSuccessfulContractCall: boolean;
 }
 


### PR DESCRIPTION
##Summary 
Hardened the event indexer against ledger re-organisations and duplicate data ingestion. Every indexed event is now linked to its on-chain source via tx_hash and event_index, the pipeline only processes ledgers that have reached closed/finalized status, and a unique database constraint prevents the same event from being written twice.

###Changes

- Finality check added to fetchAndProcessEvents — fetches latestLedger once per poll cycle and skips processing if no closed ledgers are available, guarding against re-org phantom events

- eventIndex extracted from Stellar event IDs (format: ledger-txindex-eventindex) in parseContractEvent and propagated through the full pipeline

- EventLog schema updated with eventIndex Int @default(0) and @@unique([txHash, eventIndex]) constraint

- AuditLogService.logEvent converted from create to upsert on (txHash, eventIndex) — re-processing the same event after a re-org recovery updates the existing row instead of throwing a duplicate key error

- Migration SQL added to apply the column and constraint to the live database

###Files Modified

- schema.prisma —  eventIndex field + unique constraint on EventLog
- 
- add_event_index_and_finality.sql — DB migration
- 
- types.ts — eventIndex added to ParsedContractEvent
- 
- event-parser.t — parseEventIndex helper, eventIndex populated
- 
- event-watcher.ts — finality check, eventIndex passed to all audit log calls
- 
- audit-log.service.t  — idempotent upsert on (txHash, eventIndex)

###Security Notes 

No logic changes to stream fund flows. All security gaps identified in the spec are documented and flagged for follow-up — token custody, settle auth, re-init guard, overflow protection, and maturity enforcement.

this pr Closes #485 