### PR TITLE
feat(Contract-V2): Nebula-DAO vote-weight integration and timelocked …

### DIFF
--- a/contracts/Contract-V2/src/contracterror.rs
+++ b/contracts/Contract-V2/src/contracterror.rs
@@ -61,4 +61,14 @@ pub enum Error {
     EmergencyMode = 41,
     /// V1 stream has already been migrated; replay attack prevented
     AlreadyMigrated = 42,
+    /// Caller's DAO voting power is below the required threshold
+    InsufficientVotingPower = 43,
+    /// DAO token contract address not configured
+    DaoTokenNotSet = 44,
+    /// Treasury split is still within the 48-hour timelock window
+    TreasurySplitTimelocked = 45,
+    /// No pending treasury split found for this ID
+    PendingTreasurySplitNotFound = 46,
+    /// Treasury split has already been executed
+    TreasurySplitAlreadyExecuted = 47,
 }

--- a/contracts/Contract-V2/src/lib.rs
+++ b/contracts/Contract-V2/src/lib.rs
@@ -50,6 +50,13 @@ pub trait ComplianceTrait {
     fn is_allowed(env: Env, addr: Address) -> bool;
 }
 
+/// Nebula-DAO governance token interface.
+/// Used to query an address's token balance as a proxy for voting power.
+#[soroban_sdk::contractclient(name = "DaoTokenClient")]
+pub trait DaoTokenTrait {
+    fn balance(env: Env, id: Address) -> i128;
+}
+
 #[contractimpl]
 impl Contract {
     // ----------------------------------------------------------------
@@ -2413,6 +2420,190 @@ impl Contract {
     pub fn get_withdrawal_nonce(env: Env, beneficiary: Address, stream_id: u64) -> u64 {
         let nonce_key = (symbol_short!("W_NONCE"), beneficiary, stream_id);
         env.storage().instance().get(&nonce_key).unwrap_or(0u64)
+    }
+
+    // ----------------------------------------------------------------
+    // Nebula-DAO Vote-Weight Integration (Issue: Governance)
+    // ----------------------------------------------------------------
+
+    /// Set the DAO governance token contract address. Admin-only.
+    pub fn set_dao_token(env: Env, token: Address) -> Result<(), Error> {
+        storage::try_get_admin(&env)?.require_auth();
+        storage::set_dao_token(&env, &token);
+        Ok(())
+    }
+
+    /// Set the minimum voting power threshold for treasury splits. Admin-only.
+    pub fn set_voting_threshold(env: Env, threshold: i128) -> Result<(), Error> {
+        storage::try_get_admin(&env)?.require_auth();
+        storage::set_voting_threshold(&env, threshold);
+        Ok(())
+    }
+
+    /// Query the DAO token balance of `addr` as a proxy for voting power.
+    /// Returns `Err(DaoTokenNotSet)` if no DAO token has been configured.
+    pub fn check_voting_power(env: Env, addr: Address) -> Result<i128, Error> {
+        let dao_token = storage::get_dao_token(&env).ok_or(Error::DaoTokenNotSet)?;
+        let client = DaoTokenClient::new(&env, &dao_token);
+        Ok(client.balance(&addr))
+    }
+
+    /// Execute an admin-only split from the Treasury account.
+    ///
+    /// The caller must hold DAO token balance >= the configured voting threshold.
+    /// Funds are transferred from the treasury address to each recipient.
+    ///
+    /// # Parameters
+    /// - `caller`: The address initiating the split (must have sufficient voting power).
+    /// - `token`: The token to distribute.
+    /// - `recipients`: List of recipient addresses.
+    /// - `amounts`: Corresponding amounts for each recipient.
+    pub fn treasury_split_by_vote(
+        env: Env,
+        caller: Address,
+        token: Address,
+        recipients: Vec<Address>,
+        amounts: Vec<i128>,
+    ) -> Result<(), Error> {
+        caller.require_auth();
+
+        // Check voting power
+        let voting_power = Self::check_voting_power(env.clone(), caller.clone())?;
+        let threshold = storage::get_voting_threshold(&env);
+        if voting_power < threshold {
+            return Err(Error::InsufficientVotingPower);
+        }
+
+        let treasury = storage::get_treasury(&env).ok_or(Error::NoTreasury)?;
+        let token_client = soroban_sdk::token::TokenClient::new(&env, &token);
+
+        for i in 0..recipients.len() {
+            let recipient = recipients.get(i).unwrap();
+            let amount = amounts.get(i).unwrap();
+            token_client.transfer(&treasury, &recipient, &amount);
+        }
+
+        let now = env.ledger().timestamp();
+        let mut data = Vec::new(&env);
+        data.push_back(caller.into_val(&env));
+        data.push_back(token.clone().into_val(&env));
+        data.push_back(now.into_val(&env));
+
+        env.events().publish(
+            (symbol_short!("dao_split"), token),
+            NebulaEvent {
+                version: 2,
+                timestamp: now,
+                action: symbol_short!("dao_split"),
+                data,
+            },
+        );
+
+        Ok(())
+    }
+
+    // ----------------------------------------------------------------
+    // Timelocked Treasury Splits (Issue: Governance Security)
+    // ----------------------------------------------------------------
+
+    /// Initiate a treasury split. Starts the 48-hour community veto window.
+    ///
+    /// Returns the `split_id` that must be passed to `execute_treasury_split`
+    /// after the timelock expires.
+    pub fn initiate_treasury_split(
+        env: Env,
+        initiator: Address,
+        token: Address,
+        recipients: Vec<Address>,
+        amounts: Vec<i128>,
+    ) -> Result<u64, Error> {
+        initiator.require_auth();
+        storage::try_get_admin(&env)?.require_auth();
+
+        let unlock_time = env.ledger().timestamp() + storage::ADMIN_DELAY;
+        let split_id = storage::next_treasury_split_id(&env);
+
+        storage::set_pending_treasury_split(
+            &env,
+            split_id,
+            &storage::PendingTreasurySplit {
+                initiator: initiator.clone(),
+                token: token.clone(),
+                recipients,
+                amounts,
+                unlock_time,
+                executed: false,
+            },
+        );
+
+        let now = env.ledger().timestamp();
+        let mut data = Vec::new(&env);
+        data.push_back(split_id.into_val(&env));
+        data.push_back(initiator.into_val(&env));
+        data.push_back(token.into_val(&env));
+        data.push_back(unlock_time.into_val(&env));
+
+        env.events().publish(
+            (symbol_short!("ts_init"), split_id),
+            NebulaEvent {
+                version: 2,
+                timestamp: now,
+                action: symbol_short!("ts_init"),
+                data,
+            },
+        );
+
+        Ok(split_id)
+    }
+
+    /// Execute a pending treasury split after the 48-hour timelock has elapsed.
+    ///
+    /// Reverts with `TreasurySplitTimelocked` if called too early, or
+    /// `TreasurySplitAlreadyExecuted` if already executed.
+    pub fn execute_treasury_split(env: Env, caller: Address, split_id: u64) -> Result<(), Error> {
+        caller.require_auth();
+        storage::try_get_admin(&env)?.require_auth();
+
+        let mut split = storage::get_pending_treasury_split(&env, split_id)
+            .ok_or(Error::PendingTreasurySplitNotFound)?;
+
+        if split.executed {
+            return Err(Error::TreasurySplitAlreadyExecuted);
+        }
+
+        if env.ledger().timestamp() < split.unlock_time {
+            return Err(Error::TreasurySplitTimelocked);
+        }
+
+        let treasury = storage::get_treasury(&env).ok_or(Error::NoTreasury)?;
+        let token_client = soroban_sdk::token::TokenClient::new(&env, &split.token);
+
+        for i in 0..split.recipients.len() {
+            let recipient = split.recipients.get(i).unwrap();
+            let amount = split.amounts.get(i).unwrap();
+            token_client.transfer(&treasury, &recipient, &amount);
+        }
+
+        split.executed = true;
+        storage::set_pending_treasury_split(&env, split_id, &split);
+
+        let now = env.ledger().timestamp();
+        let mut data = Vec::new(&env);
+        data.push_back(split_id.into_val(&env));
+        data.push_back(caller.into_val(&env));
+        data.push_back(now.into_val(&env));
+
+        env.events().publish(
+            (symbol_short!("ts_exec"), split_id),
+            NebulaEvent {
+                version: 2,
+                timestamp: now,
+                action: symbol_short!("ts_exec"),
+                data,
+            },
+        );
+
+        Ok(())
     }
 }
 

--- a/contracts/Contract-V2/src/storage.rs
+++ b/contracts/Contract-V2/src/storage.rs
@@ -98,6 +98,18 @@ pub enum DataKeyV2 {
     /// Persistent flag per V1 stream ID. Set to true after a successful migration
     /// to prevent replay attacks (migrating the same V1 stream twice).
     V1MigratedMap(u64), // 16
+
+    // -- Nebula-DAO Vote-Weight Integration (Issue: Governance) ------
+    /// Address of the DAO governance token contract
+    DaoToken, // 17
+    /// Minimum voting power required to execute admin-only treasury splits
+    VotingThreshold, // 18
+
+    // -- Timelocked Treasury Splits (Issue: Governance Security) -----
+    /// Pending treasury split by ID
+    PendingTreasurySplit(u64), // 19
+    /// Counter for pending treasury split IDs
+    TreasurySplitCount, // 20
 }
 
 /// Global stream counter.
@@ -661,5 +673,78 @@ pub fn remove_pending_stream_request(env: &Env, request_id: u64) {
     env.storage()
         .instance()
         .remove(&DataKeyV2::PendingStreamRequest(request_id));
+    bump_instance(env);
+}
+
+// ----------------------------------------------------------------
+// Nebula-DAO Vote-Weight Integration (Issue: Governance)
+// ----------------------------------------------------------------
+
+pub fn set_dao_token(env: &Env, token: &Address) {
+    env.storage().instance().set(&DataKeyV2::DaoToken, token);
+    bump_instance(env);
+}
+
+pub fn get_dao_token(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&DataKeyV2::DaoToken)
+}
+
+pub fn set_voting_threshold(env: &Env, threshold: i128) {
+    env.storage().instance().set(&DataKeyV2::VotingThreshold, &threshold);
+    bump_instance(env);
+}
+
+pub fn get_voting_threshold(env: &Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKeyV2::VotingThreshold)
+        .unwrap_or(0)
+}
+
+// ----------------------------------------------------------------
+// Timelocked Treasury Splits (Issue: Governance Security)
+// ----------------------------------------------------------------
+
+/// A pending treasury split waiting out the 48-hour timelock.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct PendingTreasurySplit {
+    pub initiator: Address,
+    pub token: Address,
+    pub recipients: Vec<Address>,
+    pub amounts: Vec<i128>,
+    pub unlock_time: u64,
+    pub executed: bool,
+}
+
+pub fn next_treasury_split_id(env: &Env) -> u64 {
+    let id: u64 = env
+        .storage()
+        .instance()
+        .get(&DataKeyV2::TreasurySplitCount)
+        .unwrap_or(0);
+    env.storage()
+        .instance()
+        .set(&DataKeyV2::TreasurySplitCount, &(id + 1));
+    id
+}
+
+pub fn set_pending_treasury_split(env: &Env, split_id: u64, split: &PendingTreasurySplit) {
+    env.storage()
+        .instance()
+        .set(&DataKeyV2::PendingTreasurySplit(split_id), split);
+    bump_instance(env);
+}
+
+pub fn get_pending_treasury_split(env: &Env, split_id: u64) -> Option<PendingTreasurySplit> {
+    env.storage()
+        .instance()
+        .get(&DataKeyV2::PendingTreasurySplit(split_id))
+}
+
+pub fn clear_pending_treasury_split(env: &Env, split_id: u64) {
+    env.storage()
+        .instance()
+        .remove(&DataKeyV2::PendingTreasurySplit(split_id));
     bump_instance(env);
 }


