### PR TITLE
feat: asset-specific decimal scaling (#445)

### DIFF
--- a/frontend/components/streamingbalance/streamingbalance.tsx
+++ b/frontend/components/streamingbalance/streamingbalance.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useMemo } from "react";
 import { motion, useSpring, useTransform } from "framer-motion";
 import type { Stream } from "@/lib/contracts/stellarstream";
 import { useFlowRate } from "@/lib/use-flow-rate";
+import { useAssetDecimals } from "@/lib/use-asset-decimals";
 
 const DIGIT_HEIGHT = 56;
 const DIGITS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
@@ -131,22 +132,35 @@ export interface StreamingBalanceCardProps {
   initialValue?: number;
   rate?: number;
   prefix?: string;
+  /** Override decimal places. When `stream` is provided and assetIssuer is set,
+   *  decimals are fetched dynamically from Stellar Horizon. */
   decimals?: number;
   color?: string;
   /** Pass a live contract Stream to derive balance and rate automatically */
   stream?: Stream | null;
+  /** Asset code for dynamic decimal lookup (e.g. "USDC") */
+  assetCode?: string;
+  /** Asset issuer for dynamic decimal lookup. Omit for native XLM. */
+  assetIssuer?: string;
 }
 
 export default function StreamingBalanceCard({
   initialValue = 48291.3847291,
   rate = 0.0000247,
   prefix = "$",
-  decimals = 7,
+  decimals: decimalsProp,
   color = "#00f5ff",
   stream,
+  assetCode,
+  assetIssuer,
 }: StreamingBalanceCardProps) {
+  // Fetch decimals from Stellar Horizon when asset info is provided
+  const { decimals: fetchedDecimals } = useAssetDecimals(assetCode, assetIssuer);
+  // Explicit prop wins; otherwise use dynamically fetched value
+  const decimals = decimalsProp ?? fetchedDecimals;
+
   // If a contract stream is provided, derive rate and initial balance from it
-  const flowRate = useFlowRate(stream);
+  const flowRate = useFlowRate(stream, decimals);
   const resolvedInitial = stream ? flowRate.balance : initialValue;
   const resolvedRate = stream ? flowRate.ratePerMs : rate;
 

--- a/frontend/lib/use-asset-decimals.ts
+++ b/frontend/lib/use-asset-decimals.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+const HORIZON_URL = "https://horizon.stellar.org";
+const DEFAULT_DECIMALS = 7;
+
+/**
+ * Fetches the decimal precision for a Stellar asset from Horizon.
+ *
+ * Native XLM always uses 7 decimals. For issued assets, Horizon's
+ * asset endpoint returns `precision` (if set by the issuer via TOML)
+ * or we fall back to 7 (the Stellar network default).
+ *
+ * @param assetCode   - e.g. "USDC", "XLM"
+ * @param assetIssuer - issuer account ID (omit for native XLM)
+ */
+export function useAssetDecimals(
+  assetCode: string | null | undefined,
+  assetIssuer: string | null | undefined,
+): { decimals: number; isLoading: boolean } {
+  const [decimals, setDecimals] = useState(DEFAULT_DECIMALS);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    // Native XLM is always 7
+    if (!assetCode || !assetIssuer || assetCode === "XLM") {
+      setDecimals(DEFAULT_DECIMALS);
+      return;
+    }
+
+    let cancelled = false;
+    setIsLoading(true);
+
+    fetch(
+      `${HORIZON_URL}/assets?asset_code=${encodeURIComponent(assetCode)}&asset_issuer=${encodeURIComponent(assetIssuer)}&limit=1`,
+    )
+      .then((res) => res.json())
+      .then((data) => {
+        if (cancelled) return;
+        const record = data?._embedded?.records?.[0];
+        // Horizon exposes `precision` for assets that declare it via TOML
+        const precision =
+          typeof record?.precision === "number"
+            ? record.precision
+            : DEFAULT_DECIMALS;
+        setDecimals(precision);
+      })
+      .catch(() => {
+        if (!cancelled) setDecimals(DEFAULT_DECIMALS);
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [assetCode, assetIssuer]);
+
+  return { decimals, isLoading };
+}

--- a/frontend/lib/use-flow-rate.ts
+++ b/frontend/lib/use-flow-rate.ts
@@ -3,9 +3,8 @@
 import { useState, useEffect, useCallback } from "react";
 import type { Stream } from "@/lib/contracts/stellarstream";
 
-// Stellar uses 7 decimal places (stroops)
-const DECIMALS = 7;
-const DIVISOR = 10 ** DECIMALS;
+// Default Stellar decimal places (stroops)
+const DEFAULT_DECIMALS = 7;
 
 export interface FlowRateResult {
   /** Current interpolated balance in display units (e.g. 48291.3847291) */
@@ -24,13 +23,17 @@ export interface FlowRateResult {
  * The balance is interpolated locally at 60fps between block updates
  * so the counter feels live without hammering the RPC.
  *
- * @param stream  - Raw Stream from the contract (bigint fields, ms timestamps)
- * @param nowMs   - Optional override for current time (useful for testing)
+ * @param stream   - Raw Stream from the contract (bigint fields, ms timestamps)
+ * @param decimals - Asset decimal places (default: 7 for Stellar stroops)
+ * @param nowMs    - Optional override for current time (useful for testing)
  */
 export function useFlowRate(
   stream: Stream | null | undefined,
+  decimals: number = DEFAULT_DECIMALS,
   nowMs: number = Date.now(),
 ): FlowRateResult {
+  const divisor = 10 ** decimals;
+
   const deriveState = useCallback(
     (s: Stream | null | undefined, now: number) => {
       if (!s || s.cancelled || s.isPaused) {
@@ -39,8 +42,8 @@ export function useFlowRate(
 
       const start = Number(s.startTime);
       const end = Number(s.endTime);
-      const total = Number(s.totalAmount) / DIVISOR;
-      const withdrawn = Number(s.withdrawn) / DIVISOR;
+      const total = Number(s.totalAmount) / divisor;
+      const withdrawn = Number(s.withdrawn) / divisor;
       const duration = end - start;
 
       if (duration <= 0 || now < start) {
@@ -54,7 +57,7 @@ export function useFlowRate(
 
       return { balance, ratePerMs, isFlowing: now >= start && now < end };
     },
-    [],
+    [divisor],
   );
 
   const [state, setState] = useState<FlowRateResult>(() =>
@@ -67,9 +70,9 @@ export function useFlowRate(
       return;
     }
 
-    // Recalculate immediately when stream changes
+    // Recalculate immediately when stream or decimals change
     setState(deriveState(stream, Date.now()));
-  }, [stream, deriveState]);
+  }, [stream, decimals, deriveState]);
 
   return state;
 }
@@ -77,8 +80,14 @@ export function useFlowRate(
 /**
  * Aggregates flow_rate across multiple streams (e.g. all incoming streams).
  * Returns the combined real-time balance and net rate.
+ *
+ * @param streams  - Array of contract Stream objects
+ * @param decimals - Asset decimal places (default: 7 for Stellar stroops)
  */
-export function useAggregatedFlowRate(streams: Stream[]): FlowRateResult {
+export function useAggregatedFlowRate(
+  streams: Stream[],
+  decimals: number = DEFAULT_DECIMALS,
+): FlowRateResult {
   const [state, setState] = useState<FlowRateResult>({
     balance: 0,
     ratePerMs: 0,
@@ -86,6 +95,7 @@ export function useAggregatedFlowRate(streams: Stream[]): FlowRateResult {
   });
 
   useEffect(() => {
+    const divisor = 10 ** decimals;
     const now = Date.now();
     let totalBalance = 0;
     let totalRate = 0;
@@ -96,8 +106,8 @@ export function useAggregatedFlowRate(streams: Stream[]): FlowRateResult {
 
       const start = Number(s.startTime);
       const end = Number(s.endTime);
-      const total = Number(s.totalAmount) / DIVISOR;
-      const withdrawn = Number(s.withdrawn) / DIVISOR;
+      const total = Number(s.totalAmount) / divisor;
+      const withdrawn = Number(s.withdrawn) / divisor;
       const duration = end - start;
 
       if (duration <= 0 || now < start) continue;
@@ -116,7 +126,7 @@ export function useAggregatedFlowRate(streams: Stream[]): FlowRateResult {
       ratePerMs: totalRate,
       isFlowing: anyFlowing,
     });
-  }, [streams]);
+  }, [streams, decimals]);
 
   return state;
 }


### PR DESCRIPTION
- Add useAssetDecimals hook to fetch precision from Stellar Horizon
- Refactor useFlowRate/useAggregatedFlowRate to accept decimals param
- StreamingBalanceCard resolves decimals dynamically via assetCode/assetIssuer props
- Explicit decimals prop still takes priority for backward compatibility

closes #445