### PR TITLE
feat(#692): add recipient Tax ID metadata field

### DIFF
--- a/frontend/app/api/v3/split/metadata/route.ts
+++ b/frontend/app/api/v3/split/metadata/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export interface RecipientMetadata {
+  address: string;
+  taxId: string;
+}
+
+export interface SplitMetadataPayload {
+  splitId: string;
+  recipients: RecipientMetadata[];
+}
+
+/**
+ * POST /api/v3/split/metadata
+ *
+ * Stores off-chain Tax ID / internal note metadata for split recipients.
+ * This data is never written to the public ledger.
+ */
+export async function POST(req: NextRequest) {
+  const body = (await req.json()) as SplitMetadataPayload;
+
+  if (!body.splitId || !Array.isArray(body.recipients)) {
+    return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+  }
+
+  // TODO: forward to the backend analytics layer:
+  // await fetch(`${process.env.BACKEND_URL}/api/v3/split/metadata`, {
+  //   method: "POST",
+  //   headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+  //   body: JSON.stringify(body),
+  // });
+
+  return NextResponse.json({ ok: true, splitId: body.splitId }, { status: 201 });
+}

--- a/frontend/app/dashboard/create-stream/page.tsx
+++ b/frontend/app/dashboard/create-stream/page.tsx
@@ -17,6 +17,8 @@ interface FormData {
   asset: string;
   recipientAddress: string;
   recipientLabel: string;
+  /** Optional Tax ID / internal note — stored backend-only, never on-chain. */
+  recipientTaxId: string;
   // Stream Splitter (Issue #55)
   splitEnabled: boolean;
   splitAddress: string;
@@ -37,6 +39,7 @@ const INITIAL_FORM: FormData = {
   asset: "",
   recipientAddress: "",
   recipientLabel: "",
+  recipientTaxId: "",
   splitEnabled: false,
   splitAddress: "",
   splitPercent: 10,
@@ -581,6 +584,15 @@ function Step1({
         />
       </Field>
 
+      <Field label="Tax ID / Internal Note (optional)" hint="Stored on our servers only — never written to the public ledger.">
+        <GlassInput
+          value={form.recipientTaxId}
+          onChange={(v) => update({ recipientTaxId: v })}
+          placeholder="e.g. 12-3456789 or contractor ref"
+          prefix="🔒"
+        />
+      </Field>
+
       <div className="h-px bg-white/[0.06]" />
 
       <StreamSplitter form={form} update={update} />
@@ -977,6 +989,19 @@ export default function CreateStreamPage() {
     setSignAttempts(attempt);
     if (attempt === 1) { setRecoveryError("insufficient-xlm"); return; }
     if (attempt === 2) { setRecoveryError("network-congested"); return; }
+
+    // POST off-chain metadata (Tax ID) — only when a taxId was provided
+    if (form.recipientTaxId.trim()) {
+      const splitId = `stream-${Date.now()}`;
+      await fetch("/api/v3/split/metadata", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          splitId,
+          recipients: [{ address: form.recipientAddress, taxId: form.recipientTaxId.trim() }],
+        }),
+      }).catch((err) => console.error("[CreateStream] metadata POST failed", err));
+    }
 
     setSuccess(true);
   };

--- a/frontend/lib/bulk-splitter/types.ts
+++ b/frontend/lib/bulk-splitter/types.ts
@@ -3,9 +3,13 @@
 export interface Voter {
   address: string;
   governance_score: bigint;
+  /** Optional internal Tax ID / note — stored backend-only, never on-chain. */
+  taxId?: string;
 }
 
 export interface Recipient {
   address: string;
   amount: bigint;
+  /** Optional internal Tax ID / note — stored backend-only, never on-chain. */
+  taxId?: string;
 }

--- a/frontend/lib/bulk-splitter/utils.ts
+++ b/frontend/lib/bulk-splitter/utils.ts
@@ -22,24 +22,35 @@ export function parseSnapshotData(rawData: string): Voter[] {
 
   // JSON path
   if (trimmed.startsWith('[') || trimmed.startsWith('{')) {
-    const parsed = JSON.parse(trimmed) as Array<{ address: string; governance_score: number | string }>;
+    const parsed = JSON.parse(trimmed) as Array<{ address: string; governance_score: number | string; tax_id?: string }>;
     const arr = Array.isArray(parsed) ? parsed : [parsed];
     return arr.map((row) => ({
       address: String(row.address).trim(),
       governance_score: BigInt(row.governance_score),
+      ...(row.tax_id ? { taxId: String(row.tax_id).trim() } : {}),
     }));
   }
 
   // CSV path
   const lines = trimmed.split(/\r?\n/).filter(Boolean);
-  // Skip header row
-  const dataLines = lines[0].toLowerCase().includes('address') ? lines.slice(1) : lines;
+  const headerLine = lines[0].toLowerCase();
+  const hasHeader = headerLine.includes('address');
+  const dataLines = hasHeader ? lines.slice(1) : lines;
+  // Detect optional tax_id column position from header
+  const taxIdColIndex = hasHeader
+    ? headerLine.split(',').findIndex((h) => h.trim() === 'tax_id')
+    : -1;
   return dataLines.map((line) => {
-    const [address, score] = line.split(',');
-    return {
+    const cols = line.split(',');
+    const [address, score] = cols;
+    const voter: Voter = {
       address: address.trim(),
       governance_score: BigInt(score.trim()),
     };
+    if (taxIdColIndex >= 0 && cols[taxIdColIndex]?.trim()) {
+      voter.taxId = cols[taxIdColIndex].trim();
+    }
+    return voter;
   });
 }
 
@@ -61,6 +72,7 @@ export function calculateRewards(voters: Voter[], totalReward: bigint): Recipien
   const recipients: Recipient[] = voters.map((v) => ({
     address: v.address,
     amount: (totalReward * v.governance_score) / totalScore,
+    ...(v.taxId ? { taxId: v.taxId } : {}),
   }));
 
   // Compute dust and assign to the highest-scoring voter.


### PR DESCRIPTION
### What
Adds an optional **Tax ID / Internal Note** field per recipient that is stored off-chain and never written to the public ledger.

### Changes

**UI — Manual Input (`create-stream/page.tsx`)**
- New "Tax ID / Internal Note (optional)" input in Step 1, below Recipient Label
- Hint text explicitly states the value is server-only and never on-chain
- On stream creation, POSTs `{ splitId, recipients: [{ address, taxId }] }` to `/api/v3/split/metadata` (skipped when field is empty, non-blocking)

**API Route (`app/api/v3/split/metadata/route.ts`)** *(new)*
- `POST /api/v3/split/metadata` — validates payload and stubs the forward to the backend analytics layer

**CSV Parser (`lib/bulk-splitter/utils.ts`)**
- `parseSnapshotData` now reads an optional `tax_id` column from CSV headers and `tax_id` key from JSON input

**Types (`lib/bulk-splitter/types.ts`)**
- `Voter` and `Recipient` both gain an optional `taxId?: string` field
- `calculateRewards` threads `taxId` from `Voter` through to the output `Recipient`

### Privacy
The `taxId` value is **never included in the on-chain transaction**. It is only sent to `/api/v3/split/metadata` after the ledger submission succeeds.

### Testing
- Existing `utils.test.ts` suite passes unchanged (no breaking changes to CSV/JSON parsing for inputs without `tax_id`)
- Manual: fill the Tax ID field → sign stream → confirm `POST /api/v3/split/metadata` fires in network tab
- Manual: leave Tax ID empty → confirm no POST is made

### Notes for Reviewers
- The API route is a stub — the `TODO` comment marks where the real `fetch` to `BACKEND_URL` should be wired in by the backend team
- `splitId` is currently derived from `Date.now()`; should be replaced with the real on-chain stream ID once the contract client returns it


close #692 
