### PR TITLE
feat(frontend): Asset-Price Oracle Integration

### DIFF
--- a/frontend/components/AssetPrice.tsx
+++ b/frontend/components/AssetPrice.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { useAssetPrice } from "@/lib/use-asset-price";
+
+interface AssetPriceProps {
+  amount: number;
+  assetCode: string;
+  className?: string;
+  showToggle?: boolean;
+}
+
+/**
+ * AssetPrice component
+ * Displays real-time USD value of an asset with a pulse animation on update.
+ */
+export function AssetPrice({
+  amount,
+  assetCode,
+  className = "",
+  showToggle = true,
+}: AssetPriceProps) {
+  const [view, setView] = useState<"native" | "usd">("usd");
+  const { price, justUpdated, isLoading } = useAssetPrice(assetCode);
+
+  const usdValue = price !== null ? amount * price : null;
+
+  const toggleView = () => {
+    if (showToggle) {
+      setView((v) => (v === "native" ? "usd" : "native"));
+    }
+  };
+
+  return (
+    <div
+      className={`relative inline-flex flex-col items-start gap-1 ${className}`}
+      onClick={toggleView}
+      style={{ cursor: showToggle ? "pointer" : "default" }}
+    >
+      <div className="flex items-center gap-2">
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={view}
+            initial={{ opacity: 0, y: 5 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -5 }}
+            transition={{ duration: 0.2 }}
+            className="flex items-baseline gap-1.5"
+          >
+            {view === "usd" ? (
+              <>
+                <span className="text-sm font-medium text-slate-400">$</span>
+                <span className="text-lg font-bold text-white">
+                  {usdValue !== null ? usdValue.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }) : "---"}
+                </span>
+                <span className="text-xs font-medium text-slate-500 uppercase">USD</span>
+              </>
+            ) : (
+              <>
+                <span className="text-lg font-bold text-white">
+                  {amount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 7 })}
+                </span>
+                <span className="text-sm font-medium text-slate-400 uppercase">{assetCode}</span>
+              </>
+            )}
+          </motion.div>
+        </AnimatePresence>
+
+        {/* Pulse Indicator */}
+        <AnimatePresence>
+          {justUpdated && (
+            <motion.div
+              initial={{ scale: 0.5, opacity: 0 }}
+              animate={{ scale: [1, 1.5, 1], opacity: [0, 0.5, 0] }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 1, repeat: 1 }}
+              className="absolute -right-4 top-1 w-2 h-2 rounded-full bg-cyan-400"
+            />
+          )}
+        </AnimatePresence>
+      </div>
+
+      {isLoading && view === "usd" && (
+        <span className="text-[10px] text-cyan-400/50 animate-pulse">Syncing Oracle...</span>
+      )}
+      
+      {!isLoading && justUpdated && view === "usd" && (
+        <motion.span 
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="text-[10px] text-cyan-400 font-medium"
+        >
+          Price Updated
+        </motion.span>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/streamingbalance/streamingbalance.tsx
+++ b/frontend/components/streamingbalance/streamingbalance.tsx
@@ -5,6 +5,8 @@ import { motion, useSpring, useTransform } from "framer-motion";
 import type { Stream } from "@/lib/contracts/stellarstream";
 import { useFlowRate } from "@/lib/use-flow-rate";
 import { useAssetDecimals } from "@/lib/use-asset-decimals";
+import { useAssetPrice } from "@/lib/use-asset-price";
+import { AnimatePresence } from "framer-motion";
 
 const DIGIT_HEIGHT = 56;
 const DIGITS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
@@ -208,6 +210,14 @@ export default function StreamingBalanceCard({
     return () => cancelAnimationFrame(rafRef.current);
   }, [resolvedRate, resolvedInitial]);
 
+  const { price, justUpdated, isLoading: isPriceLoading } = useAssetPrice(assetCode || "XLM");
+  const [view, setView] = useState<"native" | "usd">("usd");
+
+  const displayValue = view === "usd" && price !== null ? balance * price : balance;
+  const displayPrefix = view === "usd" ? "$" : "";
+  const displayDecimals = view === "usd" ? 2 : decimals;
+  const displayAssetCode = view === "native" ? (assetCode || "XLM") : "USD";
+
   return (
     <div
       style={{
@@ -218,7 +228,12 @@ export default function StreamingBalanceCard({
         boxShadow: `0 0 0 1px ${color}11, 0 8px 32px rgba(0,0,0,0.5), 0 0 60px ${color}12, inset 0 1px 0 ${color}18, inset 0 0 40px ${color}07`,
         position: "relative",
         display: "inline-flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: "12px",
+        cursor: "pointer",
       }}
+      onClick={() => setView((v) => (v === "native" ? "usd" : "native"))}
     >
       {CORNERS.map(([v, h]) => (
         <div
@@ -236,12 +251,74 @@ export default function StreamingBalanceCard({
           }}
         />
       ))}
-      <Odometer
-        value={balance}
-        prefix={prefix}
-        decimals={decimals}
-        color={color}
-      />
+      
+      <div style={{ position: "relative" }}>
+        <Odometer
+          value={displayValue}
+          prefix={displayPrefix}
+          decimals={displayDecimals}
+          color={color}
+        />
+        
+        {/* Pulse Indicator from Oracle */}
+        <AnimatePresence>
+          {justUpdated && view === "usd" && (
+            <motion.div
+              initial={{ scale: 0.5, opacity: 0 }}
+              animate={{ scale: [1, 2, 1], opacity: [0, 0.8, 0] }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 1.5, repeat: 1 }}
+              style={{
+                position: "absolute",
+                top: -10,
+                right: -20,
+                width: 12,
+                height: 12,
+                borderRadius: "50%",
+                background: color,
+                boxShadow: `0 0 15px ${color}`,
+              }}
+            />
+          )}
+        </AnimatePresence>
+      </div>
+
+      <div style={{ display: "flex", alignItems: "center", gap: "8px", width: "100%", justifyContent: "space-between" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+          <span style={{ fontSize: "12px", color: `${color}88`, fontWeight: 600, letterSpacing: "0.1em", textTransform: "uppercase" }}>
+            {displayAssetCode}
+          </span>
+          {isPriceLoading && view === "usd" && (
+            <span style={{ fontSize: "10px", color: `${color}44`, animation: "pulse 2s infinite" }}>
+              Oracle Sync...
+            </span>
+          )}
+        </div>
+        
+        <div style={{ fontSize: "10px", color: `${color}66`, fontWeight: 500 }}>
+          CLICK TO TOGGLE VIEW
+        </div>
+      </div>
+
+      {justUpdated && view === "usd" && (
+        <motion.div
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0 }}
+          style={{
+            position: "absolute",
+            bottom: -20,
+            left: "50%",
+            transform: "translateX(-50%)",
+            fontSize: "10px",
+            color,
+            fontWeight: "bold",
+            letterSpacing: "0.05em",
+          }}
+        >
+          ORACLE UPDATED
+        </motion.div>
+      )}
     </div>
   );
 }

--- a/frontend/components/xlm-balance-orb.tsx
+++ b/frontend/components/xlm-balance-orb.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect } from "react";
 
+import { AssetPrice } from "./AssetPrice";
+
 interface XLMBalanceOrbProps {
   balance: number;
   threshold?: number;
@@ -321,7 +323,7 @@ export default function XLMBalanceOrb({
           role="button"
           aria-label={`Low XLM balance warning. Current balance: ${balance.toFixed(2)} XLM. Click to learn more.`}
           tabIndex={0}
-          onKeyDown={(e) => {
+          onKeyDown={(e: React.KeyboardEvent) => {
             if (e.key === "Enter" || e.key === " ") {
               e.preventDefault();
               setIsExpanded(!isExpanded);
@@ -354,9 +356,7 @@ export default function XLMBalanceOrb({
             </div>
 
             <div className="bubble-balance">
-              <span className="balance-label">Current:</span>
-              <span className="balance-value">{balance.toFixed(2)}</span>
-              <span className="balance-unit">XLM</span>
+              <AssetPrice amount={balance} assetCode="XLM" />
             </div>
 
             <div className="bubble-message">

--- a/frontend/lib/price-service.ts
+++ b/frontend/lib/price-service.ts
@@ -1,0 +1,64 @@
+/**
+ * Price Service for StellarStream
+ * Handles fetching real-time prices from CoinGecko
+ */
+
+const COINGECKO_API_BASE = "https://api.coingecko.com/api/v3";
+const PRICE_CACHE_TTL = 60 * 1000; // 1 minute cache
+
+interface PriceCache {
+  [assetId: string]: {
+    price: number;
+    timestamp: number;
+  };
+}
+
+const priceCache: PriceCache = {};
+
+/**
+ * Maps Stellar asset codes to CoinGecko IDs
+ */
+const ASSET_ID_MAP: Record<string, string> = {
+  XLM: "stellar",
+  USDC: "usd-coin",
+  EURC: "euro-coin",
+  // Add more mappings as needed
+};
+
+/**
+ * Fetches the current USD price for a given asset code.
+ *
+ * @param assetCode - The Stellar asset code (e.g., "XLM", "USDC")
+ * @returns The current USD price or null if not found
+ */
+export async function getAssetPrice(assetCode: string): Promise<number | null> {
+  const cgId = ASSET_ID_MAP[assetCode.toUpperCase()];
+  if (!cgId) {
+    if (assetCode.toUpperCase() === "USDC" || assetCode.toUpperCase() === "USD") return 1.0;
+    return null;
+  }
+
+  const now = Date.now();
+  const cached = priceCache[cgId];
+
+  if (cached && now - cached.timestamp < PRICE_CACHE_TTL) {
+    return cached.price;
+  }
+
+  try {
+    const response = await fetch(
+      `${COINGECKO_API_BASE}/simple/price?ids=${cgId}&vs_currencies=usd`
+    );
+    const data = await response.json();
+    const price = data[cgId]?.usd;
+
+    if (typeof price === "number") {
+      priceCache[cgId] = { price, timestamp: now };
+      return price;
+    }
+  } catch (error) {
+    console.error(`Error fetching price for ${assetCode}:`, error);
+  }
+
+  return cached?.price ?? null;
+}

--- a/frontend/lib/use-asset-price.ts
+++ b/frontend/lib/use-asset-price.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { getAssetPrice } from "./price-service";
+
+interface UseAssetPriceResult {
+  price: number | null;
+  isLoading: boolean;
+  justUpdated: boolean;
+}
+
+/**
+ * Hook to fetch and poll for asset prices.
+ *
+ * @param assetCode - The Stellar asset code (e.g., "XLM")
+ * @param intervalMs - Polling interval in milliseconds (default: 30000ms)
+ */
+export function useAssetPrice(
+  assetCode: string | null | undefined,
+  intervalMs: number = 30000
+): UseAssetPriceResult {
+  const [price, setPrice] = useState<number | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [justUpdated, setJustUpdated] = useState(false);
+  const lastPriceRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!assetCode) return;
+
+    let cancelled = false;
+
+    const fetchPrice = async () => {
+      if (!lastPriceRef.current) setIsLoading(true);
+      
+      const newPrice = await getAssetPrice(assetCode);
+      
+      if (cancelled) return;
+
+      if (newPrice !== null && newPrice !== lastPriceRef.current) {
+        setPrice(newPrice);
+        
+        // Only trigger "just updated" if it's not the first fetch
+        if (lastPriceRef.current !== null) {
+          setJustUpdated(true);
+          setTimeout(() => {
+            if (!cancelled) setJustUpdated(false);
+          }, 2000);
+        }
+        
+        lastPriceRef.current = newPrice;
+      }
+      
+      setIsLoading(false);
+    };
+
+    fetchPrice();
+    const interval = setInterval(fetchPrice, intervalMs);
+
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [assetCode, intervalMs]);
+
+  return { price, isLoading, justUpdated };
+}


### PR DESCRIPTION
Closes #455 
Overview
This PR implements #455 by integrating a real-time price oracle (CoinGecko) into the frontend. It allows users to view the USD value of their streams and assets with a smooth toggle between native units and USD, featuring a pulse animation on price updates.

Changes
New Files

frontend/lib/price-service.ts
: Core service to fetch real-time prices from CoinGecko with 1-minute caching.

frontend/lib/use-asset-price.ts
: Custom hook for polling asset prices and managing "just updated" states.

frontend/components/AssetPrice.tsx
: Reusable UI component with Native/USD toggle and pulse animations.
Modified Files

frontend/components/streamingbalance/streamingbalance.tsx
: Integrated the 

useAssetPrice
 hook and toggle logic into the Odometer display. Added "ORACLE UPDATED" pulse indicators.

frontend/components/xlm-balance-orb.tsx
: Integrated the 

AssetPrice
 component into the low-balance warning bubble.
Technical Implementation
Oracle Integration: Uses the CoinGecko Simple Price API to fetch XLM and USDC prices.
Animations: Implements subtle "pulse" effects and status indicators using framer-motion to signal real-time data syncs.
Toggle State: Standardized view switching between native asset codes (XLM) and USD via local state.
Checklist
 Integrate price oracle API (CoinGecko)
 Animation: Show "Price Updated" pulse when USD value shifts
 Allow users to toggle between "Native Asset" and "USD" views