### PR TITLE
feat: implement Versioned Route Architecture (/api/v2)

### DIFF
--- a/backend/src/api/v2/index.ts
+++ b/backend/src/api/v2/index.ts
@@ -1,0 +1,15 @@
+import { Router } from "express";
+import { responseWrapper } from "../../middleware/responseWrapper.js";
+
+import streamsRouter from "./streams.routes.js";
+import statsRouter from "./stats.routes.js";
+
+const router = Router();
+
+// Apply standard JSON response wrapper to all V2 endpoints
+router.use(responseWrapper);
+
+router.use("/streams", streamsRouter);
+router.use("/stats", statsRouter);
+
+export default router;

--- a/backend/src/api/v2/stats.routes.ts
+++ b/backend/src/api/v2/stats.routes.ts
@@ -1,0 +1,38 @@
+import { Router, Request, Response } from "express";
+import asyncHandler from "../../utils/asyncHandler.js";
+import { prisma } from "../../lib/db.js";
+
+const router = Router();
+
+/**
+ * GET /api/v2/stats/protocol
+ * Returns real-time protocol-wide volume metrics.
+ */
+router.get(
+    "/protocol",
+    asyncHandler(async (_req: Request, res: Response) => {
+        const streams = await prisma.stream.findMany({
+            select: { amount: true, withdrawn: true, status: true }
+        });
+
+        let totalVolume = 0n;
+        let totalWithdrawn = 0n;
+        let activeStreamsCount = 0;
+
+        for (const s of streams) {
+            totalVolume += BigInt(s.amount || '0');
+            totalWithdrawn += BigInt(s.withdrawn || '0');
+            if (s.status === "ACTIVE") {
+                activeStreamsCount++;
+            }
+        }
+
+        res.json({
+            totalVolume: totalVolume.toString(),
+            totalWithdrawn: totalWithdrawn.toString(),
+            activeStreamsCount
+        });
+    })
+);
+
+export default router;

--- a/backend/src/api/v2/streams.routes.ts
+++ b/backend/src/api/v2/streams.routes.ts
@@ -1,0 +1,49 @@
+import { Router, Request, Response } from "express";
+import { z } from "zod";
+import asyncHandler from "../../utils/asyncHandler.js";
+import { StreamService } from "../../services/stream.service.js";
+import stellarAddressSchema from "../../validation/stellar.js";
+
+const router = Router();
+const streamService = new StreamService();
+
+const getStreamsParamsSchema = z.object({
+    address: stellarAddressSchema,
+});
+
+/**
+ * GET /api/v2/streams/:address
+ * Fetches V1 and V2 streams for a user, sorted by status.
+ * Returns { success: true, data: { v1: [...], v2: [...] } } via middleware.
+ */
+router.get(
+    "/:address",
+    asyncHandler(async (req: Request, res: Response) => {
+        // Validate address
+        const parseResult = getStreamsParamsSchema.safeParse(req.params);
+        if (!parseResult.success) {
+            res.status(400).json({ error: "Invalid address format" });
+            return;
+        }
+        const { address } = parseResult.data;
+
+        // Fetch all current streams (assume all are v1 for now)
+        const streams = await streamService.getStreamsForAddress(address);
+
+        // Sort by status
+        const statusOrder = { ACTIVE: 1, PAUSED: 2, COMPLETED: 3, CANCELED: 4 };
+        streams.sort((a, b) => {
+            const aRank = statusOrder[a.status as keyof typeof statusOrder] || 10;
+            const bRank = statusOrder[b.status as keyof typeof statusOrder] || 10;
+            return aRank - bRank;
+        });
+
+        // Provide empty array for v2 as placeholder for future Nebula features
+        res.json({
+            v1: streams,
+            v2: []
+        });
+    })
+);
+
+export default router;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -103,6 +103,10 @@ app.get("/api/v1/search", rateLimitMiddleware, getSearch);
 // ── Core API router (streams, yield, snapshots, governance, audit-log) ────────
 app.use("/api/v1", apiRouter);
 
+// ── V2 API router ─────────────────────────────────────────────────────────────
+import apiV2Router from "./api/v2/index.js";
+app.use("/api/v2", apiV2Router);
+
 // ── Batch metadata + stream graph ─────────────────────────────────────────────
 app.use("/api/v1", batchRoutes);
 

--- a/backend/src/middleware/responseWrapper.ts
+++ b/backend/src/middleware/responseWrapper.ts
@@ -1,0 +1,25 @@
+import { Request, Response, NextFunction } from "express";
+
+export function responseWrapper(_req: Request, res: Response, next: NextFunction) {
+    const originalJson = res.json;
+
+    res.json = function (body: any) {
+        // Prevent double wrapping
+        if (body && typeof body === "object" && "success" in body && "data" in body) {
+            return originalJson.call(this, body);
+        }
+
+        // Construct standardized response format
+        const isSuccess = res.statusCode >= 200 && res.statusCode < 300;
+
+        const wrappedBody = {
+            success: isSuccess,
+            data: isSuccess ? body : null,
+            error: !isSuccess ? (body?.error || body?.message || "An error occurred") : null,
+        };
+
+        return originalJson.call(this, wrappedBody);
+    };
+
+    next();
+}


### PR DESCRIPTION
Closes #482 
This pr implements Versioned Route Architecture (/api/v2)
## **Changes**
***Created the responseWrapper middleware to ensure a standard JSON response structure.***
***Created the V2 streams and stats API routes, accommodating both V1 and V2 stream layouts for the /streams/:address endpoint and computing protocol-wide metrics for the /stats/protocol endpoint.***
***Mounted the V2 router into the main backend application.***