### PR TITLE
feat(contract-v2): implement stream-yield split routing (#410), parti…

### DIFF
--- a/contracts/Contract-V2/src/contracterror.rs
+++ b/contracts/Contract-V2/src/contracterror.rs
@@ -41,4 +41,8 @@ pub enum Error {
     MigrationPaused = 31,
     /// Relayer fee exceeds the available withdrawal amount
     InvalidRelayerFee = 32,
+    /// split_bps must be < 10000 (cannot split 100% away from beneficiary)
+    InvalidSplitBps = 33,
+    /// Address is flagged by the compliance oracle
+    AddressFlagged = 34,
 }

--- a/contracts/Contract-V2/src/lib.rs
+++ b/contracts/Contract-V2/src/lib.rs
@@ -16,7 +16,7 @@ pub use types::{
     MigrationEvent, NebulaEvent, Operation, OperationExecutedEvent, OperationScheduledEvent,
     PermitArgs, PermitStreamCreatedEvent, StreamArgs, StreamBatchEntry, StreamCancelledV2Event,
     StreamClaimV2Event, StreamCreatedV2Event, StreamMigratedEvent, StreamRefilledEvent,
-    StreamStatus, StreamToppedUpEvent, StreamV2,
+    StreamSplitUpdatedEvent, StreamStatus, StreamToppedUpEvent, StreamV2,
 };
 use v1_interface::Client as V1Client;
 
@@ -37,6 +37,16 @@ const CONTRACT_METADATA_HASH: [u8; 32] = [
 pub trait VaultTrait {
     fn deposit(env: Env, amount: i128);
     fn withdraw(env: Env, amount: i128) -> i128; // returns actual amount withdrawn
+    /// Returns the accrued interest on `principal` without withdrawing it.
+    fn get_accrued_interest(env: Env, principal: i128) -> i128;
+}
+
+/// Compliance oracle interface (Issue #412).
+/// The oracle must implement `is_allowed(addr) -> bool`.
+/// Returning `false` means the address is on the deny-list.
+#[soroban_sdk::contractclient(name = "ComplianceClient")]
+pub trait ComplianceTrait {
+    fn is_allowed(env: Env, addr: Address) -> bool;
 }
 
 #[contractimpl]
@@ -234,6 +244,9 @@ impl Contract {
             is_recurrent: false,
             cycle_duration: 0,
             cancellation_type: 0,
+            yield_recipient: 0,
+            split_address: None,
+            split_bps: 0,
         };
 
         storage::set_stream(&env, v2_stream_id, &v2_stream);
@@ -323,37 +336,59 @@ impl Contract {
             return Err(Error::AlreadyCancelled);
         }
 
+        // Compliance oracle check (Issue #412)
+        Self::require_compliant(&env, &stream.beneficiary)?;
+
         let now = env.ledger().timestamp();
-        let unlocked = Self::calculate_unlocked_internal(&stream, now);
-        let to_withdraw = unlocked.saturating_sub(stream.withdrawn_amount);
-
-        if to_withdraw <= 0 {
-            return Err(Error::NothingToWithdraw);
-        }
-
-        // If Yield-Bearing, withdraw principal from Vault
-        if stream.yield_enabled {
-            if let Some(vault_addr) = &stream.vault_address {
-                let vault_client = VaultClient::new(&env, vault_addr);
-                // Attempt to withdraw from vault, catching if it's paused/fails
-                let result = vault_client.try_withdraw(&to_withdraw);
-
-                if result.is_err() {
-                    stream.is_pending = true;
                     storage::set_stream(&env, stream_id, &stream);
                     // Return Ok(0) to persist the 'is_pending' state change.
                     // Returning Err automatically rolls back state in Soroban.
                     return Ok(0);
                 }
+
+                // Route accrued interest to the designated yield_recipient (Issue #410)
+                let interest = vault_client.get_accrued_interest(&to_withdraw);
+                if interest > 0 {
+                    let interest_dest = match stream.yield_recipient {
+                        0 => stream.sender.clone(),
+                        2 => storage::get_treasury(&env).unwrap_or(stream.sender.clone()),
+                        _ => stream.beneficiary.clone(), // 1 = Receiver (default)
+                    };
+                    let token_client = soroban_sdk::token::TokenClient::new(&env, &stream.token);
+                    token_client.transfer(
+                        &env.current_contract_address(),
+                        &interest_dest,
+                        &interest,
+                    );
+                }
             }
         }
 
-        // Perform transfer
+        // Perform transfer — apply split if configured (Issue #411)
         let token_client = soroban_sdk::token::TokenClient::new(&env, &stream.token);
+        let to_beneficiary = if stream.split_bps > 0 {
+            if let Some(ref split_addr) = stream.split_address.clone() {
+                let split_amount = (to_withdraw * stream.split_bps as i128) / 10_000;
+                let remainder = to_withdraw - split_amount;
+                if split_amount > 0 {
+                    token_client.transfer(
+                        &env.current_contract_address(),
+                        split_addr,
+                        &split_amount,
+                    );
+                }
+                remainder
+            } else {
+                to_withdraw
+            }
+        } else {
+            to_withdraw
+        };
+
         token_client.transfer(
             &env.current_contract_address(),
             &stream.beneficiary,
-            &to_withdraw,
+            &to_beneficiary,
         );
 
         // Update state
@@ -657,6 +692,52 @@ impl Contract {
                 timestamp: now,
                 action: symbol_short!("benefic"),
                 data,
+            },
+        );
+
+        Ok(())
+    }
+
+    // ----------------------------------------------------------------
+    // Issue #411 — Stream-Splitting
+    // ----------------------------------------------------------------
+
+    /// Set or update the split configuration for a stream.
+    /// Only the current beneficiary may call this.
+    /// Pass `split_address = None` and `split_bps = 0` to remove an existing split.
+    pub fn split_stream(
+        env: Env,
+        stream_id: u64,
+        split_address: Option<Address>,
+        split_bps: u32,
+    ) -> Result<(), Error> {
+        Self::require_not_paused(&env)?;
+
+        if split_bps >= 10_000 {
+            return Err(Error::InvalidSplitBps);
+        }
+
+        let mut stream = storage::get_stream(&env, stream_id).ok_or(Error::StreamNotFound)?;
+
+        if stream.cancelled {
+            return Err(Error::AlreadyCancelled);
+        }
+
+        stream.beneficiary.require_auth();
+
+        stream.split_address = split_address.clone();
+        stream.split_bps = split_bps;
+        storage::set_stream(&env, stream_id, &stream);
+
+        let now = env.ledger().timestamp();
+        env.events().publish(
+            (stream_id, symbol_short!("split")),
+            StreamSplitUpdatedEvent {
+                stream_id,
+                beneficiary: stream.beneficiary,
+                split_address,
+                split_bps,
+                timestamp: now,
             },
         );
 
@@ -977,6 +1058,17 @@ impl Contract {
         Ok(())
     }
 
+    /// If a compliance oracle is configured, verify `addr` is not flagged.
+    fn require_compliant(env: &Env, addr: &Address) -> Result<(), Error> {
+        if let Some(oracle_addr) = storage::get_compliance_oracle(env) {
+            let oracle = ComplianceClient::new(env, &oracle_addr);
+            if !oracle.is_allowed(addr) {
+                return Err(Error::AddressFlagged);
+            }
+        }
+        Ok(())
+    }
+
     fn require_asset_whitelisted(env: &Env, asset: &Address) -> Result<(), Error> {
         if !storage::is_asset_whitelisted(env, asset) {
             return Err(Error::AssetNotWhitelisted);
@@ -1016,6 +1108,10 @@ impl Contract {
         if args.total_amount < storage::get_min_value(&env, &args.token) {
             return Err(Error::BelowDustThreshold);
         }
+
+        // Compliance oracle check (Issue #412)
+        Self::require_compliant(&env, &args.sender)?;
+        Self::require_compliant(&env, &args.receiver)?;
 
         let token_client = soroban_sdk::token::TokenClient::new(&env, &args.token);
         token_client.transfer(
@@ -1059,6 +1155,9 @@ impl Contract {
             is_recurrent: args.is_recurrent,
             cycle_duration: args.cycle_duration,
             cancellation_type: args.cancellation_type,
+            yield_recipient: args.yield_recipient,
+            split_address: args.split_address.clone(),
+            split_bps: args.split_bps,
         };
 
         storage::set_stream(&env, stream_id, &stream);
@@ -1176,6 +1275,9 @@ impl Contract {
             is_recurrent: false,
             cycle_duration: 0,
             cancellation_type: 0,
+            yield_recipient: 0,
+            split_address: None,
+            split_bps: 0,
         };
 
         storage::set_stream(&env, stream_id, &stream);
@@ -1286,10 +1388,10 @@ impl Contract {
                 is_recurrent: args.is_recurrent,
                 cycle_duration: args.cycle_duration,
                 cancellation_type: args.cancellation_type,
+                yield_recipient: args.yield_recipient,
+                split_address: args.split_address.clone(),
+                split_bps: args.split_bps,
             };
-
-            storage::set_stream(&env, stream_id, &stream);
-            storage::update_stats(&env, stream_amount, &args.sender, &args.receiver);
 
             let now = env.ledger().timestamp();
             let mut data = Vec::new(&env);
@@ -1504,6 +1606,40 @@ impl Contract {
     /// Get the current treasury address.
     pub fn get_treasury(env: Env) -> Option<Address> {
         storage::get_treasury(&env)
+    }
+
+    // ----------------------------------------------------------------
+    // Issue #412 — Compliance Oracle
+    // ----------------------------------------------------------------
+
+    /// Set the sanctions-list oracle. Admin-only.
+    /// Pass the address of a contract implementing `ComplianceTrait`.
+    pub fn set_compliance_oracle(env: Env, oracle: Address) -> Result<(), Error> {
+        storage::try_get_admin(&env)?.require_auth();
+        storage::set_compliance_oracle(&env, &oracle);
+        Ok(())
+    }
+
+    pub fn get_compliance_oracle(env: Env) -> Option<Address> {
+        storage::get_compliance_oracle(&env)
+    }
+
+    // ----------------------------------------------------------------
+    // Issue #413 — Circular Event Log
+    // ----------------------------------------------------------------
+
+    /// Append a raw event payload to the stream's circular log (max 50 entries).
+    /// Any caller may append; the log is informational and not access-controlled.
+    pub fn append_event_log(env: Env, stream_id: u64, data: Bytes) -> Result<(), Error> {
+        // Verify the stream exists before accepting log entries.
+        storage::get_stream(&env, stream_id).ok_or(Error::StreamNotFound)?;
+        storage::append_event_log(&env, stream_id, data);
+        Ok(())
+    }
+
+    /// Return the last ≤50 event payloads for `stream_id` in insertion order.
+    pub fn get_stream_event_log(env: Env, stream_id: u64) -> soroban_sdk::Vec<Bytes> {
+        storage::get_event_log(&env, stream_id)
     }
 
     /// Set the protocol fee in basis points (e.g. 100 = 1%). Admin-only.

--- a/contracts/Contract-V2/src/storage.rs
+++ b/contracts/Contract-V2/src/storage.rs
@@ -34,6 +34,9 @@ struct StoredStreamV2 {
     pub multiplier_bps: i128,
     pub vault_address: Option<Address>,
     pub cycle_duration: u64,
+    pub yield_recipient: u32,
+    pub split_address: Option<Address>,
+    pub split_bps: u32,
 }
 
 // ----------------------------------------------------------------
@@ -80,6 +83,18 @@ pub enum DataKeyV2 {
     // -- Migration pause -----------------------------------------
     /// When true, migrate_stream is blocked while standard V2 ops remain live.
     MigrationPaused, // 12
+
+    // -- Compliance Oracle (Issue #412) --------------------------
+    /// Optional sanctions-list oracle address. When set, create_stream and
+    /// withdraw call oracle.is_allowed(addr) before proceeding.
+    ComplianceOracle, // 13
+
+    // -- Circular Event Log (Issue #413) -------------------------
+    /// Per-stream circular buffer: stores the last 50 event payloads.
+    /// Value type: EventLog struct (head, count, entries).
+    EventLog(u64), // 14
+    /// Temporary overflow slot for evicted entries (indexer safety net).
+    EventLogEvicted(u64, u32), // 15
 }
 
 /// Global stream counter.
@@ -272,6 +287,9 @@ pub fn set_stream(env: &Env, stream_id: u64, stream: &StreamV2) {
         multiplier_bps: stream.multiplier_bps,
         vault_address: stream.vault_address.clone(),
         cycle_duration: stream.cycle_duration,
+        yield_recipient: stream.yield_recipient,
+        split_address: stream.split_address.clone(),
+        split_bps: stream.split_bps,
     };
     env.storage().persistent().set(&key, &stored);
     env.storage()
@@ -314,6 +332,9 @@ pub fn get_stream(env: &Env, stream_id: u64) -> Option<StreamV2> {
             cycle_duration: stored.cycle_duration,
             cancellation_type,
             penalty_bps,
+            yield_recipient: stored.yield_recipient,
+            split_address: stored.split_address,
+            split_bps: stored.split_bps,
         }
     })
 }
@@ -551,4 +572,101 @@ pub fn is_asset_whitelisted(env: &Env, asset: &Address) -> bool {
         .instance()
         .get(&DataKeyV2::WhitelistedAsset(asset.clone()))
         .unwrap_or(false)
+}
+
+// ----------------------------------------------------------------
+// Compliance Oracle helpers (Issue #412)
+// ----------------------------------------------------------------
+
+pub fn set_compliance_oracle(env: &Env, oracle: &Address) {
+    env.storage()
+        .instance()
+        .set(&DataKeyV2::ComplianceOracle, oracle);
+    bump_instance(env);
+}
+
+pub fn get_compliance_oracle(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&DataKeyV2::ComplianceOracle)
+}
+
+// ----------------------------------------------------------------
+// Issue #413 — Circular Event Log
+// ----------------------------------------------------------------
+
+pub const EVENT_LOG_CAP: u32 = 50;
+
+/// On-chain circular buffer for per-stream event payloads.
+/// `head` is the index of the next write slot (0..CAP).
+/// `count` is the number of valid entries (≤ CAP).
+#[contracttype]
+#[derive(Clone)]
+pub struct StoredEventLog {
+    pub head: u32,
+    pub count: u32,
+    pub entries: soroban_sdk::Vec<soroban_sdk::Bytes>,
+}
+
+/// Append `data` to the circular log for `stream_id`.
+/// If the buffer is full the oldest entry is moved to temporary storage
+/// (1-ledger TTL) before being overwritten, giving the indexer a last
+/// chance to read it.
+pub fn append_event_log(env: &Env, stream_id: u64, data: soroban_sdk::Bytes) {
+    let key = DataKeyV2::EventLog(stream_id);
+
+    let mut log: StoredEventLog = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or(StoredEventLog {
+            head: 0,
+            count: 0,
+            entries: soroban_sdk::Vec::new(env),
+        });
+
+    if log.count < EVENT_LOG_CAP {
+        // Buffer not yet full — grow the Vec.
+        log.entries.push_back(data);
+        log.count += 1;
+        // head stays at 0 until the buffer is full; once full it tracks oldest.
+    } else {
+        // Buffer full — evict oldest (at head) to temporary storage, then overwrite.
+        if let Some(evicted) = log.entries.get(log.head) {
+            let tmp_key = DataKeyV2::EventLogEvicted(stream_id, log.head);
+            env.storage().temporary().set(&tmp_key, &evicted);
+            // 1-ledger TTL — just enough for the indexer to catch it.
+            env.storage().temporary().extend_ttl(&tmp_key, 0, 1);
+        }
+        log.entries.set(log.head, data);
+        log.head = (log.head + 1) % EVENT_LOG_CAP;
+        // count stays at CAP
+    }
+
+    env.storage().persistent().set(&key, &log);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, STREAM_TTL_THRESHOLD, STREAM_TTL_BUMP);
+}
+
+/// Return the event log for `stream_id` in insertion order.
+pub fn get_event_log(env: &Env, stream_id: u64) -> soroban_sdk::Vec<soroban_sdk::Bytes> {
+    let key = DataKeyV2::EventLog(stream_id);
+    let log: Option<StoredEventLog> = env.storage().persistent().get(&key);
+    let log = match log {
+        Some(l) => l,
+        None => return soroban_sdk::Vec::new(env),
+    };
+
+    let mut ordered = soroban_sdk::Vec::new(env);
+    let start = if log.count == EVENT_LOG_CAP {
+        log.head // oldest slot when full
+    } else {
+        0
+    };
+    for i in 0..log.count {
+        let idx = (start + i) % EVENT_LOG_CAP;
+        if let Some(entry) = log.entries.get(idx) {
+            ordered.push_back(entry);
+        }
+    }
+    ordered
 }

--- a/contracts/Contract-V2/src/test.rs
+++ b/contracts/Contract-V2/src/test.rs
@@ -51,6 +51,9 @@ fn stream_args(sender: &Address, receiver: &Address, token: &Address, total_amou
         cycle_duration: 0,
         cancellation_type: 0,
         affiliate: None,
+        yield_recipient: 0,
+        split_address: None,
+        split_bps: 0,
     }
 }
 
