### PR TITLE
[Backend] Feature: "Nebula-Bot" Discord/Telegram Integration

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -28,7 +28,11 @@ NODE_ENV=development
 
 SENTRY_DSN=your-sentry-dsn-here
 
-# JWT Authentication
+# Notifications (Discord / Telegram stream alerts)
+TELEGRAM_BOT_TOKEN=your-telegram-bot-token-here
+# Discord webhooks are stored per-user in the NotificationSubscription table
+
+
 JWT_SECRET=your-strong-random-secret-here
 
 # Gas Tank / Burn Rate Configuration

--- a/backend/prisma/migrations/add_notification_subscriptions.sql
+++ b/backend/prisma/migrations/add_notification_subscriptions.sql
@@ -1,0 +1,24 @@
+-- Migration: notification subscriptions for Discord/Telegram stream alerts
+
+CREATE TYPE IF NOT EXISTS "NotificationPlatform" AS ENUM ('discord', 'telegram');
+
+CREATE TABLE IF NOT EXISTS "NotificationSubscription" (
+  "id"             TEXT        NOT NULL DEFAULT gen_random_uuid()::text,
+  "stellarAddress" TEXT        NOT NULL,
+  "platform"       "NotificationPlatform" NOT NULL,
+  "webhookUrl"     TEXT,
+  "chatId"         TEXT,
+  "isActive"       BOOLEAN     NOT NULL DEFAULT true,
+  "createdAt"      TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt"      TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "NotificationSubscription_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "NotificationSubscription_stellarAddress_platform_key"
+    UNIQUE ("stellarAddress", "platform")
+);
+
+CREATE INDEX IF NOT EXISTS "NotificationSubscription_stellarAddress_idx"
+  ON "NotificationSubscription"("stellarAddress");
+
+CREATE INDEX IF NOT EXISTS "NotificationSubscription_platform_idx"
+  ON "NotificationSubscription"("platform");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -188,3 +188,24 @@ model LedgerHash {
   hash      String
   createdAt DateTime @default(now())
 }
+
+// Notification subscriptions — maps a Stellar address to a Discord/Telegram endpoint
+model NotificationSubscription {
+  id             String   @id @default(cuid())
+  stellarAddress String               // Receiver address to watch
+  platform       NotificationPlatform // discord | telegram
+  webhookUrl     String?              // Discord: full webhook URL
+  chatId         String?              // Telegram: chat/user ID
+  isActive       Boolean  @default(true)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  @@unique([stellarAddress, platform])
+  @@index([stellarAddress])
+  @@index([platform])
+}
+
+enum NotificationPlatform {
+  discord
+  telegram
+}

--- a/backend/src/api/index.ts
+++ b/backend/src/api/index.ts
@@ -11,6 +11,7 @@ import governanceRouter from "./governance.routes.js";
 import gasTankRouter from "./gas-tank.routes.js";
 import analyticsRouter from "./analytics.routes.js";
 import walletAuthRouter from "./wallet-auth.routes.js";
+import notificationRouter from "./notification-subscription.routes.js";
 
 const router = Router();
 
@@ -22,6 +23,7 @@ router.use("/", governanceRouter);
 router.use("/", gasTankRouter);
 router.use("/analytics", analyticsRouter);
 router.use("/auth", walletAuthRouter);
+router.use("/notifications", notificationRouter);
 
 const auditLogService = new AuditLogService();
 