### PR DESCRIPTION
### Summary

This PR implements the full Nebula-DAO governance layer across the contract and backend, 
covering four issues:

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


### Issue 1 — [Contract] Nebula-DAO Vote-Weight Integration
Branch: feature/nebula-dao-vote-weight-integration

- Added DaoTokenClient trait to call balance() on any SEP-41-compatible governance token.
- Added set_dao_token / set_voting_threshold admin helpers (stored in DataKeyV2::DaoToken /
VotingThreshold).
- Added check_voting_power(addr) — queries the DAO token contract and returns the caller's 
balance.
- Added treasury_split_by_vote(caller, token, recipients, amounts) — executes an admin-only
split from the Treasury if voting_power >= threshold. Emits a dao_split event.
- New errors: InsufficientVotingPower (43), DaoTokenNotSet (44).

closes #699 

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


### Issue 2 — [Contract] Timelocked Governance Distributions
Branch: feature/nebula-dao-vote-weight-integration (same commit)

- Added PendingTreasurySplit storage type with unlock_time = now + 48h.
- Two-step execution flow:
  - initiate_treasury_split(initiator, token, recipients, amounts) — stores the split and 
starts the 48-hour veto window. Emits ts_init.
  - execute_treasury_split(caller, split_id) — executes the transfer after the timelock. 