@@ -82,9 +85,10 @@ fn test_packed_stream_metadata_round_trip() {
         is_recurrent: true,
         cycle_duration: 10,
         cancellation_type: 7,
+        yield_recipient: 0,
+        split_address: None,
+        split_bps: 0,
     };
-
-    let packed = crate::storage::pack_stream_metadata(&stream);
     let (status, penalty_bps, curve_type, migrated_from_v1, yield_enabled, is_recurrent, cancellation_type) =
         crate::storage::unpack_stream_metadata(packed);
 
@@ -866,6 +870,9 @@ fn test_cliff_period_locks_funds() {
         cycle_duration: 0,
         cancellation_type: 0,
         affiliate: None,
+        yield_recipient: 0,
+        split_address: None,
+        split_bps: 0,
     });
 
     // 1. Before cliff (t=140): unlocked should be zero
@@ -920,6 +927,9 @@ fn test_v2_cancel_splits_funds() {
         cycle_duration: 0,
         cancellation_type: 0,
         affiliate: None,
+        yield_recipient: 0,
+        split_address: None,
+        split_bps: 0,
     });
 
     // Cancel at t=30.
@@ -990,6 +1000,9 @@ fn test_geometric_rate_unlock_math() {
         cycle_duration: 0,
         cancellation_type: 0,
         affiliate: None,
+        yield_recipient: 0,
+        split_address: None,
+        split_bps: 0,
     });
 
     // t=25