--- a/backend/src/api/notification-subscription.routes.ts
+++ b/backend/src/api/notification-subscription.routes.ts
@@ -1,0 +1,173 @@
+/**
+ * Notification Subscription Routes
+ *
+ * POST /api/v1/notifications/subscribe   — register a Discord/Telegram subscription
+ * DELETE /api/v1/notifications/unsubscribe — remove a subscription
+ * GET  /api/v1/notifications/:address    — list subscriptions for an address
+ */
+
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+import { PrismaClient } from '../generated/client/index.js';
+import { logger } from '../logger.js';
+
+const router = Router();
+const prisma = new PrismaClient();
+
+// ── Validation schemas ────────────────────────────────────────────────────────
+
+const subscribeSchema = z.object({
+  stellarAddress: z.string().min(1),
+  platform: z.enum(['discord', 'telegram']),
+  webhookUrl: z.string().url().optional(),
+  chatId: z.string().optional(),
+}).refine(
+  (d: { platform: string; webhookUrl?: string; chatId?: string }) =>
+    d.platform === 'discord' ? !!d.webhookUrl : !!d.chatId,
+  { message: 'discord requires webhookUrl; telegram requires chatId' }
+);
+
+const unsubscribeSchema = z.object({
+  stellarAddress: z.string().min(1),
+  platform: z.enum(['discord', 'telegram']),
+});
+
+// ── Routes ────────────────────────────────────────────────────────────────────
+
+/**
+ * @openapi
+ * /notifications/subscribe:
+ *   post:
+ *     summary: Subscribe to stream notifications
+ *     description: Register a Stellar address to receive "Stream Received" alerts via Discord or Telegram.
+ *     tags:
+ *       - Notifications
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [stellarAddress, platform]
+ *             properties:
+ *               stellarAddress:
+ *                 type: string
+ *                 example: GDEF...UVW
+ *               platform:
+ *                 type: string
+ *                 enum: [discord, telegram]
+ *               webhookUrl:
+ *                 type: string
+ *                 description: Required when platform is discord
+ *               chatId:
+ *                 type: string
+ *                 description: Required when platform is telegram
+ *     responses:
+ *       201:
+ *         description: Subscription created or updated
+ *       400:
+ *         description: Validation error
+ */
+router.post('/subscribe', async (req: Request, res: Response) => {
+  const parsed = subscribeSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: parsed.error.errors[0]?.message ?? 'Invalid input' });
+    return;
+  }
+
+  const { stellarAddress, platform, webhookUrl, chatId } = parsed.data;
+
+  try {
+    const sub = await (prisma as any).notificationSubscription.upsert({
+      where: { stellarAddress_platform: { stellarAddress, platform } },
+      update: { webhookUrl, chatId, isActive: true },
+      create: { stellarAddress, platform, webhookUrl, chatId },
+    });
+
+    logger.info('[Notification] Subscription saved', { stellarAddress, platform });
+    res.status(201).json({ success: true, data: sub });
+  } catch (err) {
+    logger.error('[Notification] Subscribe failed', { err });
+    res.status(500).json({ error: 'Failed to save subscription' });
+  }
+});
+
+/**
+ * @openapi
+ * /notifications/unsubscribe:
+ *   delete:
+ *     summary: Unsubscribe from stream notifications
+ *     tags:
+ *       - Notifications
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [stellarAddress, platform]
+ *             properties:
+ *               stellarAddress:
+ *                 type: string
+ *               platform:
+ *                 type: string
+ *                 enum: [discord, telegram]
+ *     responses:
+ *       200:
+ *         description: Unsubscribed successfully
+ *       404:
+ *         description: Subscription not found
+ */
+router.delete('/unsubscribe', async (req: Request, res: Response) => {
+  const parsed = unsubscribeSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: parsed.error.errors[0]?.message ?? 'Invalid input' });
+    return;
+  }
+
+  const { stellarAddress, platform } = parsed.data;
+
+  try {
+    await (prisma as any).notificationSubscription.update({
+      where: { stellarAddress_platform: { stellarAddress, platform } },
+      data:  { isActive: false },
+    });
+
+    res.json({ success: true });
+  } catch {
+    res.status(404).json({ error: 'Subscription not found' });
+  }
+});
+
+/**
+ * @openapi
+ * /notifications/{address}:
+ *   get:
+ *     summary: List subscriptions for a Stellar address
+ *     tags:
+ *       - Notifications
+ *     parameters:
+ *       - in: path
+ *         name: address
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: List of active subscriptions
+ */
+router.get('/:address', async (req: Request, res: Response) => {
+  const { address } = req.params;
+  try {
+    const subs = await (prisma as any).notificationSubscription.findMany({
+      where: { stellarAddress: address, isActive: true },
+      select: { id: true, platform: true, isActive: true, createdAt: true },
+    });
+    res.json({ success: true, data: subs });
+  } catch (err) {
+    logger.error('[Notification] List failed', { err });
+    res.status(500).json({ error: 'Failed to retrieve subscriptions' });
+  }
+});
+
+export default router;

--- a/backend/src/indexer/dual-version-ingestor.ts
+++ b/backend/src/indexer/dual-version-ingestor.ts
@@ -14,8 +14,10 @@ import {
   saveLastLedgerSequence,
 } from "../services/syncMetadata.service.js";
 import { logger } from "../logger.js";
+import { NotificationService } from "../services/notification.service.js";
 
 const prisma = new PrismaClient();
+const notificationService = new NotificationService();
 
 const RPC_URL          = process.env.STELLAR_RPC_URL ?? "";
 const V1_CONTRACT_ID   = process.env.V1_CONTRACT_ID  ?? "";
@@ -130,6 +132,18 @@ export class DualVersionIngestor {
         legacy:      isLegacy,
       },
     });
