### PR TITLE
feat: Storage: "Migration-Ledger" Bit-Map

### DIFF
--- a/contracts/Contract-V2/src/contracterror.rs
+++ b/contracts/Contract-V2/src/contracterror.rs
@@ -59,4 +59,6 @@ pub enum Error {
     InvalidDuration = 40,
     /// Contract is in emergency (withdraw-only) mode; new capital cannot enter
     EmergencyMode = 41,
+    /// V1 stream has already been migrated; replay attack prevented
+    AlreadyMigrated = 42,
 }

--- a/contracts/Contract-V2/src/lib.rs
+++ b/contracts/Contract-V2/src/lib.rs
@@ -451,6 +451,11 @@ impl Contract {
         }
         caller.require_auth();
 
+        // Issue #399 — replay-attack prevention
+        if storage::is_v1_migrated(&env, v1_stream_id) {
+            return Err(Error::AlreadyMigrated);
+        }
+
         let v1_client = V1Client::new(&env, &v1_contract);
 
         let v1_stream = v1_client
@@ -523,6 +528,8 @@ impl Contract {
 
         storage::set_stream(&env, v2_stream_id, &v2_stream);
         storage::update_stats(&env, remaining, &v1_stream.sender, &caller);
+        // Issue #399 — record migration so the same V1 stream cannot be migrated again
+        storage::mark_v1_migrated(&env, v1_stream_id);
 
         let mut data = Vec::new(&env);
         data.push_back(v2_stream_id.into_val(&env));
@@ -565,6 +572,11 @@ impl Contract {
         // Note: For hackathon/simplicity, we assume the Symbol matches the numeric ID.
         // In production, this would use a more robust parsing utility.
         let v1_stream_id = Self::parse_symbol_to_u64(&v1_id);
+
+        // Issue #399 — replay-attack prevention
+        if storage::is_v1_migrated(&env, v1_stream_id) {
+            return Err(Error::AlreadyMigrated);
+        }
 
         let v1_client = V1Client::new(&env, &v1_contract);
 
@@ -623,6 +635,8 @@ impl Contract {
 
         storage::set_stream(&env, v2_stream_id, &v2_stream);
         storage::update_stats(&env, remaining_balance, &v1_stream.sender, &caller);
+        // Issue #399 — record migration so the same V1 stream cannot be migrated again
+        storage::mark_v1_migrated(&env, v1_stream_id);
 
         // Emit standardized Nebula migration event
         let mut data = Vec::new(&env);

--- a/contracts/Contract-V2/src/storage.rs
+++ b/contracts/Contract-V2/src/storage.rs
@@ -93,6 +93,11 @@ pub enum DataKeyV2 {
     // -- Emergency Mode (Issue #393) ---------------------------------
     /// When true, create_stream and top_up are blocked; withdraw remains accessible.
     Emergency, // 15
+
+    // -- Migration Ledger Bit-Map (Issue #399) -----------------------
+    /// Persistent flag per V1 stream ID. Set to true after a successful migration
+    /// to prevent replay attacks (migrating the same V1 stream twice).
+    V1MigratedMap(u64), // 16
 }
 
 /// Global stream counter.
@@ -441,6 +446,28 @@ pub fn set_emergency(env: &Env, active: bool) {
         .instance()
         .set(&DataKeyV2::Emergency, &active);
     bump_instance(env);
+}
+
+// ----------------------------------------------------------------
+// persistent() helpers — Migration Ledger Bit-Map (Issue #399)
+// ----------------------------------------------------------------
+
+/// Returns true if `v1_stream_id` has already been migrated to V2.
+pub fn is_v1_migrated(env: &Env, v1_stream_id: u64) -> bool {
+    env.storage()
+        .persistent()
+        .get(&DataKeyV2::V1MigratedMap(v1_stream_id))
+        .unwrap_or(false)
+}
+
+/// Mark `v1_stream_id` as migrated. Uses the same TTL as streams so the
+/// record outlives the migration window by at least 120 days.
+pub fn mark_v1_migrated(env: &Env, v1_stream_id: u64) {
+    let key = DataKeyV2::V1MigratedMap(v1_stream_id);
+    env.storage().persistent().set(&key, &true);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, STREAM_TTL_THRESHOLD, STREAM_TTL_BUMP);
 }
 
 // ----------------------------------------------------------------


### PR DESCRIPTION
This PR closes #399

Here's a full summary of what was implemented for Issue #399:

[storage.rs](vscode-webview://1h3vb899t6rdeaeonm1vpalam6hqr2vc3knhpkv0iea80agg3i37/contracts/Contract-V2/src/storage.rs)
DataKeyV2 enum — appended V1MigratedMap(u64), // 16

New persistent helpers:

is_v1_migrated(env, v1_stream_id) -> bool — checks if a V1 ID is in the map
mark_v1_migrated(env, v1_stream_id) — sets the flag and extends TTL 120 days (matching the stream TTL, so records outlive any replay window)
[contracterror.rs](vscode-webview://1h3vb899t6rdeaeonm1vpalam6hqr2vc3knhpkv0iea80agg3i37/contracts/Contract-V2/src/contracterror.rs)

AlreadyMigrated = 42,
[lib.rs](vscode-webview://1h3vb899t6rdeaeonm1vpalam6hqr2vc3knhpkv0iea80agg3i37/contracts/Contract-V2/src/lib.rs)
Both migration functions get the same two-line pattern:

Before the V1 cancel call:


if storage::is_v1_migrated(&env, v1_stream_id) {
    return Err(Error::AlreadyMigrated);
}
After set_stream succeeds:


storage::mark_v1_migrated(&env, v1_stream_id);
