### PR TITLE
feat(splitter-v3): add scheduled split with cancel and refund support

### DIFF
--- a/contracts/splitter-v3/src/errors.rs
+++ b/contracts/splitter-v3/src/errors.rs
@@ -14,4 +14,9 @@ pub enum Error {
     ProposalNotFound = 9,
     AlreadyExecuted = 10,
     QuorumNotReached = 11,    // < 2 approvals
+    SplitNotFound = 12,       // no scheduled split with that id
+    NotSplitSender = 13,      // caller is not the original sender
+    SplitAlreadyCancelled = 14, // split was already cancelled
+    SplitAlreadyExecuted = 15,  // split was already executed
+    SplitNotYetDue = 16,      // release_time has not been reached
 }

--- a/contracts/splitter-v3/src/lib.rs
+++ b/contracts/splitter-v3/src/lib.rs
@@ -43,6 +43,30 @@ pub struct Proposal {
     pub executed: bool,
 }
 
+/// Status of a scheduled split.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum SplitStatus {
+    Pending,
+    Executed,
+    Cancelled,
+}
+
+/// A scheduled (future) split stored on-chain until its release_time.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct SplitConfig {
+    /// The address that funded and scheduled this split.
+    pub sender: Address,
+    /// Recipients and their shares (must sum to 10_000 bps).
+    pub recipients: Vec<Recipient>,
+    /// Total tokens locked in the contract for this split.
+    pub total_amount: i128,
+    /// Ledger timestamp (seconds) after which the split can be executed.
+    pub release_time: u64,
+    pub status: SplitStatus,
+}
+
 // ── Contract ──────────────────────────────────────────────────────────────────
 
 #[contract]