+
+    // Fire "Stream Received" notification for new streams
+    if (action === "create") {
+      notificationService.notifyStreamReceived({
+        streamId,
+        sender:       String(payload.sender   ?? ""),
+        receiver:     String(payload.receiver ?? ""),
+        amount:       String(payload.amount   ?? "0"),
+        tokenAddress: payload.token ? String(payload.token) : null,
+        txHash:       event.txHash ?? event.id,
+      }).catch(err => logger.error("[DualIngestor] Notification dispatch error", { err }));
+    }
   }
 
   /**

--- a/backend/src/services/notification.service.ts
+++ b/backend/src/services/notification.service.ts
@@ -1,0 +1,127 @@
+/**
+ * Notification Service
+ *
+ * Dispatches "Stream Received" alerts to Discord or Telegram
+ * for users who have registered a subscription for their Stellar address.
+ */
+
+import { PrismaClient } from '../generated/client/index.js';
+import { logger } from '../logger.js';
+
+const prisma = new PrismaClient();
+
+const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN ?? '';
+
+// ── Payload ───────────────────────────────────────────────────────────────────
+
+export interface StreamReceivedEvent {
+  streamId:    string;
+  sender:      string;
+  receiver:    string;
+  amount:      string;
+  tokenAddress: string | null;
+  txHash:      string;
+}
+
+// ── Formatters ────────────────────────────────────────────────────────────────
+
+function formatDiscordPayload(event: StreamReceivedEvent): object {
+  return {
+    username: 'StellarStream 🌊',
+    avatar_url: 'https://stellar.org/favicon.ico',
+    embeds: [
+      {
+        title: '📥 Stream Received',
+        description: 'A new payment stream has been created for you on **StellarStream**.',
+        color: 0x7c3aed,
+        fields: [
+          { name: '💰 Amount',    value: `\`${event.amount}\``,      inline: true },
+          { name: '🪙 Token',     value: event.tokenAddress ? `\`${event.tokenAddress}\`` : 'XLM', inline: true },
+          { name: '🆔 Stream ID', value: `\`${event.streamId}\``,    inline: false },
+          { name: '📤 From',      value: `\`${event.sender}\``,      inline: false },
+          { name: '🔗 Tx',        value: `[View on Stellar Expert](https://stellar.expert/explorer/testnet/tx/${event.txHash})`, inline: false },
+        ],
+        footer: { text: 'StellarStream • Real-time asset streaming on Stellar' },
+        timestamp: new Date().toISOString(),
+      },
+    ],
+  };
+}
+
+function formatTelegramMessage(event: StreamReceivedEvent): string {
+  const token = event.tokenAddress ?? 'XLM';
+  return [
+    '📥 *Stream Received*',
+    '',
+    `💰 *Amount:* \`${event.amount}\` ${token}`,
+    `🆔 *Stream ID:* \`${event.streamId}\``,
+    `📤 *From:* \`${event.sender}\``,
+    `🔗 [View on Stellar Expert](https://stellar.expert/explorer/testnet/tx/${event.txHash})`,
+  ].join('\n');
+}
+
+// ── Dispatch helpers ──────────────────────────────────────────────────────────
+
+async function sendDiscord(webhookUrl: string, event: StreamReceivedEvent): Promise<void> {
+  const res = await fetch(webhookUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(formatDiscordPayload(event)),
+  });
+  if (!res.ok) {
+    throw new Error(`Discord webhook failed: ${res.status} ${res.statusText}`);
+  }
+}
+
+async function sendTelegram(chatId: string, event: StreamReceivedEvent): Promise<void> {
+  if (!TELEGRAM_BOT_TOKEN) {
+    throw new Error('TELEGRAM_BOT_TOKEN is not configured');
+  }
+  const url = `https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      chat_id:    chatId,
+      text:       formatTelegramMessage(event),
+      parse_mode: 'Markdown',
+      disable_web_page_preview: false,
+    }),
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Telegram API failed: ${res.status} — ${body}`);
+  }
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+export class NotificationService {
+  /**
+   * Look up all active subscriptions for the receiver address and
+   * dispatch a "Stream Received" notification to each platform.
+   */
+  async notifyStreamReceived(event: StreamReceivedEvent): Promise<void> {
+    const subs = await (prisma as any).notificationSubscription.findMany({
+      where: { stellarAddress: event.receiver, isActive: true },
+    });
+
+    if (subs.length === 0) return;
+
+    await Promise.allSettled(
+      subs.map(async (sub: any) => {
+        try {
+          if (sub.platform === 'discord' && sub.webhookUrl) {
+            await sendDiscord(sub.webhookUrl, event);
+            logger.info('[Notification] Discord alert sent', { receiver: event.receiver, streamId: event.streamId });
+          } else if (sub.platform === 'telegram' && sub.chatId) {
+            await sendTelegram(sub.chatId, event);
+            logger.info('[Notification] Telegram alert sent', { receiver: event.receiver, streamId: event.streamId });
+          }
+        } catch (err) {
+          logger.error('[Notification] Dispatch failed', { platform: sub.platform, receiver: event.receiver, err });
+        }
+      })
+    );
+  }
+}


### PR DESCRIPTION
closes #515 

feat(notifications): add Discord/Telegram stream alert service
feat(notifications): add Discord/Telegram stream alert service

- Add NotificationSubscription table mapping Stellar address to platform endpoint
- Add NotificationService dispatching "Stream Received" embeds to Discord webhooks and Telegram Bot API
- Add /api/v1/notifications routes: subscribe, unsubscribe, list by address
- Hook into DualVersionIngestor to trigger alerts on new stream create events
- Add migration SQL for NotificationSubscription table
- Add TELEGRAM_BOT_TOKEN to .env.example
