### PR TITLE
feat(Contract-V2): implement emergency withdraw-only mode (Issue #393)

### DIFF
--- a/contracts/Contract-V2/src/contracterror.rs
+++ b/contracts/Contract-V2/src/contracterror.rs
@@ -57,4 +57,6 @@ pub enum Error {
     MissingDuration = 39,
     /// Invalid duration value in bridge metadata
     InvalidDuration = 40,
+    /// Contract is in emergency (withdraw-only) mode; new capital cannot enter
+    EmergencyMode = 41,
 }

--- a/contracts/Contract-V2/src/lib.rs
+++ b/contracts/Contract-V2/src/lib.rs
@@ -1187,6 +1187,7 @@ impl Contract {
         extra_amount: i128,
     ) -> Result<(), Error> {
         Self::require_not_paused(&env)?;
+        Self::require_not_emergency(&env)?;
         sender.require_auth();
 
         if extra_amount <= 0 {
@@ -1321,6 +1322,37 @@ impl Contract {
     }
 
     // ----------------------------------------------------------------
+    // Issue #393 — Emergency (withdraw-only) Mode
+    // ----------------------------------------------------------------
+
+    /// Activate emergency mode: blocks create_stream and top_up while
+    /// leaving withdraw accessible so beneficiaries can always exit.
+    pub fn set_emergency_mode(env: Env, active: bool) -> Result<(), Error> {
+        let admin = storage::try_get_admin(&env)?;
+        admin.require_auth();
+        storage::set_emergency(&env, active);
+        let now = env.ledger().timestamp();
+        let mut data = Vec::new(&env);
+        data.push_back(admin.clone().into_val(&env));
+        data.push_back(active.into_val(&env));
+        data.push_back(now.into_val(&env));
+        env.events().publish(
+            (symbol_short!("emergency"), admin.clone()),
+            NebulaEvent {
+                version: 2,
+                timestamp: now,
+                action: symbol_short!("emergency"),
+                data,
+            },
+        );
+        Ok(())
+    }
+
+    pub fn is_emergency_mode(env: Env) -> bool {
+        storage::is_emergency(&env)
+    }
+
+    // ----------------------------------------------------------------
     // Issue: Migration Pause — granular security control
     // ----------------------------------------------------------------
 
@@ -1434,6 +1466,13 @@ impl Contract {
         Ok(())
     }
 
+    fn require_not_emergency(env: &Env) -> Result<(), Error> {
+        if storage::is_emergency(env) {
+            return Err(Error::EmergencyMode);
+        }
+        Ok(())
+    }
+
     /// If a compliance oracle is configured, verify `addr` is not flagged.
     fn require_compliant(env: &Env, addr: &Address) -> Result<(), Error> {
         if let Some(oracle_addr) = storage::get_compliance_oracle(env) {
@@ -1469,6 +1508,7 @@ impl Contract {
 
     pub fn create_stream(env: Env, args: StreamArgs) -> Result<u64, Error> {
         Self::require_not_paused(&env)?;
+        Self::require_not_emergency(&env)?;
         args.sender.require_auth();
         Self::require_asset_whitelisted(&env, &args.token)?;
 

--- a/contracts/Contract-V2/src/storage.rs
+++ b/contracts/Contract-V2/src/storage.rs
@@ -89,6 +89,10 @@ pub enum DataKeyV2 {
     PendingStreamRequest(u64), // 13
     /// Counter for generating unique pending stream request IDs
     StreamRequestCount, // 14
+
+    // -- Emergency Mode (Issue #393) ---------------------------------
+    /// When true, create_stream and top_up are blocked; withdraw remains accessible.
+    Emergency, // 15
 }
 
 /// Global stream counter.
@@ -416,6 +420,26 @@ pub fn is_paused(env: &Env) -> bool {
 /// Sets the contract's paused state.
 pub fn set_paused(env: &Env, paused: bool) {
     env.storage().instance().set(&DataKeyV2::Paused, &paused);
+    bump_instance(env);
+}
+
+// ----------------------------------------------------------------
+// instance() helpers — Emergency Mode (Issue #393)
+// ----------------------------------------------------------------
+
+/// Returns true if the contract is in emergency (withdraw-only) mode.
+pub fn is_emergency(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .get(&DataKeyV2::Emergency)
+        .unwrap_or(false)
+}
+
+/// Sets the emergency mode state.
+pub fn set_emergency(env: &Env, active: bool) {
+    env.storage()
+        .instance()
+        .set(&DataKeyV2::Emergency, &active);
     bump_instance(env);
 }
 


### PR DESCRIPTION
- Add `Emergency` key to `DataKeyV2` instance storage
- Add `is_emergency` / `set_emergency` storage helpers
- Add `EmergencyMode = 41` error variant
- Add `set_emergency_mode(active)` admin function with event emission
- Add `is_emergency_mode()` query function
- Add `require_not_emergency` private guard
- Guard `create_stream` and `top_up` with emergency check
- `withdraw` remains fully accessible during emergency mode

This PR closes #393 