@@ -74,6 +98,7 @@ impl SplitterV3 {
         env.storage().instance().set(&DataKey::StrictMode, &false);
         env.storage().instance().set(&DataKey::NextProposalId, &0u64);
         env.storage().instance().set(&DataKey::QuorumAdmins, &quorum_admins);
+        env.storage().instance().set(&DataKey::NextSplitId, &0u64);
 
         // Auto-verify the owner.
         Self::_set_verified(&env, &owner, true);
@@ -285,6 +310,186 @@ impl SplitterV3 {
         }
 
         Ok(())
+    }
+
+    // ── Scheduled splits ──────────────────────────────────────────────────────
+
+    /// Lock `total_amount` tokens and schedule a split for `release_time`.
+    ///
+    /// Tokens are transferred from `sender` to the contract immediately.
+    /// The split can be executed by anyone once `release_time` has passed,
+    /// or cancelled exclusively by `sender` before that point.
+    ///
+    /// Returns the new `split_id`.
+    pub fn schedule_split(
+        env: Env,
+        sender: Address,
+        recipients: Vec<Recipient>,
+        total_amount: i128,
+        release_time: u64,
+    ) -> Result<u64, Error> {
+        sender.require_auth();
+
+        // Validate shares sum to 10_000 bps.
+        let mut bps_sum: u32 = 0;
+        for r in recipients.iter() {
+            bps_sum = bps_sum.checked_add(r.share_bps).ok_or(Error::Overflow)?;
+        }
+        if bps_sum != 10_000 {
+            return Err(Error::InvalidSplit);
+        }
+
+        // Lock the tokens in the contract.
+        let token_addr: Address = env.storage().instance().get(&DataKey::Token).unwrap();
+        let token_client = token::Client::new(&env, &token_addr);
+        token_client.transfer(&sender, &env.current_contract_address(), &total_amount);
+
+        // Assign and increment the split id counter.
+        let split_id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::NextSplitId)
+            .unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&DataKey::NextSplitId, &(split_id + 1));
+
+        let config = SplitConfig {
+            sender,
+            recipients,
+            total_amount,
+            release_time,
+            status: SplitStatus::Pending,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::ScheduledSplit(split_id), &config);
+
+        env.events()
+            .publish((symbol_short!("sched"), split_id), release_time);
+
+        Ok(split_id)
+    }
+
+    /// Execute a scheduled split once its `release_time` has been reached.
+    ///
+    /// Anyone may call this — the auth check is on the ledger timestamp, not
+    /// the caller identity.
+    pub fn execute_split(env: Env, split_id: u64) -> Result<(), Error> {
+        let mut config: SplitConfig = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ScheduledSplit(split_id))
+            .ok_or(Error::SplitNotFound)?;
+
+        match config.status {
+            SplitStatus::Cancelled => return Err(Error::SplitAlreadyCancelled),
+            SplitStatus::Executed => return Err(Error::SplitAlreadyExecuted),
+            SplitStatus::Pending => {}
+        }
+
+        if env.ledger().timestamp() < config.release_time {
+            return Err(Error::SplitNotYetDue);
+        }
+
+        let token_addr: Address = env.storage().instance().get(&DataKey::Token).unwrap();
+        let token_client = token::Client::new(&env, &token_addr);
+        let contract_addr = env.current_contract_address();
+
+        let fee_bps: u32 = env.storage().instance().get(&DataKey::FeeBps).unwrap_or(0);
+        let fee_amount = if fee_bps > 0 {
+            let f = config
+                .total_amount
+                .checked_mul(fee_bps as i128)
+                .ok_or(Error::Overflow)?
+                / 10_000;
+            let treasury: Address = env.storage().instance().get(&DataKey::Treasury).unwrap();
+            if f > 0 {
+                token_client.transfer(&contract_addr, &treasury, &f);
+            }
+            f
+        } else {
+            0
+        };
+        let distributable = config
+            .total_amount
+            .checked_sub(fee_amount)
+            .ok_or(Error::Overflow)?;
+
+        Self::_distribute(
+            &env,
+            &token_client,
+            &contract_addr,
+            &config.recipients,
+            distributable,
+        )?;
+
+        config.status = SplitStatus::Executed;
+        env.storage()
+            .persistent()
+            .set(&DataKey::ScheduledSplit(split_id), &config);
+
+        Ok(())
+    }
+
+    /// Cancel a pending scheduled split and refund the locked tokens to the
+    /// original sender.
+    ///
+    /// Auth: only the `sender` stored in the `SplitConfig` may call this.
+    /// Reverts if the split has already been executed or cancelled, or if
+    /// the release_time has already passed.
+    pub fn cancel_split(env: Env, caller: Address, split_id: u64) -> Result<(), Error> {
+        caller.require_auth();
+
+        let mut config: SplitConfig = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ScheduledSplit(split_id))
+            .ok_or(Error::SplitNotFound)?;
+
+        // Strict sender-only auth: only the original funder may cancel.
+        if config.sender != caller {
+            return Err(Error::NotSplitSender);
+        }
+
+        match config.status {
+            SplitStatus::Cancelled => return Err(Error::SplitAlreadyCancelled),
+            SplitStatus::Executed => return Err(Error::SplitAlreadyExecuted),
+            SplitStatus::Pending => {}
+        }
+
+        // Disallow cancellation once the release window has opened — at that
+        // point recipients have a legitimate claim and execute_split can be
+        // called by anyone.
+        if env.ledger().timestamp() >= config.release_time {
+            return Err(Error::SplitNotYetDue);
+        }
+
+        // Refund the full locked amount back to the sender.
+        let token_addr: Address = env.storage().instance().get(&DataKey::Token).unwrap();
+        let token_client = token::Client::new(&env, &token_addr);
+        token_client.transfer(
+            &env.current_contract_address(),
+            &config.sender,
+            &config.total_amount,
+        );
+
+        config.status = SplitStatus::Cancelled;
+        env.storage()
+            .persistent()
+            .set(&DataKey::ScheduledSplit(split_id), &config);
+
+        env.events()
+            .publish((symbol_short!("cancel"), split_id), config.sender);
+
+        Ok(())
+    }
+
+    /// View a scheduled split by id.
+    pub fn get_split(env: Env, split_id: u64) -> Option<SplitConfig> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ScheduledSplit(split_id))
     }
 
     // ── Views ─────────────────────────────────────────────────────────────────