@@ -1051,6 +1064,9 @@ fn test_create_batch_streams_success() {
             cycle_duration: 0,
             cancellation_type: 0,
             affiliate: None,
+            yield_recipient: 0,
+            split_address: None,
+            split_bps: 0,
         },
         StreamArgs {
             sender: sender.clone(),
@@ -1069,6 +1085,9 @@ fn test_create_batch_streams_success() {
             cycle_duration: 0,
             cancellation_type: 0,
             affiliate: None,
+            yield_recipient: 0,
+            split_address: None,
+            split_bps: 0,
         },
     ];
 
@@ -1129,6 +1148,9 @@ fn test_create_batch_streams_max_limit() {
             cycle_duration: 0,
             cancellation_type: 0,
             affiliate: None,
+            yield_recipient: 0,
+            split_address: None,
+            split_bps: 0,
         });
     }
 
@@ -1173,6 +1195,9 @@ fn test_create_batch_streams_atomic_failure() {
             cycle_duration: 0,
             cancellation_type: 0,
             affiliate: None,
+            yield_recipient: 0,
+            split_address: None,
+            split_bps: 0,
         },
         StreamArgs {
             sender: sender.clone(),
@@ -1191,6 +1216,9 @@ fn test_create_batch_streams_atomic_failure() {
             cycle_duration: 0,
             cancellation_type: 0,
             affiliate: None,
+            yield_recipient: 0,
+            split_address: None,
+            split_bps: 0,
         },
     ];
 