Emits ts_exec. Reverts with TreasurySplitTimelocked if called early.
- New errors: TreasurySplitTimelocked (45), PendingTreasurySplitNotFound (46), 
TreasurySplitAlreadyExecuted (47).

closes #701 

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


### Issue 3 — [Backend] Governance Event Watcher
Branch: feature/governance-event-watcher

- Added Disbursement Prisma model with statuses: PENDING, EXECUTED, CANCELLED_BY_GOVERNANCE
.
- Added add_disbursements.sql migration.
- Added GovernanceEventWatcher service that polls Soroban RPC for ts_init, ts_exec, and 
VetoSignal contract events:
  - ts_init → upserts a Disbursement as PENDING.
  - ts_exec → transitions to EXECUTED.
  - VetoSignal → transitions to CANCELLED_BY_GOVERNANCE.
- Wired into server start/stop lifecycle alongside existing background workers.

closes #702

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


### Issue 4 — [Backend] Snapshot-to-Split Export
Branch: feature/snapshot-to-split-export

- Added GET /api/v3/governance/snapshot/:ledger endpoint.
- Returns a CSV (address,balance) of all DAO token holders at the requested ledger, ready 
for the V3 Splitter.
- **Strategy 1:** Replays indexed Transfer/Mint/Burn events from the ContractEvent table up
to the target ledger to reconstruct historical balances.
- **Strategy 2 (fallback):** Derives holder weights from active stream remaining balances 
when event history is unavailable.
- Validates the ledger is not in the future via Soroban RPC.
- Mounted under a new /api/v3 router.

closes #706 

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


### Files Changed

| Layer | Files |
|---|---|
| Contract | contracts/Contract-V2/src/lib.rs, storage.rs, contracterror.rs |
| Backend | backend/src/services/governance-event-watcher.service.ts |
| Backend | backend/src/api/v3/governance.routes.ts, v3/index.ts |
| Backend | backend/prisma/schema.prisma, migrations/add_disbursements.sql |
| Backend | backend/src/index.ts |