### PR TITLE
feat(contracts): #601 add MultiAssetRecipient struct and split_multi_…

### DIFF
--- a/contracts/Contract-V2/src/lib.rs
+++ b/contracts/Contract-V2/src/lib.rs
@@ -13,10 +13,10 @@ use contracterror::Error;
 pub use types::{
     AdminTransferredEvent, BatchStreamsCreatedEvent, BeneficiaryTransferredV2Event,
     ClawbackRebalanceEvent, ContractPausedEvent, ContractUnpausedEvent, FeesWithdrawnEvent,
-    MigrationEvent, NebulaEvent, Operation, OperationExecutedEvent, OperationScheduledEvent,
-    PermitArgs, PermitStreamCreatedEvent, StreamArgs, StreamBatchEntry, StreamCancelledV2Event,
-    StreamClaimV2Event, StreamCreatedV2Event, StreamMigratedEvent, StreamRefilledEvent,
-    StreamStatus, StreamToppedUpEvent, StreamV2, StreamRequestInitiatedEvent,
+    MigrationEvent, MultiAssetRecipient, NebulaEvent, Operation, OperationExecutedEvent,
+    OperationScheduledEvent, PermitArgs, PermitStreamCreatedEvent, StreamArgs, StreamBatchEntry,
+    StreamCancelledV2Event, StreamClaimV2Event, StreamCreatedV2Event, StreamMigratedEvent,
+    StreamRefilledEvent, StreamStatus, StreamToppedUpEvent, StreamV2, StreamRequestInitiatedEvent,
     StreamRequestApprovedEvent, StreamRequestExecutedEvent,
 };
 use v1_interface::Client as V1Client;
@@ -2602,6 +2602,42 @@ impl Contract {
                 data,
             },
         );
+
+        Ok(())
+    }
+
+    // ----------------------------------------------------------------
+    // Issue #601 — Multi-Asset Batch Disbursement
+    // ----------------------------------------------------------------
+
+    /// Disburse multiple assets to multiple recipients in a single atomic call.
+    ///
+    /// The caller must have pre-approved this contract (via `token.approve`) for
+    /// each distinct asset/amount combination before invoking this function.
+    /// Each `MultiAssetRecipient` row may specify a different asset, so USDC can
+    /// go to some recipients while XLM (or any SAC-compliant token) goes to others.
+    ///
+    /// Panics (via `require_auth`) if the caller has not authorised the transaction.
+    pub fn split_multi_asset(
+        env: Env,
+        from: Address,
+        recipients: Vec<MultiAssetRecipient>,
+    ) -> Result<(), Error> {
+        Self::require_not_paused(&env)?;
+
+        if recipients.is_empty() || recipients.len() > 50 {
+            return Err(Error::BatchTooLarge);
+        }
+
+        from.require_auth();
+
+        for entry in recipients.iter() {
+            if entry.amount <= 0 {
+                return Err(Error::BelowDustThreshold);
+            }
+            let token_client = soroban_sdk::token::TokenClient::new(&env, &entry.asset);
+            token_client.transfer(&from, &entry.address, &entry.amount);
+        }
 
         Ok(())
     }

--- a/contracts/Contract-V2/src/types.rs
+++ b/contracts/Contract-V2/src/types.rs
@@ -192,6 +192,21 @@ pub struct PermitStreamCreatedEvent {
     pub timestamp: u64,
 }
 
+// ----------------------------------------------------------------
+// Issue #601 — Multi-Asset Batch Disbursement
+// ----------------------------------------------------------------
+
+/// A single recipient entry for `split_multi_asset`.
+/// Each row specifies its own asset, so different recipients can receive
+/// different tokens in a single atomic call.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct MultiAssetRecipient {
+    pub address: Address,
+    pub asset: Address,
+    pub amount: i128,
+}
+
 /// Emitted when the admin is transferred to a new address.
 #[contracttype]
 #[derive(Clone, Debug)]


### PR DESCRIPTION
## [Contract] Feature: Multi-Asset Batch Disbursement 
### What
Adds the ability to disburse multiple different assets to multiple recipients in a single atomic contract call.

### Why
The existing `create_batch_streams` only handles a single token per batch. Payroll and airdrop scenarios often require sending USDC to some recipients and XLM (or other SAC tokens) to others — previously impossible without multiple separate transactions.

### Changes
- **`types.rs`** — new `MultiAssetRecipient` struct: `address: Address`, `asset: Address`, `amount: i128`
- **`lib.rs`** — new `split_multi_asset(env, from, recipients)` function:
  - Caller pre-approves the contract via `token.approve` for each asset before calling
  - Instantiates a per-row `TokenClient` so each recipient can receive a different token
  - Guards: `require_not_paused`, `from.require_auth()`, `amount > 0`, batch size 1–50

### Behaviour

split_multi_asset(env, alice, [
 { address: bob,   asset: USDC, amount: 500_000_000 },
 { address: carol, asset: XLM,  amount: 100_0000000  },
])
Each transfer is executed atomically — if any step fails the entire call reverts.

### Error handling
Reuses existing error variants — no new error codes needed:
| Condition | Error |
|---|---|
| Empty list or > 50 recipients | `BatchTooLarge` |
| `amount <= 0` on any row | `BelowDustThreshold` |
| Contract paused | `ContractPaused` |

closes #601
