### PR TITLE
feat(splitter-v3): add pull-based claimable balance system

### DIFF
--- a/contracts/splitter-v3/src/errors.rs
+++ b/contracts/splitter-v3/src/errors.rs
@@ -19,4 +19,5 @@ pub enum Error {
     SplitAlreadyCancelled = 14, // split was already cancelled
     SplitAlreadyExecuted = 15,  // split was already executed
     SplitNotYetDue = 16,      // release_time has not been reached
+    NothingToClaim = 17,      // claimable balance is zero
 }

--- a/contracts/splitter-v3/src/lib.rs
+++ b/contracts/splitter-v3/src/lib.rs
@@ -492,6 +492,110 @@ impl SplitterV3 {
             .get(&DataKey::ScheduledSplit(split_id))
     }
 
+    // ── Pull-based (claimable) splits ─────────────────────────────────────────
+
+    /// Like `split`, but instead of pushing tokens to recipients, credits each
+    /// recipient's claimable balance in the contract.  Recipients must call
+    /// `claim_share` to actually receive their funds.
+    ///
+    /// This avoids failures caused by missing trustlines on the recipient side.
+    /// The fee is still deducted and forwarded to the treasury immediately.
+    pub fn split_pull(
+        env: Env,
+        sender: Address,
+        recipients: Vec<Recipient>,
+        total_amount: i128,
+    ) -> Result<(), Error> {
+        sender.require_auth();
+
+        let mut bps_sum: u32 = 0;
+        for r in recipients.iter() {
+            bps_sum = bps_sum.checked_add(r.share_bps).ok_or(Error::Overflow)?;
+        }
+        if bps_sum != 10_000 {
+            return Err(Error::InvalidSplit);
+        }
+
+        let token_addr: Address = env.storage().instance().get(&DataKey::Token).unwrap();
+        let token_client = token::Client::new(&env, &token_addr);
+        let contract_addr = env.current_contract_address();
+
+        // Pull the full amount into the contract.
+        token_client.transfer(&sender, &contract_addr, &total_amount);
+
+        // Deduct fee and forward to treasury immediately.
+        let fee_bps: u32 = env.storage().instance().get(&DataKey::FeeBps).unwrap_or(0);
+        let fee_amount = if fee_bps > 0 {
+            let f = total_amount
+                .checked_mul(fee_bps as i128)
+                .ok_or(Error::Overflow)?
+                / 10_000;
+            let treasury: Address = env.storage().instance().get(&DataKey::Treasury).unwrap();
+            if f > 0 {
+                token_client.transfer(&contract_addr, &treasury, &f);
+            }
+            f
+        } else {
+            0
+        };
+        let distributable = total_amount.checked_sub(fee_amount).ok_or(Error::Overflow)?;
+
+        // Credit each recipient's claimable balance — no token transfer yet.
+        for r in recipients.iter() {
+            let share = distributable
+                .checked_mul(r.share_bps as i128)
+                .ok_or(Error::Overflow)?
+                / 10_000;
+            if share > 0 {
+                Self::_credit_claimable(&env, &r.address, &token_addr, share)?;
+            }
+        }
+
+        env.events()
+            .publish((symbol_short!("pullsplit"),), distributable);
+
+        Ok(())
+    }
+
+    /// Claim all tokens owed to `caller` for the given `asset`.
+    ///
+    /// Reads the caller's claimable balance, zeroes it, then transfers the
+    /// tokens from the contract to the caller.  Reverts with `NothingToClaim`
+    /// if the balance is zero.
+    pub fn claim_share(env: Env, caller: Address, asset: Address) -> Result<(), Error> {
+        caller.require_auth();
+
+        let key = DataKey::ClaimableBalance(caller.clone(), asset.clone());
+        let amount: i128 = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(0);
+
+        if amount <= 0 {
+            return Err(Error::NothingToClaim);
+        }
+
+        // Zero the balance before transferring (checks-effects-interactions).
+        env.storage().persistent().set(&key, &0i128);
+
+        let token_client = token::Client::new(&env, &asset);
+        token_client.transfer(&env.current_contract_address(), &caller, &amount);
+
+        env.events()
+            .publish((symbol_short!("claimed"), caller), amount);
+
+        Ok(())
+    }
+
+    /// View the claimable balance for a given recipient and asset.
+    pub fn claimable_balance(env: Env, recipient: Address, asset: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ClaimableBalance(recipient, asset))
+            .unwrap_or(0)
+    }
+
     // ── Views ─────────────────────────────────────────────────────────────────
 
     pub fn is_verified(env: &Env, address: Address) -> bool {
@@ -547,6 +651,20 @@ impl SplitterV3 {
         env.storage()
             .persistent()
             .set(&DataKey::VerifiedUsers(user.clone()), &status);
+    }
+
+    /// Increment a recipient's claimable balance for a given asset.
+    fn _credit_claimable(
+        env: &Env,
+        recipient: &Address,
+        asset: &Address,
+        amount: i128,
+    ) -> Result<(), Error> {
+        let key = DataKey::ClaimableBalance(recipient.clone(), asset.clone());
+        let current: i128 = env.storage().persistent().get(&key).unwrap_or(0);
+        let updated = current.checked_add(amount).ok_or(Error::Overflow)?;
+        env.storage().persistent().set(&key, &updated);
+        Ok(())
     }
 
     fn _distribute(

--- a/contracts/splitter-v3/src/storage.rs
+++ b/contracts/splitter-v3/src/storage.rs
@@ -25,4 +25,6 @@ pub enum DataKey {
     NextSplitId,
     /// persistent() — scheduled splits keyed by split_id
     ScheduledSplit(u64),
+    /// persistent() — claimable balance keyed by (recipient, asset)
+    ClaimableBalance(Address, Address),
 }

--- a/contracts/splitter-v3/src/test.rs
+++ b/contracts/splitter-v3/src/test.rs
@@ -360,3 +360,106 @@ fn test_cancel_executed_split_rejected() {
     let result = s.contract.cancel_split(&s.owner, &split_id);
     assert_eq!(result, Err(Error::SplitAlreadyExecuted));
 }
+
+// ── Pull-based claimable balance tests ───────────────────────────────────────
+
+#[test]
+fn test_split_pull_credits_claimable_balances() {
+    let s = setup();
+    let alice = Address::generate(&s.env);
+    let bob = Address::generate(&s.env);
+    let token_addr = s.token.address.clone();
+
+    let mut recipients = Vec::new(&s.env);
+    recipients.push_back(Recipient { address: alice.clone(), share_bps: 7_000 });
+    recipients.push_back(Recipient { address: bob.clone(), share_bps: 3_000 });
+
+    // Use 0% fee for clean math.
+    let id = s.contract.propose_change(&s.admin_a, &AdminAction::UpdateFee(0)).unwrap();
+    s.contract.approve_proposal(&s.admin_b, &id).unwrap();
+    s.contract.execute_proposal(&s.admin_c, &id).unwrap();
+
+    s.contract.split_pull(&s.owner, &recipients, &1_000_000).unwrap();
+
+    // Tokens NOT yet in wallets — still in contract.
+    assert_eq!(s.token.balance(&alice), 0);
+    assert_eq!(s.token.balance(&bob), 0);
+
+    // Claimable balances credited correctly.
+    assert_eq!(s.contract.claimable_balance(&alice, &token_addr), 700_000);
+    assert_eq!(s.contract.claimable_balance(&bob, &token_addr), 300_000);
+}
+
+#[test]
+fn test_claim_share_transfers_and_zeroes_balance() {
+    let s = setup();
+    let alice = Address::generate(&s.env);
+    let token_addr = s.token.address.clone();
+
+    let mut recipients = Vec::new(&s.env);
+    recipients.push_back(Recipient { address: alice.clone(), share_bps: 10_000 });
+
+    let id = s.contract.propose_change(&s.admin_a, &AdminAction::UpdateFee(0)).unwrap();
+    s.contract.approve_proposal(&s.admin_b, &id).unwrap();
+    s.contract.execute_proposal(&s.admin_c, &id).unwrap();
+
+    s.contract.split_pull(&s.owner, &recipients, &500_000).unwrap();
+
+    // Alice claims her share.
+    s.contract.claim_share(&alice, &token_addr).unwrap();
+
+    assert_eq!(s.token.balance(&alice), 500_000);
+    // Balance zeroed after claim.
+    assert_eq!(s.contract.claimable_balance(&alice, &token_addr), 0);
+}
+
+#[test]
+fn test_claim_share_nothing_to_claim_rejected() {
+    let s = setup();
+    let alice = Address::generate(&s.env);
+    let token_addr = s.token.address.clone();
+
+    let result = s.contract.claim_share(&alice, &token_addr);
+    assert_eq!(result, Err(Error::NothingToClaim));
+}
+
+#[test]
+fn test_split_pull_fee_deducted_before_crediting() {
+    let s = setup();
+    let alice = Address::generate(&s.env);
+    let token_addr = s.token.address.clone();
+
+    // Default fee is 100 bps (1%).
+    let mut recipients = Vec::new(&s.env);
+    recipients.push_back(Recipient { address: alice.clone(), share_bps: 10_000 });
+
+    s.contract.split_pull(&s.owner, &recipients, &1_000_000).unwrap();
+
+    // Fee = 10_000; distributable = 990_000 → alice gets 990_000.
+    assert_eq!(s.contract.claimable_balance(&alice, &token_addr), 990_000);
+    // Treasury received the fee immediately.
+    assert_eq!(s.token.balance(&s.treasury), 10_000);
+}
+
+#[test]
+fn test_multiple_split_pulls_accumulate_balance() {
+    let s = setup();
+    let alice = Address::generate(&s.env);
+    let token_addr = s.token.address.clone();
+
+    let mut recipients = Vec::new(&s.env);
+    recipients.push_back(Recipient { address: alice.clone(), share_bps: 10_000 });
+
+    let id = s.contract.propose_change(&s.admin_a, &AdminAction::UpdateFee(0)).unwrap();
+    s.contract.approve_proposal(&s.admin_b, &id).unwrap();
+    s.contract.execute_proposal(&s.admin_c, &id).unwrap();
+
+    s.contract.split_pull(&s.owner, &recipients, &200_000).unwrap();
+    s.contract.split_pull(&s.owner, &recipients, &300_000).unwrap();
+
+    // Balances accumulate across multiple pulls before claiming.
+    assert_eq!(s.contract.claimable_balance(&alice, &token_addr), 500_000);
+
+    s.contract.claim_share(&alice, &token_addr).unwrap();
+    assert_eq!(s.token.balance(&alice), 500_000);
+}


### PR DESCRIPTION
closes #636

- Add ClaimableBalance(Address, Address) storage key keyed by (recipient, asset)
- Add NothingToClaim error variant
- Implement split_pull: locks funds in contract and credits recipient balances
- Implement claim_share: recipient-initiated withdrawal with CEI pattern
- Implement claimable_balance: read-only view per recipient/asset
- Add _credit_claimable internal helper with overflow protection
- Fee is deducted and forwarded to treasury immediately on split_pull
- Add 5 tests covering credits, claims, zero-balance guard, fee deduction, and accumulation