@@ -1313,6 +1341,9 @@ fn test_get_active_volume_single_stream_as_receiver() {
         cycle_duration: 0,
         cancellation_type: 0,
         affiliate: None,
+        yield_recipient: 0,
+        split_address: None,
+        split_bps: 0,
     });
 
     // Receiver should have 100M locked
@@ -1351,6 +1382,9 @@ fn test_get_active_volume_single_stream_as_sender() {
         cycle_duration: 0,
         cancellation_type: 0,
         affiliate: None,
+        yield_recipient: 0,
+        split_address: None,
+        split_bps: 0,
     });
 
     // Sender should also have 100M locked (their commitment)
@@ -1390,6 +1424,9 @@ fn test_get_active_volume_multiple_streams() {
         cycle_duration: 0,
         cancellation_type: 0,
         affiliate: None,
+        yield_recipient: 0,
+        split_address: None,
+        split_bps: 0,
     });
 
     let _sid2 = v2_client.create_stream(&StreamArgs {
@@ -1408,6 +1445,9 @@ fn test_get_active_volume_multiple_streams() {
         cycle_duration: 0,
         cancellation_type: 0,
         affiliate: None,
+        yield_recipient: 0,
+        split_address: None,
+        split_bps: 0,
     });
 
     let _sid3 = v2_client.create_stream(&StreamArgs {
@@ -1426,6 +1466,9 @@ fn test_get_active_volume_multiple_streams() {
         cycle_duration: 0,
         cancellation_type: 0,
         affiliate: None,
+        yield_recipient: 0,
+        split_address: None,
+        split_bps: 0,
     });
 
     // Receiver should have total of 600M locked
@@ -1465,6 +1508,9 @@ fn test_get_active_volume_after_partial_withdrawal() {
         cycle_duration: 0,
         cancellation_type: 0,
         affiliate: None,
+        yield_recipient: 0,
+        split_address: None,
+        split_bps: 0,
     });
 
     // At t=50, 50M unlocked
@@ -1508,6 +1554,9 @@ fn test_get_active_volume_excludes_cancelled_streams() {
         cycle_duration: 0,
         cancellation_type: 0,
         affiliate: None,
+        yield_recipient: 0,
+        split_address: None,
+        split_bps: 0,
     });
 
     let sid2 = v2_client.create_stream(&StreamArgs {
@@ -1526,6 +1575,9 @@ fn test_get_active_volume_excludes_cancelled_streams() {
         cycle_duration: 0,
         cancellation_type: 0,
         affiliate: None,
+        yield_recipient: 0,
+        split_address: None,
+        split_bps: 0,
     });
 
     // Cancel first stream
@@ -1569,6 +1621,9 @@ fn test_get_active_volume_unrelated_user_returns_zero() {
         cycle_duration: 0,
         cancellation_type: 0,
         affiliate: None,
+        yield_recipient: 0,
+        split_address: None,
+        split_bps: 0,
     });
 
     // Stranger has no involvement in the stream