--- a/contracts/splitter-v3/src/storage.rs
+++ b/contracts/splitter-v3/src/storage.rs
@@ -21,4 +21,8 @@ pub enum DataKey {
     VerifiedUsers(Address),
     /// persistent() — proposals keyed by id
     Proposal(u64),
+    /// instance() — next scheduled split id counter
+    NextSplitId,
+    /// persistent() — scheduled splits keyed by split_id
+    ScheduledSplit(u64),
 }

--- a/contracts/splitter-v3/src/test.rs
+++ b/contracts/splitter-v3/src/test.rs
@@ -196,3 +196,167 @@ fn test_split_uses_updated_fee() {
     // 0% fee → alice gets the full amount.
     assert_eq!(s.token.balance(&alice), 1_000_000);
 }
+
+// ── Scheduled split tests ─────────────────────────────────────────────────────
+
+use crate::{SplitStatus};
+use soroban_sdk::testutils::Ledger as _;
+
+#[test]
+fn test_schedule_and_execute_split() {
+    let s = setup();
+    let alice = Address::generate(&s.env);
+    let bob = Address::generate(&s.env);
+
+    let mut recipients = Vec::new(&s.env);
+    recipients.push_back(Recipient { address: alice.clone(), share_bps: 6_000 });
+    recipients.push_back(Recipient { address: bob.clone(), share_bps: 4_000 });
+
+    let now = s.env.ledger().timestamp();
+    let release_time = now + 1_000;
+
+    let split_id = s.contract
+        .schedule_split(&s.owner, &recipients, &1_000_000, &release_time)
+        .unwrap();
+
+    // Advance ledger past release_time.
+    s.env.ledger().with_mut(|l| l.timestamp = release_time + 1);
+
+    s.contract.execute_split(&split_id).unwrap();
+
+    // 1% fee (100 bps) → distributable = 990_000
+    // alice: 990_000 * 6000 / 10000 = 594_000
+    // bob:   990_000 * 4000 / 10000 = 396_000
+    assert_eq!(s.token.balance(&alice), 594_000);
+    assert_eq!(s.token.balance(&bob), 396_000);
+
+    let config = s.contract.get_split(split_id).unwrap();
+    assert_eq!(config.status, SplitStatus::Executed);
+}
+
+#[test]
+fn test_cancel_split_refunds_sender() {
+    let s = setup();
+    let alice = Address::generate(&s.env);
+
+    let mut recipients = Vec::new(&s.env);
+    recipients.push_back(Recipient { address: alice.clone(), share_bps: 10_000 });
+
+    let now = s.env.ledger().timestamp();
+    let release_time = now + 1_000;
+    let initial_balance = s.token.balance(&s.owner);
+
+    let split_id = s.contract
+        .schedule_split(&s.owner, &recipients, &500_000, &release_time)
+        .unwrap();
+
+    // Tokens are locked — owner balance reduced.
+    assert_eq!(s.token.balance(&s.owner), initial_balance - 500_000);
+
+    // Cancel before release_time.
+    s.contract.cancel_split(&s.owner, &split_id).unwrap();
+
+    // Tokens fully refunded.
+    assert_eq!(s.token.balance(&s.owner), initial_balance);
+
+    let config = s.contract.get_split(split_id).unwrap();
+    assert_eq!(config.status, SplitStatus::Cancelled);
+}
+
+#[test]
+fn test_cancel_split_wrong_sender_rejected() {
+    let s = setup();
+    let alice = Address::generate(&s.env);
+    let attacker = Address::generate(&s.env);
+
+    let mut recipients = Vec::new(&s.env);
+    recipients.push_back(Recipient { address: alice.clone(), share_bps: 10_000 });
+
+    let now = s.env.ledger().timestamp();
+    let split_id = s.contract
+        .schedule_split(&s.owner, &recipients, &100_000, &(now + 1_000))
+        .unwrap();
+
+    let result = s.contract.cancel_split(&attacker, &split_id);
+    assert_eq!(result, Err(Error::NotSplitSender));
+}
+
+#[test]
+fn test_cancel_split_after_release_time_rejected() {
+    let s = setup();
+    let alice = Address::generate(&s.env);
+
+    let mut recipients = Vec::new(&s.env);
+    recipients.push_back(Recipient { address: alice.clone(), share_bps: 10_000 });
+
+    let now = s.env.ledger().timestamp();
+    let release_time = now + 500;
+
+    let split_id = s.contract
+        .schedule_split(&s.owner, &recipients, &100_000, &release_time)
+        .unwrap();
+
+    // Advance past release_time.
+    s.env.ledger().with_mut(|l| l.timestamp = release_time + 1);
+
+    let result = s.contract.cancel_split(&s.owner, &split_id);
+    assert_eq!(result, Err(Error::SplitNotYetDue));
+}
+
+#[test]
+fn test_execute_split_before_release_time_rejected() {
+    let s = setup();
+    let alice = Address::generate(&s.env);
+
+    let mut recipients = Vec::new(&s.env);
+    recipients.push_back(Recipient { address: alice.clone(), share_bps: 10_000 });
+
+    let now = s.env.ledger().timestamp();
+    let split_id = s.contract
+        .schedule_split(&s.owner, &recipients, &100_000, &(now + 1_000))
+        .unwrap();
+
+    let result = s.contract.execute_split(&split_id);
+    assert_eq!(result, Err(Error::SplitNotYetDue));
+}
+
+#[test]
+fn test_cancel_already_cancelled_split_rejected() {
+    let s = setup();
+    let alice = Address::generate(&s.env);
+
+    let mut recipients = Vec::new(&s.env);
+    recipients.push_back(Recipient { address: alice.clone(), share_bps: 10_000 });
+
+    let now = s.env.ledger().timestamp();
+    let split_id = s.contract
+        .schedule_split(&s.owner, &recipients, &100_000, &(now + 1_000))
+        .unwrap();
+
+    s.contract.cancel_split(&s.owner, &split_id).unwrap();
+
+    let result = s.contract.cancel_split(&s.owner, &split_id);
+    assert_eq!(result, Err(Error::SplitAlreadyCancelled));
+}
+
+#[test]
+fn test_cancel_executed_split_rejected() {
+    let s = setup();
+    let alice = Address::generate(&s.env);
+
+    let mut recipients = Vec::new(&s.env);
+    recipients.push_back(Recipient { address: alice.clone(), share_bps: 10_000 });
+
+    let now = s.env.ledger().timestamp();
+    let release_time = now + 500;
+
+    let split_id = s.contract
+        .schedule_split(&s.owner, &recipients, &100_000, &release_time)
+        .unwrap();
+
+    s.env.ledger().with_mut(|l| l.timestamp = release_time + 1);
+    s.contract.execute_split(&split_id).unwrap();
+
+    let result = s.contract.cancel_split(&s.owner, &split_id);
+    assert_eq!(result, Err(Error::SplitAlreadyExecuted));
+}


### PR DESCRIPTION
- Add SplitConfig struct and SplitStatus enum (Pending/Executed/Cancelled)
- Add NextSplitId and ScheduledSplit(u64) storage keys
- Implement schedule_split: locks tokens and stores future split by release_time
- Implement execute_split: permissionless execution once release_time is reached
- Implement cancel_split: sender-only cancellation with full refund before release_time
- Add get_split view function
- Add 5 new error variants for scheduled split failure cases
- Add 7 tests covering happy path, auth guards, and state transition edge cases
closes #638