### PR TITLE
feat/integrate test suite

### DIFF
--- a/backend/src/__jest__/indexer.test.ts
+++ b/backend/src/__jest__/indexer.test.ts
@@ -15,14 +15,14 @@
 import { xdr, nativeToScVal } from "@stellar/stellar-sdk";
 
 // ─── Mock Prisma before any service imports ───────────────────────────────────
-const mockEventLogCreate = jest.fn().mockResolvedValue({ id: "mock-id" });
+const mockEventLogUpsert = jest.fn().mockResolvedValue({ id: "mock-id" });
 const mockEventLogFindMany = jest.fn().mockResolvedValue([]);
 
 jest.mock("../generated/client/index.js", () => {
   return {
     PrismaClient: jest.fn().mockImplementation(() => ({
       eventLog: {
-        create: mockEventLogCreate,
+        upsert: mockEventLogUpsert,
         findMany: mockEventLogFindMany,
       },
     })),
@@ -197,7 +197,7 @@ describe("Indexer — Soroban event parsing and DB persistence", () => {
   // ── AuditLogService → prisma.eventLog.create ─────────────────────────────
 
   describe("AuditLogService.logEvent() — DB persistence", () => {
-    it("calls prisma.eventLog.create with correct data for a stream_created event", async () => {
+    it("calls prisma.eventLog.upsert with correct data for a stream_created event", async () => {
       await auditLogService.logEvent({
         eventType: "create",
         streamId: "42",
@@ -210,23 +210,27 @@ describe("Indexer — Soroban event parsing and DB persistence", () => {
         metadata: { stream_id: "42", total_amount: "5000000000" },
       });
 
-      expect(mockEventLogCreate).toHaveBeenCalledTimes(1);
-      expect(mockEventLogCreate).toHaveBeenCalledWith({
-        data: {
+      expect(mockEventLogUpsert).toHaveBeenCalledTimes(1);
+      const upsertArg = mockEventLogUpsert.mock.calls[0][0];
+      expect(upsertArg.create).toEqual({
           eventType: "create",
           streamId: "42",
           txHash: "txhash_create_001",
+          eventIndex: 0,
           ledger: 1234,
           ledgerClosedAt: "2025-06-01T12:00:00Z",
           sender: "GALICESENDERADDRESS",
           receiver: "GBOBRECEIVER",
           amount: 5000000000n,
-          metadata: JSON.stringify({ stream_id: "42", total_amount: "5000000000" }),
+          metadata: JSON.stringify({
+            stream_id: "42",
+            total_amount: "5000000000",
+          }),
         },
-      });
+      );
     });
 
-    it("calls prisma.eventLog.create with correct data for a stream_withdrawn event", async () => {
+    it("calls prisma.eventLog.upsert with correct data for a stream_withdrawn event", async () => {
       await auditLogService.logEvent({
         eventType: "withdraw",
         streamId: "42",
@@ -237,16 +241,16 @@ describe("Indexer — Soroban event parsing and DB persistence", () => {
         metadata: { stream_id: "42", amount: "1000000" },
       });
 
-      expect(mockEventLogCreate).toHaveBeenCalledTimes(1);
-      const callArg = mockEventLogCreate.mock.calls[0][0];
-      expect(callArg.data.eventType).toBe("withdraw");
-      expect(callArg.data.streamId).toBe("42");
-      expect(callArg.data.amount).toBe(1000000n);
-      expect(callArg.data.sender).toBeNull();
-      expect(callArg.data.receiver).toBeNull();
+      expect(mockEventLogUpsert).toHaveBeenCalledTimes(1);
+      const upsertArg = mockEventLogUpsert.mock.calls[0][0];
+      expect(upsertArg.create.eventType).toBe("withdraw");
+      expect(upsertArg.create.streamId).toBe("42");
+      expect(upsertArg.create.amount).toBe(1000000n);
+      expect(upsertArg.create.sender).toBeNull();
+      expect(upsertArg.create.receiver).toBeNull();
     });
 
-    it("calls prisma.eventLog.create with correct data for a stream_cancelled event", async () => {
+    it("calls prisma.eventLog.upsert with correct data for a stream_cancelled event", async () => {
       await auditLogService.logEvent({
         eventType: "cancel",
         streamId: "7",
@@ -257,12 +261,12 @@ describe("Indexer — Soroban event parsing and DB persistence", () => {
         metadata: { stream_id: "7", to_receiver: "800000", to_sender: "200000" },
       });
 
-      expect(mockEventLogCreate).toHaveBeenCalledTimes(1);
-      const callArg = mockEventLogCreate.mock.calls[0][0];
-      expect(callArg.data.eventType).toBe("cancel");
-      expect(callArg.data.streamId).toBe("7");
-      expect(callArg.data.amount).toBe(1000000n);
-      expect(callArg.data.metadata).toBe(
+      expect(mockEventLogUpsert).toHaveBeenCalledTimes(1);
+      const upsertArg = mockEventLogUpsert.mock.calls[0][0];
+      expect(upsertArg.create.eventType).toBe("cancel");
+      expect(upsertArg.create.streamId).toBe("7");
+      expect(upsertArg.create.amount).toBe(1000000n);
+      expect(upsertArg.create.metadata).toBe(
         JSON.stringify({ stream_id: "7", to_receiver: "800000", to_sender: "200000" })
       );
     });
@@ -279,8 +283,8 @@ describe("Indexer — Soroban event parsing and DB persistence", () => {
         metadata: meta,
       });
 
-      const callArg = mockEventLogCreate.mock.calls[0][0];
-      expect(callArg.data.metadata).toBe(JSON.stringify(meta));
+      const upsertArg = mockEventLogUpsert.mock.calls[0][0];
+      expect(upsertArg.create.metadata).toBe(JSON.stringify(meta));
     });
 
     it("passes null for optional fields when not provided", async () => {
@@ -293,15 +297,15 @@ describe("Indexer — Soroban event parsing and DB persistence", () => {
         // no sender, receiver, amount, metadata
       });
 
-      const callArg = mockEventLogCreate.mock.calls[0][0];
-      expect(callArg.data.sender).toBeNull();
-      expect(callArg.data.receiver).toBeNull();
-      expect(callArg.data.amount).toBeNull();
-      expect(callArg.data.metadata).toBeNull();
+      const upsertArg = mockEventLogUpsert.mock.calls[0][0];
+      expect(upsertArg.create.sender).toBeNull();
+      expect(upsertArg.create.receiver).toBeNull();
+      expect(upsertArg.create.amount).toBeNull();
+      expect(upsertArg.create.metadata).toBeNull();
     });
 
-    it("does not throw when prisma.eventLog.create rejects (error is swallowed)", async () => {
-      mockEventLogCreate.mockRejectedValueOnce(new Error("DB connection lost"));
+    it("does not throw when prisma.eventLog.upsert rejects (error is swallowed)", async () => {
+      mockEventLogUpsert.mockRejectedValueOnce(new Error("DB connection lost"));
 
       // AuditLogService catches and logs errors — it must not propagate
       await expect(
@@ -355,8 +359,8 @@ describe("Indexer — Soroban event parsing and DB persistence", () => {
       });
 
       // Step 3: verify the Prisma create was called with the right data
-      expect(mockEventLogCreate).toHaveBeenCalledTimes(1);
-      const saved = mockEventLogCreate.mock.calls[0][0].data;
+      expect(mockEventLogUpsert).toHaveBeenCalledTimes(1);
+      const saved = mockEventLogUpsert.mock.calls[0][0].create;
       expect(saved.eventType).toBe("create");
       expect(saved.txHash).toBe("e2e_txhash_create");
       expect(saved.ledger).toBe(2000);
@@ -389,8 +393,8 @@ describe("Indexer — Soroban event parsing and DB persistence", () => {
         metadata: eventData,
       });
 
-      expect(mockEventLogCreate).toHaveBeenCalledTimes(1);
-      const saved = mockEventLogCreate.mock.calls[0][0].data;
+      expect(mockEventLogUpsert).toHaveBeenCalledTimes(1);
+      const saved = mockEventLogUpsert.mock.calls[0][0].create;
       expect(saved.eventType).toBe("withdraw");
       expect(saved.txHash).toBe("e2e_txhash_withdraw");
       expect(saved.ledger).toBe(2100);
@@ -433,8 +437,8 @@ describe("Indexer — Soroban event parsing and DB persistence", () => {
         },
       });
 
-      expect(mockEventLogCreate).toHaveBeenCalledTimes(1);
-      const saved = mockEventLogCreate.mock.calls[0][0].data;
+      expect(mockEventLogUpsert).toHaveBeenCalledTimes(1);
+      const saved = mockEventLogUpsert.mock.calls[0][0].create;
       expect(saved.eventType).toBe("cancel");
       expect(saved.txHash).toBe("e2e_txhash_cancel");
       expect(saved.ledger).toBe(2200);

--- a/backend/src/__jest__/ingestion-stream-webhook.test.ts
+++ b/backend/src/__jest__/ingestion-stream-webhook.test.ts
@@ -1,0 +1,317 @@
+import express from "express";
+import request from "supertest";
+import { nativeToScVal, xdr } from "@stellar/stellar-sdk";
+import { mockDb, createMockPrismaClient, createMockLibPrisma } from "./mock-prisma-db";
+
+// Ensure a deterministic fetch mock for webhook delivery assertions.
+global.fetch = jest.fn(async () => ({
+  ok: true,
+  status: 200,
+  statusText: "OK",
+})) as any;
+
+function applyIngestionMocks() {
+  const prismaClientFactory = () => createMockPrismaClient();
+
+  jest.doMock("@sentry/node", () => ({
+    withScope: jest.fn(),
+    captureException: jest.fn(),
+    init: jest.fn(),
+  }));
+
+  jest.doMock("../generated/client/index.js", () => {
+    return {
+      PrismaClient: jest.fn().mockImplementation(() => prismaClientFactory()),
+      StreamStatus: {
+        ACTIVE: "ACTIVE",
+        PAUSED: "PAUSED",
+        COMPLETED: "COMPLETED",
+        CANCELED: "CANCELED",
+      },
+    };
+  });
+
+  // Some modules import from "../generated/client" (directory), not the index.js.
+  jest.doMock("../generated/client", () => {
+    return {
+      PrismaClient: jest.fn().mockImplementation(() => prismaClientFactory()),
+      StreamStatus: {
+        ACTIVE: "ACTIVE",
+        PAUSED: "PAUSED",
+        COMPLETED: "COMPLETED",
+        CANCELED: "CANCELED",
+      },
+    };
+  });
+
+  jest.doMock("../services/stream-lifecycle-service", () => {
+    // Re-implement only the pure helpers used by EventWatcher.
+    function toBigIntOrNull(value: unknown): bigint | null {
+      if (typeof value === "bigint") return value;
+      if (typeof value === "number" && Number.isFinite(value)) return BigInt(Math.trunc(value));
+      if (typeof value === "string" && value.trim().length > 0) {
+        try {
+          return BigInt(value);
+        } catch {
+          return null;
+        }
+      }
+      return null;
+    }
+
+    function toObjectOrNull(value: unknown): Record<string, unknown> | null {
+      if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+      return value as Record<string, unknown>;
+    }
+
+    return {
+      StreamLifecycleService: jest.fn().mockImplementation(() => ({
+        upsertCreatedStream: jest.fn(async () => undefined),
+        registerWithdrawal: jest.fn(async () => undefined),
+        cancelStream: jest.fn(async () => ({
+          streamId: "mock",
+          originalTotalAmount: 0n,
+          finalStreamedAmount: 0n,
+          remainingUnstreamedAmount: 0n,
+          closedAtIso: new Date().toISOString(),
+        })),
+      })),
+      toBigIntOrNull,
+      toObjectOrNull,
+    };
+  });
+
+  jest.doMock("../lib/db", () => {
+    return {
+      prisma: createMockLibPrisma(),
+    };
+  });
+}
+
+// ─── Test helpers ───────────────────────────────────────────────────────────
+
+function buildRawCreateStreamEvent(args: {
+  id?: string;
+  txHash?: string;
+  ledger?: number;
+  streamId: number;
+  sender: string;
+  receiver: string;
+  amountStroops: number;
+  durationSeconds: number;
+}) {
+  const { id, txHash, ledger, streamId, sender, receiver, amountStroops, durationSeconds } =
+    args;
+
+  // topic[0] determines EventWatcher eventType via extractEventType()
+  // and must decode to a supported stream creation event type.
+  const topic0 = nativeToScVal("stream_created", { type: "symbol" });
+  // Use `string` (not `symbol`) because Stellar `symbol` is limited to 32 bytes.
+  // The StreamWatcher heuristic uses scValToNative() so scvString is sufficient.
+  const topic1 = nativeToScVal(sender, { type: "string" });
+
+  const payload = nativeToScVal(
+    {
+      stream_id: streamId,
+      sender,
+      receiver,
+      amount: amountStroops,
+      duration: durationSeconds,
+      total_amount: amountStroops,
+    },
+    { type: "map" },
+  );
+
+  return {
+    id: id ?? `${ledger ?? 1000}-0-1`,
+    type: "contract",
+    ledger: ledger ?? 1000,
+    ledgerClosedAt: "2026-01-01T00:00:00Z",
+    contractId: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+    txHash: txHash ?? "mock-txhash-create-stream",
+    topic: [topic0, topic1] as xdr.ScVal[],
+    value: payload,
+    inSuccessfulContractCall: true,
+    pagingToken: "0",
+  } as any;
+}
+
+function makeMockRpcServer(ledgerSequence: number, events: any[]) {
+  return {
+    getLatestLedger: jest.fn(async () => ({ sequence: ledgerSequence })),
+    getEvents: jest.fn(async () => ({ events })),
+  };
+}
+
+function makeMockHorizonServer(sequenceToHash: Record<number, string>) {
+  return {
+    ledgers: () => ({
+      ledger: (sequence: number) => ({
+        call: jest.fn(async () => ({
+          records: [{ hash: sequenceToHash[sequence] ?? `hash_${sequence}` }],
+        })),
+      }),
+    }),
+  };
+}
+
+describe("High-fidelity ingestion + webhook tests", () => {
+  const sender = "G" + "S".repeat(55);
+  const receiver = "G" + "R".repeat(55);
+  const amountStroops = 100_000_000_001; // >= 10000_0000000n threshold used in EventWatcher
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDb.reset();
+  });
+
+  it("indexes create_stream events into Stream table and triggers webhooks", async () => {
+    jest.resetModules();
+    applyIngestionMocks();
+
+    const webhookUrl = "https://example.com/webhook/stream";
+    mockDb.seedWebhook({ url: webhookUrl, isActive: true });
+
+    const rawEvent = buildRawCreateStreamEvent({
+      streamId: 42,
+      sender,
+      receiver,
+      amountStroops,
+      durationSeconds: 3600,
+      txHash: "txhash_stream_created_42",
+      ledger: 1000,
+      id: "1000-0-7",
+    });
+
+    const { EventWatcher } = await import("../event-watcher");
+    const { parseContractEvent, extractEventType } = await import("../event-parser");
+
+    // Pre-flight: ensure we built real ScVal objects compatible with parseContractEvent().
+    expect(rawEvent.topic).toHaveLength(2);
+    expect(typeof rawEvent.topic[0].toXDR).toBe("function");
+    expect(typeof rawEvent.topic[1].toXDR).toBe("function");
+    expect(() => rawEvent.topic[0].toXDR("base64")).not.toThrow();
+    expect(() => rawEvent.topic[1].toXDR("base64")).not.toThrow();
+    expect(typeof rawEvent.value.switch).toBe("function");
+    expect(() => rawEvent.value.switch()).not.toThrow();
+
+    const parsed = parseContractEvent(rawEvent as any);
+    expect(parsed).not.toBeNull();
+    expect(extractEventType((parsed as any).topics)).toBe("stream_created");
+
+    const watcher: any = new EventWatcher({
+      rpcUrl: "http://localhost:8000",
+      // Horizon.Server rejects insecure http:// URLs during construction.
+      // We override `watcher.horizonServer` below anyway.
+      horizonUrl: "https://example.com/horizon",
+      networkPassphrase: "Test SDF Network ; September 2015",
+      contractId: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+      pollIntervalMs: 1000,
+      maxRetries: 1,
+      retryDelayMs: 1,
+    });
+
+    // Drive the full ingestion path (RPC -> processEvent -> storeLedgerHash).
+    watcher.server = makeMockRpcServer(1000, [rawEvent]);
+    watcher.horizonServer = makeMockHorizonServer({ 1000: "ledger_hash_1000" });
+    watcher.state = {
+      lastProcessedLedger: 999,
+      isRunning: false,
+      errorCount: 0,
+      ledgersSinceLastVerification: 0,
+      lastVerifiedLedger: 0,
+    };
+
+    await watcher.fetchAndProcessEvents();
+
+    expect(mockDb.attemptedStreamCreates).toBeGreaterThan(0);
+
+    // Stream row persisted.
+    expect(mockDb.streams).toHaveLength(1);
+    expect(mockDb.streams[0]).toMatchObject({
+      txHash: "txhash_stream_created_42",
+      streamId: "42",
+      sender,
+      receiver,
+      amount: String(amountStroops),
+      duration: 3600,
+      status: "ACTIVE",
+    });
+
+    // Webhook delivered.
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const [calledUrl, options] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(calledUrl).toBe(webhookUrl);
+    expect(options.method).toBe("POST");
+    const payload = JSON.parse(options.body);
+    expect(payload).toMatchObject({
+      eventType: "stream_created",
+      txHash: "txhash_stream_created_42",
+      streamId: "42",
+      sender,
+      receiver,
+      amount: String(amountStroops),
+    });
+    expect(typeof payload.timestamp).toBe("string");
+  });
+
+  it("API: GET /api/v1/streams/:address returns ingested streams", async () => {
+    jest.resetModules();
+    applyIngestionMocks();
+
+    // Seed one stream via ingestion first.
+    mockDb.seedWebhook({ url: "https://example.com/webhook/stream", isActive: false });
+
+    const rawEvent = buildRawCreateStreamEvent({
+      streamId: 42,
+      sender,
+      receiver,
+      amountStroops,
+      durationSeconds: 3600,
+      txHash: "txhash_stream_created_42_api",
+      ledger: 1000,
+      id: "1000-0-1",
+    });
+
+    const { EventWatcher } = await import("../event-watcher");
+    const watcher: any = new EventWatcher({
+      rpcUrl: "http://localhost:8000",
+      horizonUrl: "https://example.com/horizon",
+      networkPassphrase: "Test SDF Network ; September 2015",
+      contractId: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+      pollIntervalMs: 1000,
+      maxRetries: 1,
+      retryDelayMs: 1,
+    });
+
+    watcher.server = makeMockRpcServer(1000, [rawEvent]);
+    watcher.horizonServer = makeMockHorizonServer({ 1000: "ledger_hash_1000" });
+    watcher.state = {
+      lastProcessedLedger: 999,
+      isRunning: false,
+      errorCount: 0,
+      ledgersSinceLastVerification: 0,
+      lastVerifiedLedger: 0,
+    };
+
+    await watcher.fetchAndProcessEvents();
+
+    const app = express();
+    app.use(express.json());
+
+    const streamsRouter = (await import("../api/streams.routes")).default;
+    app.use("/api/v1", streamsRouter);
+
+    const res = await request(app).get(`/api/v1/streams/${encodeURIComponent(receiver)}`);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.count).toBe(1);
+    expect(res.body.streams[0]).toMatchObject({
+      streamId: "42",
+      sender,
+      receiver,
+      amount: String(amountStroops),
+    });
+  });
+});
+

--- a/backend/src/__jest__/mock-prisma-db.ts
+++ b/backend/src/__jest__/mock-prisma-db.ts
@@ -1,0 +1,261 @@
+import type { StreamStatus } from "../generated/client/index.js";
+
+export type MockStreamRow = {
+  id: string;
+  streamId: string | null;
+  txHash: string;
+  sender: string;
+  receiver: string;
+  tokenAddress: string | null;
+  amount: string;
+  duration: number | null;
+  status: StreamStatus | "ACTIVE" | "PAUSED" | "COMPLETED" | "CANCELED";
+  withdrawn: string | null;
+  legacy: boolean;
+  migrated: boolean;
+  isPrivate: boolean;
+};
+
+export type MockWebhookRow = {
+  id: string;
+  url: string;
+  description: string | null;
+  isActive: boolean;
+};
+
+export type MockEventLogRow = {
+  id: string;
+  eventType: string;
+  streamId: string;
+  txHash: string;
+  eventIndex: number;
+  ledger: number;
+  ledgerClosedAt: string;
+  sender: string | null;
+  receiver: string | null;
+  amount: bigint | null;
+  metadata: string | null;
+};
+
+type LedgerHashRow = { sequence: number; hash: string };
+
+/**
+ * A dedicated, isolated in-memory "test database".
+ *
+ * We use this because the repository's current Jest setup mocks Prisma for
+ * event parsing tests; this extends that approach to cover ingestion and
+ * webhook triggering logic without requiring a running Postgres instance.
+ */
+export const mockDb = {
+  streams: [] as MockStreamRow[],
+  webhooks: [] as MockWebhookRow[],
+  eventLogs: [] as MockEventLogRow[],
+  ledgerHashes: [] as LedgerHashRow[],
+  attemptedStreamCreates: 0,
+  _idSeq: 1,
+
+  reset(): void {
+    this.streams = [];
+    this.webhooks = [];
+    this.eventLogs = [];
+    this.ledgerHashes = [];
+    this.attemptedStreamCreates = 0;
+    this._idSeq = 1;
+  },
+
+  seedWebhook(input: { url: string; isActive?: boolean; description?: string }): void {
+    this.webhooks.push({
+      id: `wh_${this._idSeq++}`,
+      url: input.url,
+      isActive: input.isActive ?? true,
+      description: input.description ?? null,
+    });
+  },
+};
+
+function createId(prefix: string): string {
+  const next = mockDb._idSeq++;
+  return `${prefix}_${next}`;
+}
+
+export function createMockPrismaClient() {
+  return {
+    stream: {
+      create: jest.fn(async (arg: { data: any }) => {
+        mockDb.attemptedStreamCreates++;
+        const data = arg.data as Partial<MockStreamRow>;
+        const txHash = String(data.txHash ?? "");
+        if (!txHash) throw new Error("stream.create: txHash is required");
+
+        if (mockDb.streams.some((s) => s.txHash === txHash)) {
+          // Mimic Prisma unique constraint on txHash.
+          throw new Error(`Unique constraint failed on txHash=${txHash}`);
+        }
+
+        const row: MockStreamRow = {
+          id: createId("stream"),
+          streamId: data.streamId ?? null,
+          txHash,
+          sender: String(data.sender ?? ""),
+          receiver: String(data.receiver ?? ""),
+          tokenAddress: data.tokenAddress ?? null,
+          amount: String(data.amount ?? "0"),
+          duration: data.duration ?? null,
+          status: (data.status as any) ?? "ACTIVE",
+          withdrawn: data.withdrawn ?? "0",
+          legacy: Boolean(data.legacy ?? false),
+          migrated: Boolean(data.migrated ?? false),
+          isPrivate: Boolean(data.isPrivate ?? false),
+        };
+
+        mockDb.streams.push(row);
+        return row;
+      }),
+
+      findMany: jest.fn(async (arg: { where?: any; orderBy?: any }) => {
+        const where = arg.where ?? {};
+        let rows = [...mockDb.streams];
+
+        if (where.OR && Array.isArray(where.OR)) {
+          rows = rows.filter((row) =>
+            where.OR.some((clause: any) => {
+              if (typeof clause?.sender === "string") return row.sender === clause.sender;
+              if (typeof clause?.receiver === "string") return row.receiver === clause.receiver;
+              return false;
+            }),
+          );
+        }
+
+        if (where.status) {
+          rows = rows.filter((row) => row.status === where.status);
+        }
+
+        if (where.tokenAddress?.in && Array.isArray(where.tokenAddress.in)) {
+          const allowed = new Set(where.tokenAddress.in.map(String));
+          rows = rows.filter((row) => row.tokenAddress != null && allowed.has(row.tokenAddress));
+        }
+
+        // Best-effort orderBy { id: "desc" } support.
+        if (arg.orderBy?.id === "desc") {
+          rows.sort((a, b) => (b.id > a.id ? 1 : -1));
+        }
+
+        return rows;
+      }),
+    },
+
+    webhook: {
+      findMany: jest.fn(async (arg: { where?: any }) => {
+        const where = arg.where ?? {};
+        const isActive = where.isActive;
+        return mockDb.webhooks.filter((w) =>
+          typeof isActive === "boolean" ? w.isActive === isActive : true,
+        );
+      }),
+    },
+
+    eventLog: {
+      upsert: jest.fn(async (arg: any) => {
+        const eventIndex: number = arg.where?.txHash_eventIndex?.eventIndex ?? 0;
+        const txHash: string = String(arg.where?.txHash_eventIndex?.txHash ?? "");
+
+        const existing = mockDb.eventLogs.find((e) => e.txHash === txHash && e.eventIndex === eventIndex);
+        const incoming = arg.create as Partial<MockEventLogRow>;
+
+        if (existing) {
+          existing.eventType = String(incoming.eventType ?? existing.eventType);
+          existing.streamId = String(incoming.streamId ?? existing.streamId);
+          existing.ledger = Number(incoming.ledger ?? existing.ledger);
+          existing.ledgerClosedAt = String(incoming.ledgerClosedAt ?? existing.ledgerClosedAt);
+          existing.sender = incoming.sender ?? null;
+          existing.receiver = incoming.receiver ?? null;
+          existing.amount = (incoming.amount ?? null) as any;
+          existing.metadata = incoming.metadata ?? null;
+          return existing;
+        }
+
+        const row: MockEventLogRow = {
+          id: createId("event"),
+          eventType: String(incoming.eventType ?? ""),
+          streamId: String(incoming.streamId ?? ""),
+          txHash,
+          eventIndex,
+          ledger: Number(incoming.ledger ?? 0),
+          ledgerClosedAt: String(incoming.ledgerClosedAt ?? ""),
+          sender: incoming.sender ?? null,
+          receiver: incoming.receiver ?? null,
+          amount: (incoming.amount ?? null) as any,
+          metadata: incoming.metadata ?? null,
+        };
+        mockDb.eventLogs.push(row);
+        return row;
+      }),
+
+      findMany: jest.fn(async (_arg: any) => {
+        return mockDb.eventLogs;
+      }),
+    },
+
+    ledgerHash: {
+      upsert: jest.fn(async (arg: any) => {
+        const sequence = Number(arg.where?.sequence ?? arg.create?.sequence ?? 0);
+        const hash = String(arg.update?.hash ?? arg.create?.hash ?? "");
+        const existing = mockDb.ledgerHashes.find((h) => h.sequence === sequence);
+        if (existing) {
+          existing.hash = hash;
+          return existing;
+        }
+        const row: LedgerHashRow = { sequence, hash };
+        mockDb.ledgerHashes.push(row);
+        return row;
+      }),
+
+      findMany: jest.fn(async (_arg: any) => {
+        return mockDb.ledgerHashes.map((h) => ({ sequence: h.sequence, hash: h.hash }));
+      }),
+    },
+  };
+}
+
+/**
+ * A smaller prisma surface used by API routes (via `src/lib/db`).
+ */
+export function createMockLibPrisma() {
+  return {
+    stream: {
+      findMany: jest.fn(async (arg: any) => {
+        const where = arg.where ?? {};
+        let rows = [...mockDb.streams];
+
+        if (where.OR && Array.isArray(where.OR)) {
+          rows = rows.filter((row) =>
+            where.OR.some((clause: any) => {
+              if (typeof clause?.sender === "string") return row.sender === clause.sender;
+              if (typeof clause?.receiver === "string") return row.receiver === clause.receiver;
+              return false;
+            }),
+          );
+        }
+
+        if (where.status) {
+          rows = rows.filter((row) => row.status === where.status);
+        }
+
+        if (where.tokenAddress?.in && Array.isArray(where.tokenAddress.in)) {
+          const allowed = new Set(where.tokenAddress.in.map(String));
+          rows = rows.filter((row) => row.tokenAddress != null && allowed.has(row.tokenAddress));
+        }
+
+        if (arg.orderBy?.id === "desc") {
+          rows.sort((a, b) => (b.id > a.id ? 1 : -1));
+        }
+
+        return rows;
+      }),
+    },
+    eventLog: {
+      findMany: jest.fn(async () => mockDb.eventLogs),
+    },
+  };
+}
+


### PR DESCRIPTION
closes #504 
This pr implements ***"Warp" Integration Test Suite (Jest)***
###Changes
- Dedicated test DB setup (isolated “DB”): I added an isolated in-memory Prisma substitute so tests don’t touch real Postgres.
- Mock Stellar RPC emitting ScVal events: the new tests construct real @stellar/stellar-sdk xdr.ScVal event payloads and drive the ingestion through EventWatcher.fetchAndProcessEvents() with mocked RPC/Horizon responses.

###Verification
- create/stream_created ingestion populates the Stream table in the isolated DB
- Webhooks are triggered and fetch() is called with the right payload
- I also fixed the existing baseline Jest tests to correctly mock Prisma’s eventLog.upsert (the previous mock expected create).

***I ran npm run test:jest and all Jest tests passed.***