@@ -1624,6 +1679,9 @@ fn test_get_active_volume_mixed_roles() {
         cycle_duration: 0,
         cancellation_type: 0,
         affiliate: None,
+        yield_recipient: 0,
+        split_address: None,
+        split_bps: 0,
     });
 
     // User as receiver
@@ -1643,6 +1701,9 @@ fn test_get_active_volume_mixed_roles() {
         cycle_duration: 0,
         cancellation_type: 0,
         affiliate: None,
+        yield_recipient: 0,
+        split_address: None,
+        split_bps: 0,
     });
 
     // User should have both streams counted: 200M + 200M = 400M
@@ -1683,6 +1744,9 @@ fn test_rebalance_after_clawback() {
         cycle_duration: 0,
         cancellation_type: 0,
         affiliate: None,
+        yield_recipient: 0,
+        split_address: None,
+        split_bps: 0,
     });
 
     let _sid2 = v2_client.create_stream(&StreamArgs {
@@ -1701,6 +1765,9 @@ fn test_rebalance_after_clawback() {
         cycle_duration: 0,
         cancellation_type: 0,
         affiliate: None,
+        yield_recipient: 0,
+        split_address: None,
+        split_bps: 0,
     });
 
     // Verify integrity before clawback
@@ -1762,6 +1829,11 @@ impl MockVault {
             .instance()
             .set(&symbol_short!("paused"), &paused);
     }
+
+    /// Returns a fixed 10% simulated yield on the principal.
+    pub fn get_accrued_interest(_env: Env, principal: i128) -> i128 {
+        principal / 10
+    }
 }
 
 #[test]
@@ -1800,6 +1872,9 @@ fn test_yield_bearing_stream() {
         cycle_duration: 0,
         cancellation_type: 0,
         affiliate: None,
+        yield_recipient: 0,
+        split_address: None,
+        split_bps: 0,
     });
 
     // Advance time to t=500 (50% unlocked)
@@ -1831,9 +1906,361 @@ fn test_yield_bearing_stream() {
     assert_eq!(token_client.balance(&receiver), 500_000_000);
 }
 
-// ── penalty_bps tests ─────────────────────────────────────────────────────
+// ── Issue #410: Yield-Split routing tests ────────────────────────────────────
 
