### PR TITLE
docs: [Contract-V2] Documentation:

### DIFF
--- a/Function doc.txt
+++ b/Function doc.txt
@@ -1,0 +1,126 @@
+StellarStream Contract — Public Function Reference
+====================================================
+
+create_proposal(sender, receiver, token, total_amount, start_time, end_time, required_approvals, deadline)
+  Creates a multi-sig stream proposal. No tokens transferred yet.
+  Errors: InvalidTimeRange, InvalidAmount, InvalidApprovalThreshold, ProposalExpired
+  Emits:  ProposalCreatedEvent
+  Storage: instance — (PROPOSAL_COUNT, proposal_id)
+
+approve_proposal(proposal_id, approver)
+  Adds an approval. Auto-executes and creates a stream when threshold is reached.
+  Errors: ProposalNotFound, ProposalAlreadyExecuted, ProposalExpired, AlreadyApproved
+  Emits:  ProposalApprovedEvent; StreamCreatedEvent on execution
+  Storage: instance — (PROPOSAL_COUNT, proposal_id)
+
+create_stream(sender, receiver, token, total_amount, start_time, end_time, curve_type)
+  Creates a single-sig stream. Transfers tokens immediately. Mints receipt NFT.
+  Errors: InvalidTimeRange, InvalidAmount
+  Emits:  StreamCreatedEvent
+  Storage: instance — (STREAM_COUNT, stream_id), (RECEIPT, stream_id)
+
+create_stream_with_milestones(sender, receiver, token, total_amount, start_time, end_time, milestones, curve_type)
+  Same as create_stream but with milestone unlock caps.
+  Errors: InvalidTimeRange, InvalidAmount
+  Emits:  StreamCreatedEvent
+  Storage: instance — (STREAM_COUNT, stream_id), (RECEIPT, stream_id)
+
+create_usd_pegged_stream(sender, receiver, token, usd_amount, start_time, end_time, oracle_address, max_staleness, min_price, max_price)
+  Creates a stream whose token amount is priced via oracle at creation and withdrawal.
+  Errors: InvalidTimeRange, InvalidAmount, OracleFailed, PriceOutOfBounds
+  Emits:  StreamCreatedEvent
+  Storage: instance — (STREAM_COUNT, stream_id), (RECEIPT, stream_id)
+
+pause_stream(stream_id, caller)
+  Freezes the unlock clock. Only the sender may pause.
+  Errors: StreamNotFound, Unauthorized, AlreadyCancelled
+  Emits:  StreamPausedEvent
+  Storage: instance — (STREAM_COUNT, stream_id)
+
+unpause_stream(stream_id, caller)
+  Resumes a paused stream. Adds pause duration to total_paused_duration.
+  Errors: StreamNotFound, Unauthorized, AlreadyCancelled
+  Emits:  StreamUnpausedEvent
+  Storage: instance — (STREAM_COUNT, stream_id)
+
+transfer_receipt(stream_id, from, to)
+  Transfers the receipt NFT (withdrawal rights) to a new owner.
+  Errors: StreamNotFound, NotReceiptOwner
+  Emits:  ReceiptTransferredEvent
+  Storage: instance — (RECEIPT, stream_id), (STREAM_COUNT, stream_id)
+
+get_receipt(stream_id)
+  Returns the StreamReceipt for a stream. Read-only.
+  Errors: StreamNotFound
+  Storage: instance — reads (RECEIPT, stream_id)
+
+get_receipt_metadata(stream_id)
+  Returns locked/unlocked/total balances at current time. Read-only.
+  Errors: StreamNotFound
+  Storage: instance — reads (STREAM_COUNT, stream_id)
+
+withdraw(stream_id, caller)
+  Transfers all currently unlocked tokens to the receipt owner.
+  Errors: StreamNotFound, NotReceiptOwner, AlreadyCancelled, StreamPaused, InsufficientBalance, OracleStalePrice, PriceOutOfBounds
+  Emits:  StreamClaimEvent
+  Storage: instance — (STREAM_COUNT, stream_id)
+
+cancel(stream_id, caller)
+  Settles the stream early. Receiver gets earned amount; sender gets remainder.
+  Errors: StreamNotFound, Unauthorized, AlreadyCancelled
+  Emits:  StreamCancelledEvent
+  Storage: instance — (STREAM_COUNT, stream_id)
+
+close_and_archive(stream_id, caller)
+  Removes a fully-withdrawn stream from storage, recovering the rent deposit.
+  Errors: StreamNotFound, Unauthorized, AlreadyCancelled, StreamNotFullyWithdrawn
+  Emits:  StreamArchivedEvent
+  Storage: instance — removes (STREAM_COUNT, stream_id) and (RECEIPT, stream_id)
+
+get_stream(stream_id)
+  Returns the full Stream struct. Read-only.
+  Errors: StreamNotFound
+  Storage: instance — reads (STREAM_COUNT, stream_id)
+
+get_proposal(proposal_id)
+  Returns the full StreamProposal struct. Read-only.
+  Errors: ProposalNotFound
+  Storage: instance — reads (PROPOSAL_COUNT, proposal_id)
+
+grant_role(admin, target, role)
+  Grants a Role (Admin/Pauser/TreasuryManager) to an address. Admin only.
+  Panics: Unauthorized if caller lacks Admin role
+  Emits:  ("grant", target) → role
+  Storage: instance — DataKey::Role(target, role)
+
+revoke_role(admin, target, role)
+  Revokes a role from an address. Admin only.
+  Emits:  ("revoke", target) → role
+  Storage: instance — removes DataKey::Role(target, role)
+
+check_role(address, role)
+  Returns true if address holds the given role. Read-only, no auth required.
+  Storage: instance — reads DataKey::Role(address, role)
+
+upgrade(admin, new_wasm_hash)
+  Upgrades the contract WASM. Admin only.
+  Emits:  ("upgrade", admin) → new_wasm_hash
+
+get_admin()
+  Returns the legacy admin address. Panics if not initialised.
+  Storage: instance — reads DataKey::Admin
+
+create_request(receiver, token, total_amount, duration, metadata)
+  Submits a contributor payment request (pending admin approval).
+  Emits:  RequestCreatedEvent
+  Storage: instance — RequestKey::Request(request_id)
+
+execute_request(admin, request_id)
+  Approves a pending request and creates a stream. Admin only.
+  Errors: Unauthorized, StreamNotFound, AlreadyExecuted
+  Emits:  RequestExecutedEvent, StreamCreatedEvent
+  Storage: instance — RequestKey::Request(request_id) + stream keys
+
+get_request(request_id)
+  Returns a ContributorRequest or None. Read-only.
+  Storage: instance — reads RequestKey::Request(request_id)


### PR DESCRIPTION
Closes #394 

Adds Function doc.txt — a plain-text quick-reference for every public function in StellarStreamContract.

Each entry covers:

what the function does
errors it can return
events it emits
storage type and keys used (all instance storage)
25 functions documented including stream lifecycle (create, pause, withdraw, cancel, close_and_archive), multi-sig proposals, receipt NFT transfers, RBAC, contract upgrade, and contributor payment requests.

No logic changes — docs only.

Labels: [Contract-V2] Docs Easy