-fn make_penalised_stream<'a>(env: &'a Env, penalty_bps: u32) -> (ContractClient<'a>, Address, Address, Address, u64) {
+#[test]
+fn test_yield_split_routes_interest_to_receiver() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let (token_id, token_client, asset_client) = create_token(&env, &token_admin);
+    let (_, v2_client) = setup_v2(&env, &admin);
+    v2_client.add_to_whitelist(&token_id);
+
+    let vault_id = env.register_contract(None, MockVault);
+    asset_client.mint(&sender, &1_000_000_000);
+    // Pre-fund contract to cover simulated interest payout
+    asset_client.mint(&v2_client.address, &100_000_000);
+
+    env.ledger().set_timestamp(500);
+
+    // yield_recipient = 1 (Receiver)
+    let sid = v2_client.create_stream(&StreamArgs {
+        sender: sender.clone(),
+        receiver: receiver.clone(),
+        token: token_id.clone(),
+        total_amount: 500_000_000,
+        start_time: 0,
+        cliff_time: 0,
+        end_time: 1000,
+        step_duration: 0,
+        multiplier_bps: 0,
+        penalty_bps: 0,
+        vault_address: Some(vault_id.clone()),
+        yield_enabled: true,
+        is_recurrent: false,
+        cycle_duration: 0,
+        cancellation_type: 0,
+        affiliate: None,
+        yield_recipient: 1,
+        split_address: None,
+        split_bps: 0,
+    });
+
+    // At t=500, 50% unlocked = 250_000_000 principal
+    // MockVault returns 10% interest = 25_000_000
+    v2_client.withdraw(&sid, &receiver);
+
+    // Receiver should have principal (250M) + interest (25M) = 275M
+    assert_eq!(token_client.balance(&receiver), 275_000_000);
+}
+
+#[test]
+fn test_yield_split_routes_interest_to_sender() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let (token_id, token_client, asset_client) = create_token(&env, &token_admin);
+    let (_, v2_client) = setup_v2(&env, &admin);
+    v2_client.add_to_whitelist(&token_id);
+
+    let vault_id = env.register_contract(None, MockVault);
+    asset_client.mint(&sender, &1_000_000_000);
+    asset_client.mint(&v2_client.address, &100_000_000);
+
+    env.ledger().set_timestamp(500);
+
+    // yield_recipient = 0 (Sender)
+    let sid = v2_client.create_stream(&StreamArgs {
+        sender: sender.clone(),
+        receiver: receiver.clone(),
+        token: token_id.clone(),
+        total_amount: 500_000_000,
+        start_time: 0,
+        cliff_time: 0,
+        end_time: 1000,
+        step_duration: 0,
+        multiplier_bps: 0,
+        penalty_bps: 0,
+        vault_address: Some(vault_id.clone()),
+        yield_enabled: true,
+        is_recurrent: false,
+        cycle_duration: 0,
+        cancellation_type: 0,
+        affiliate: None,
+        yield_recipient: 0,
+        split_address: None,
+        split_bps: 0,
+    });
+
+    let sender_balance_before = token_client.balance(&sender);
+    v2_client.withdraw(&sid, &receiver);
+
+    // Receiver gets only principal (250M), sender gets interest (25M)
+    assert_eq!(token_client.balance(&receiver), 250_000_000);
+    assert_eq!(token_client.balance(&sender), sender_balance_before + 25_000_000);
+}
+
+// ── Issue #411: Stream-Splitting tests ───────────────────────────────────────
+
+#[test]
+fn test_split_stream_routes_bps_to_split_address() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let tax_vault = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let (token_id, token_client, asset_client) = create_token(&env, &token_admin);
+    let (_, v2_client) = setup_v2(&env, &admin);
+    v2_client.add_to_whitelist(&token_id);
+
+    asset_client.mint(&sender, &1_000_000_000);
+
+    // Create a stream with no initial split
+    let sid = v2_client.create_stream(&StreamArgs {
+        sender: sender.clone(),
+        receiver: receiver.clone(),
+        token: token_id.clone(),
+        total_amount: 1_000_000_000,
+        start_time: 0,
+        cliff_time: 0,
+        end_time: 1000,
+        step_duration: 0,
+        multiplier_bps: 0,
+        penalty_bps: 0,
+        vault_address: None,
+        yield_enabled: false,
+        is_recurrent: false,
+        cycle_duration: 0,
+        cancellation_type: 0,
+        affiliate: None,
+        yield_recipient: 0,
+        split_address: None,
+        split_bps: 0,
+    });
+
+    // Receiver sets a 20% split to their tax vault
+    v2_client.split_stream(&sid, &Some(tax_vault.clone()), &2000u32);
+
+    // At t=500: 50% unlocked = 500_000_000
+    env.ledger().set_timestamp(500);
+    v2_client.withdraw(&sid, &receiver);
+
+    // 20% of 500M = 100M to tax_vault, 80% = 400M to receiver
+    assert_eq!(token_client.balance(&tax_vault), 100_000_000);
+    assert_eq!(token_client.balance(&receiver), 400_000_000);
+}
+
+#[test]
+fn test_split_stream_rejects_invalid_bps() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let (token_id, _, asset_client) = create_token(&env, &token_admin);
+    let (_, v2_client) = setup_v2(&env, &admin);
+    v2_client.add_to_whitelist(&token_id);
+    asset_client.mint(&sender, &1_000_000_000);
+
+    let sid = v2_client.create_stream(&StreamArgs {
+        sender: sender.clone(),
+        receiver: receiver.clone(),
+        token: token_id.clone(),
+        total_amount: 1_000_000_000,
+        start_time: 0,
+        cliff_time: 0,
+        end_time: 1000,
+        step_duration: 0,
+        multiplier_bps: 0,
+        penalty_bps: 0,
+        vault_address: None,
+        yield_enabled: false,
+        is_recurrent: false,
+        cycle_duration: 0,
+        cancellation_type: 0,
+        affiliate: None,
+        yield_recipient: 0,
+        split_address: None,
+        split_bps: 0,
+    });
+
+    // 10000 bps (100%) must be rejected
+    let result = v2_client.try_split_stream(&sid, &None, &10000u32);
+    assert!(result.is_err());
+}
+
+// ── Issue #412: Compliance Oracle tests ──────────────────────────────────────
+
+#[contract]
+pub struct MockOracle;
+
+#[contractimpl]
+impl MockOracle {
+    /// Returns false (flagged) for any address stored under key "blocked".
+    pub fn is_allowed(env: Env, addr: Address) -> bool {
+        let blocked: Option<Address> = env.storage().instance().get(&symbol_short!("blocked"));
+        blocked.map(|b| b != addr).unwrap_or(true)
+    }
+
+    pub fn set_blocked(env: Env, addr: Address) {
+        env.storage().instance().set(&symbol_short!("blocked"), &addr);
+    }
+}
+
+#[test]
+fn test_compliance_oracle_blocks_flagged_sender_on_create() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let (token_id, _, asset_client) = create_token(&env, &token_admin);
+    let (_, v2_client) = setup_v2(&env, &admin);
+    v2_client.add_to_whitelist(&token_id);
+    asset_client.mint(&sender, &1_000_000_000);
+
+    let oracle_id = env.register_contract(None, MockOracle);
+    let oracle_client = MockOracleClient::new(&env, &oracle_id);
+
+    // Register oracle and flag the sender
+    v2_client.set_compliance_oracle(&oracle_id);
+    oracle_client.set_blocked(&sender);
+
+    let result = v2_client.try_create_stream(&StreamArgs {
+        sender: sender.clone(),
+        receiver: receiver.clone(),
+        token: token_id.clone(),
+        total_amount: 100_000_000,
+        start_time: 0,
+        cliff_time: 0,
+        end_time: 1000,
+        step_duration: 0,
+        multiplier_bps: 0,
+        penalty_bps: 0,
+        vault_address: None,
+        yield_enabled: false,
+        is_recurrent: false,
+        cycle_duration: 0,
+        cancellation_type: 0,
+        affiliate: None,
+        yield_recipient: 0,
+        split_address: None,
+        split_bps: 0,
+    });
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_compliance_oracle_blocks_flagged_beneficiary_on_withdraw() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let (token_id, _, asset_client) = create_token(&env, &token_admin);
+    let (_, v2_client) = setup_v2(&env, &admin);
+    v2_client.add_to_whitelist(&token_id);
+    asset_client.mint(&sender, &1_000_000_000);
+
+    // Create stream before oracle is set
+    let sid = v2_client.create_stream(&StreamArgs {
+        sender: sender.clone(),
+        receiver: receiver.clone(),
+        token: token_id.clone(),
+        total_amount: 1_000_000_000,
+        start_time: 0,
+        cliff_time: 0,
+        end_time: 1000,
+        step_duration: 0,
+        multiplier_bps: 0,
+        penalty_bps: 0,
+        vault_address: None,
+        yield_enabled: false,
+        is_recurrent: false,
+        cycle_duration: 0,
+        cancellation_type: 0,
+        affiliate: None,
+        yield_recipient: 0,
+        split_address: None,
+        split_bps: 0,
+    });
+
+    // Now install oracle and flag the receiver
+    let oracle_id = env.register_contract(None, MockOracle);
+    let oracle_client = MockOracleClient::new(&env, &oracle_id);
+    v2_client.set_compliance_oracle(&oracle_id);
+    oracle_client.set_blocked(&receiver);
+
+    env.ledger().set_timestamp(500);
+    let result = v2_client.try_withdraw(&sid, &receiver);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_compliance_oracle_allows_clean_address() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let unrelated = Address::generate(&env); // only this one is blocked
+    let token_admin = Address::generate(&env);
+    let (token_id, token_client, asset_client) = create_token(&env, &token_admin);
+    let (_, v2_client) = setup_v2(&env, &admin);
+    v2_client.add_to_whitelist(&token_id);
+    asset_client.mint(&sender, &1_000_000_000);
+
+    let oracle_id = env.register_contract(None, MockOracle);
+    let oracle_client = MockOracleClient::new(&env, &oracle_id);
+    v2_client.set_compliance_oracle(&oracle_id);
+    oracle_client.set_blocked(&unrelated); // sender/receiver are clean
+
+    let sid = v2_client.create_stream(&StreamArgs {
+        sender: sender.clone(),
+        receiver: receiver.clone(),
+        token: token_id.clone(),
+        total_amount: 1_000_000_000,
+        start_time: 0,
+        cliff_time: 0,
+        end_time: 1000,
+        step_duration: 0,
+        multiplier_bps: 0,
+        penalty_bps: 0,
+        vault_address: None,
+        yield_enabled: false,
+        is_recurrent: false,
+        cycle_duration: 0,
+        cancellation_type: 0,
+        affiliate: None,
+        yield_recipient: 0,
+        split_address: None,
+        split_bps: 0,
+    });
+
+    env.ledger().set_timestamp(500);
+    v2_client.withdraw(&sid, &receiver);
+    assert_eq!(token_client.balance(&receiver), 500_000_000);
+}<'a>(env: &'a Env, penalty_bps: u32) -> (ContractClient<'a>, Address, Address, Address, u64) {
     env.mock_all_auths();
     let admin = Address::generate(env);
     let sender = Address::generate(env);
@@ -1859,6 +2286,15 @@ fn make_penalised_stream<'a>(env: &'a Env, penalty_bps: u32) -> (ContractClient<
         step_duration: 0,
         multiplier_bps: 0,
         penalty_bps,
+        vault_address: None,
+        yield_enabled: false,
+        is_recurrent: false,
+        cycle_duration: 0,
+        cancellation_type: 0,
+        affiliate: None,
+        yield_recipient: 0,
+        split_address: None,
+        split_bps: 0,
     });
 
     (client, sender, receiver, admin, stream_id)
@@ -1947,4 +2383,110 @@ fn test_invalid_penalty_bps_rejected() {
     });
 
     assert_eq!(result, Err(Ok(ContractError::InvalidPenalty)));
+}
+
+// ── Issue #413: Circular Event Log tests ─────────────────────────────────────
+
+#[test]
+fn test_event_log_appends_and_reads_in_order() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let (token_id, _, asset_client) = create_token(&env, &token_admin);
+    let (_, v2_client) = setup_v2(&env, &admin);
+    v2_client.add_to_whitelist(&token_id);
+    asset_client.mint(&sender, &1_000_000_000);
+
+    let sid = v2_client.create_stream(&StreamArgs {
+        sender: sender.clone(),
+        receiver: receiver.clone(),
+        token: token_id.clone(),
+        total_amount: 1_000_000_000,
+        start_time: 0,
+        cliff_time: 0,
+        end_time: 1000,
+        step_duration: 0,
+        multiplier_bps: 0,
+        penalty_bps: 0,
+        vault_address: None,
+        yield_enabled: false,
+        is_recurrent: false,
+        cycle_duration: 0,
+        cancellation_type: 0,
+        affiliate: None,
+        yield_recipient: 0,
+        split_address: None,
+        split_bps: 0,
+    });
+
+    // Append 3 entries
+    v2_client.append_event_log(&sid, &soroban_sdk::Bytes::from_slice(&env, b"event_a"));
+    v2_client.append_event_log(&sid, &soroban_sdk::Bytes::from_slice(&env, b"event_b"));
+    v2_client.append_event_log(&sid, &soroban_sdk::Bytes::from_slice(&env, b"event_c"));
+
+    let log = v2_client.get_stream_event_log(&sid);
+    assert_eq!(log.len(), 3);
+    assert_eq!(log.get(0).unwrap(), soroban_sdk::Bytes::from_slice(&env, b"event_a"));
+    assert_eq!(log.get(2).unwrap(), soroban_sdk::Bytes::from_slice(&env, b"event_c"));
+}
+
+#[test]
+fn test_event_log_circular_eviction_at_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let receiver = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let (token_id, _, asset_client) = create_token(&env, &token_admin);
+    let (_, v2_client) = setup_v2(&env, &admin);
+    v2_client.add_to_whitelist(&token_id);
+    asset_client.mint(&sender, &1_000_000_000);
+
+    let sid = v2_client.create_stream(&StreamArgs {
+        sender: sender.clone(),
+        receiver: receiver.clone(),
+        token: token_id.clone(),
+        total_amount: 1_000_000_000,
+        start_time: 0,
+        cliff_time: 0,
+        end_time: 1000,
+        step_duration: 0,
+        multiplier_bps: 0,
+        penalty_bps: 0,
+        vault_address: None,
+        yield_enabled: false,
+        is_recurrent: false,
+        cycle_duration: 0,
+        cancellation_type: 0,
+        affiliate: None,
+        yield_recipient: 0,
+        split_address: None,
+        split_bps: 0,
+    });
+
+    // Fill to cap (50) then add 2 more
+    for i in 0u32..52 {
+        let mut payload = [0u8; 4];
+        payload.copy_from_slice(&i.to_be_bytes());
+        v2_client.append_event_log(&sid, &soroban_sdk::Bytes::from_slice(&env, &payload));
+    }
+
+    let log = v2_client.get_stream_event_log(&sid);
+
+    // Buffer must not exceed 50
+    assert_eq!(log.len(), 50);
+
+    // Oldest surviving entry should be index 2 (0 and 1 were evicted)
+    let expected_oldest = soroban_sdk::Bytes::from_slice(&env, &2u32.to_be_bytes());
+    assert_eq!(log.get(0).unwrap(), expected_oldest);
+
+    // Newest entry should be index 51
+    let expected_newest = soroban_sdk::Bytes::from_slice(&env, &51u32.to_be_bytes());
+    assert_eq!(log.get(49).unwrap(), expected_newest);
 }

--- a/contracts/Contract-V2/src/types.rs
+++ b/contracts/Contract-V2/src/types.rs
@@ -30,6 +30,12 @@ pub struct StreamV2 {
     pub cycle_duration: u64,
     /// 0 = Unilateral cancellation, 1 = Mutual (both parties required) (Issue: Joint Signature)
     pub cancellation_type: u32,
+    /// Who receives accrued vault yield: 0 = Sender, 1 = Receiver, 2 = Treasury (Issue #410)
+    pub yield_recipient: u32,
+    /// Address that receives a split of every withdrawal (Issue #411)
+    pub split_address: Option<Address>,
+    /// Fraction of each withdrawal routed to split_address, in basis points 0–9999 (Issue #411)
+    pub split_bps: u32,
 }
 
 #[contracttype]
@@ -55,6 +61,12 @@ pub struct StreamArgs {
     pub cancellation_type: u32,
     /// Reserved for future routing extensions; protocol fees currently go to treasury only.
     pub affiliate: Option<Address>,
+    /// Who receives accrued vault yield: 0 = Sender, 1 = Receiver, 2 = Treasury (Issue #410)
+    pub yield_recipient: u32,
+    /// Address that receives a split of every withdrawal (Issue #411)
+    pub split_address: Option<Address>,
+    /// Fraction of each withdrawal routed to split_address, in basis points 0–9999 (Issue #411)
+    pub split_bps: u32,
 }
 
 #[contracttype]
@@ -329,5 +341,19 @@ pub struct FeesWithdrawnEvent {
     pub recipient: Address,
     pub token: Address,
     pub amount: i128,
+    pub timestamp: u64,
+}
+
+// ----------------------------------------------------------------
+// Issue #411: Stream-Splitting Events
+// ----------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct StreamSplitUpdatedEvent {
+    pub stream_id: u64,
+    pub beneficiary: Address,
+    pub split_address: Option<Address>,
+    pub split_bps: u32,
     pub timestamp: u64,
 }


### PR DESCRIPTION
## feat(contract-v2): Stream-Yield Split, Stream-Splitting, Compliance Oracle & Circular Event Log

### Overview
This PR implements four Contract-V2 features covering tokenomics, receiver-side fund routing, institutional compliance, and on-chain storage optimization.

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


### Changes

#410 — Stream-Yield Split Architecture
Added yield_recipient: u32 to StreamV2 and StreamArgs to control where accrued vault interest is routed on each withdrawal: 0 = Sender, 1 = Receiver (
default), 2 = Treasury. Extended VaultTrait with get_accrued_interest() and wired the routing logic into withdraw().

#411 — Partial Stream-Splitting
Added split_address: Option<Address> and split_bps: u32 to StreamV2. Introduced split_stream(stream_id, split_address, bps) — callable only by the 
beneficiary — which configures a per-stream BPS split applied on every withdrawal. Added InvalidSplitBps error guard (bps >= 10_000 rejected).

#412 — Sanctions-List Compliance Oracle Hook
Added set_compliance_oracle(oracle) (admin-only) backed by a new ComplianceTrait interface (is_allowed(addr) -> bool). Guards inserted in create_stream (
checks sender + receiver) and withdraw (checks beneficiary). No-ops when no oracle is configured, making it fully opt-in. Added AddressFlagged error 
variant.

#413 — Circular Event Log Buffer
Added append_event_log(stream_id, data) and get_stream_event_log(stream_id) backed by a StoredEventLog circular buffer (cap = 50) in persistent storage. 
When the buffer is full, the evicted entry is written to temporary storage with a 1-ledger TTL as an indexer safety net before being overwritten.

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


### Files Changed
- src/types.rs — new fields on StreamV2 / StreamArgs, new event structs
- src/contracterror.rs — InvalidSplitBps = 33, AddressFlagged = 34
- src/storage.rs — new DataKeyV2 variants (14, 15), storage helpers for oracle, split, and event log
- src/lib.rs — ComplianceTrait, require_compliant, split_stream, set_compliance_oracle, append_event_log, get_stream_event_log, guards in withdraw and 
create_stream
- src/test.rs — 9 new tests covering all four features

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


### Testing
Each feature is covered by dedicated tests:
- test_yield_split_routes_interest_to_receiver / _to_sender
- test_split_stream_routes_bps_to_split_address / _rejects_invalid_bps
- test_compliance_oracle_blocks_flagged_sender_on_create / _on_withdraw / _allows_clean_address
- test_event_log_appends_and_reads_in_order / _circular_eviction_at_cap

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


Closes #410
Closes #411
Closes #412
Closes #413