### PR TITLE
feat: add getExplorerLink utility and deep-links for disbursement rec…

### DIFF
--- a/frontend/components/dashboard/BulkDispatchPanel.tsx
+++ b/frontend/components/dashboard/BulkDispatchPanel.tsx
@@ -3,8 +3,10 @@
 // components/dashboard/BulkDispatchPanel.tsx
 // Issue #695 — Bulk-Retry for Failed Batch Transactions
 
+import { useState } from "react";
 import type { BatchState } from "@/lib/bulk-splitter/use-bulk-splitter";
 import type { Recipient } from "@/lib/bulk-splitter/types";
+import { getExplorerLink } from "@/lib/explorer";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 const STATUS_META: Record<
@@ -24,9 +26,12 @@ function shortenAddr(addr: string) {
 // ─── BatchRow ─────────────────────────────────────────────────────────────────
 function BatchRow({ index, state }: { index: number; state: BatchState }) {
   const meta = STATUS_META[state.status];
+  const [expanded, setExpanded] = useState(false);
+  const canExpand = state.status === "success" && state.recipients.length > 0 && !!state.txHash;
+
   return (
     <div
-      className="flex items-center gap-3 rounded-xl border px-4 py-3 transition-all duration-300"
+      className="rounded-xl border transition-all duration-300 overflow-hidden"
       style={{
         borderColor:
           state.status === "error"
@@ -42,51 +47,100 @@ function BatchRow({ index, state }: { index: number; state: BatchState }) {
             : "rgba(255,255,255,0.02)",
       }}
     >
-      {/* Status icon */}
-      <span
-        className="text-base w-5 text-center flex-shrink-0 tabular-nums"
-        style={{
-          color: meta.color,
-          animation: state.status === "pending" ? "spin 1s linear infinite" : "none",
-        }}
-      >
-        {state.status === "pending" ? (
-          <svg className="inline animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
-            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z" />
-          </svg>
-        ) : (
-          meta.icon
-        )}
-      </span>
+      {/* Main row */}
+      <div className="flex items-center gap-3 px-4 py-3">
+        {/* Status icon */}
+        <span
+          className="text-base w-5 text-center flex-shrink-0 tabular-nums"
+          style={{ color: meta.color }}
+        >
+          {state.status === "pending" ? (
+            <svg className="inline animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z" />
+            </svg>
+          ) : (
+            meta.icon
+          )}
+        </span>
 
-      {/* Batch info */}
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2">
-          <span className="font-body text-xs font-bold text-white/70">
-            Batch {index + 1}
-          </span>
-          <span className="font-body text-[10px] text-white/30">
-            {state.recipients.length} recipient{state.recipients.length !== 1 ? "s" : ""}
-          </span>
+        {/* Batch info */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="font-body text-xs font-bold text-white/70">
+              Batch {index + 1}
+            </span>
+            <span className="font-body text-[10px] text-white/30">
+              {state.recipients.length} recipient{state.recipients.length !== 1 ? "s" : ""}
+            </span>
+          </div>
+          {state.status === "error" && state.error && (
+            <p className="font-body text-[10px] text-red-400/80 mt-0.5 truncate">{state.error}</p>
+          )}
+          {state.status === "success" && state.txHash && (
+            <a
+              href={getExplorerLink(state.txHash)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-body text-[10px] text-emerald-400/60 mt-0.5 font-mono truncate hover:text-emerald-400 transition-colors inline-flex items-center gap-1"
+              title="View transaction on Stellar.Expert"
+            >
+              {shortenAddr(state.txHash)}
+              <svg className="h-2.5 w-2.5 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                <polyline points="15 3 21 3 21 9" />
+                <line x1="10" y1="14" x2="21" y2="3" />
+              </svg>
+            </a>
+          )}
         </div>
-        {state.status === "error" && state.error && (
-          <p className="font-body text-[10px] text-red-400/80 mt-0.5 truncate">{state.error}</p>
-        )}
-        {state.status === "success" && state.txHash && (
-          <p className="font-body text-[10px] text-emerald-400/60 mt-0.5 font-mono truncate">
-            {shortenAddr(state.txHash)}
-          </p>
-        )}
+
+        {/* Status badge + expand toggle */}
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <span
+            className="font-body text-[10px] font-bold tracking-wider uppercase"
+            style={{ color: meta.color }}
+          >
+            {meta.label}
+          </span>
+          {canExpand && (
+            <button
+              onClick={() => setExpanded((v) => !v)}
+              className="text-white/30 hover:text-white/60 transition-colors"
+              title={expanded ? "Hide recipients" : "Show recipients"}
+            >
+              <svg className={`h-3.5 w-3.5 transition-transform duration-200 ${expanded ? "rotate-180" : ""}`} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+                <polyline points="6 9 12 15 18 9" />
+              </svg>
+            </button>
+          )}
+        </div>
       </div>
 
-      {/* Status badge */}
-      <span
-        className="font-body text-[10px] font-bold tracking-wider uppercase flex-shrink-0"
-        style={{ color: meta.color }}
-      >
-        {meta.label}
-      </span>
+      {/* Per-recipient deep-links (expanded) */}
+      {expanded && canExpand && state.txHash && (
+        <div className="border-t border-white/[0.06] px-4 py-2 space-y-1 max-h-48 overflow-y-auto">
+          {state.recipients.map((r) => (
+            <a
+              key={r.address}
+              href={getExplorerLink(state.txHash!, r.address)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center justify-between gap-2 rounded-lg px-2 py-1.5 hover:bg-white/[0.04] transition-colors group"
+              title={`View ${r.address} on Stellar.Expert`}
+            >
+              <span className="font-mono text-[10px] text-white/50 group-hover:text-white/80 transition-colors truncate">
+                {shortenAddr(r.address)}
+              </span>
+              <svg className="h-3 w-3 text-white/20 group-hover:text-emerald-400/70 flex-shrink-0 transition-colors" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                <polyline points="15 3 21 3 21 9" />
+                <line x1="10" y1="14" x2="21" y2="3" />
+              </svg>
+            </a>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/components/dashboard/TransactionHistorySidebar.tsx
+++ b/frontend/components/dashboard/TransactionHistorySidebar.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, useCallback } from "react";
 import { Dialog, DialogPanel, DialogTitle, Transition, TransitionChild } from "@headlessui/react";
+import { getExplorerLink } from "@/lib/explorer";
 import { 
   X, 
   History, 
@@ -590,10 +591,11 @@ export function TransactionHistorySidebar({
                                   <div>
                                     <p className="text-xs text-gray-500 mb-0.5">From</p>
                                     <a
-                                      href={getStellarExpertAccountUrl(event.sender)}
+                                      href={getExplorerLink(event.hash, event.sender)}
                                       target="_blank"
                                       rel="noopener noreferrer"
                                       className="text-sm text-cyan-400 hover:text-cyan-300 font-mono truncate block"
+                                      title={`View ${event.sender} on Stellar.Expert`}
                                     >
                                       {event.sender}
                                     </a>
@@ -602,10 +604,11 @@ export function TransactionHistorySidebar({
                                     <div>
                                       <p className="text-xs text-gray-500 mb-0.5">To</p>
                                       <a
-                                        href={getStellarExpertAccountUrl(event.receiver)}
+                                        href={getExplorerLink(event.hash, event.receiver)}
                                         target="_blank"
                                         rel="noopener noreferrer"
                                         className="text-sm text-cyan-400 hover:text-cyan-300 font-mono truncate block"
+                                        title={`View ${event.receiver} on Stellar.Expert`}
                                       >
                                         {event.receiver}
                                       </a>
@@ -633,7 +636,7 @@ export function TransactionHistorySidebar({
                                   </div>
                                   
                                   <a
-                                    href={getStellarExpertUrl(event.hash)}
+                                    href={getExplorerLink(event.hash)}
                                     target="_blank"
                                     rel="noopener noreferrer"
                                     className="flex items-center gap-1 text-xs text-cyan-400 hover:text-cyan-300 transition-colors"

--- a/frontend/lib/explorer.ts
+++ b/frontend/lib/explorer.ts
@@ -1,0 +1,31 @@
+// lib/explorer.ts
+// Utility for generating deep-links to Stellar.Expert for transactions and accounts.
+
+export type StellarNetwork = "public" | "testnet";
+
+const BASE: Record<StellarNetwork, string> = {
+  public:  "https://stellar.expert/explorer/public",
+  testnet: "https://testnet.stellar.expert/explorer",
+};
+
+/**
+ * Returns a deep-link to Stellar.Expert for a specific transaction.
+ * If an `address` is provided the link targets the account page instead,
+ * which lets users see that recipient's full on-chain history.
+ *
+ * @param txHash  - The transaction hash (required).
+ * @param address - Optional recipient address. When supplied the link points
+ *                  to the account explorer page for that address.
+ * @param network - "public" (default) or "testnet".
+ */
+export function getExplorerLink(
+  txHash: string,
+  address?: string,
+  network: StellarNetwork = "public",
+): string {
+  const base = BASE[network];
+  if (address) {
+    return `${base}/account/${address}`;
+  }
+  return `${base}/tx/${txHash}`;
+}


### PR DESCRIPTION
What Adds a getExplorerLink(txHash, address?, network?) utility and wires it into the disbursement history views so every recipient in a split payment is a clickable link to Stellar.Expert.

Changes

explorer.ts
 — new shared utility

getExplorerLink(txHash, address?, network?) returns a tx deep-link by default, or an account page URL when an address is provided
supports both public and testnet networks
BulkDispatchPanel.tsx

successful batch tx hashes are now clickable links to the transaction on Stellar.Expert
added a chevron toggle per batch that expands to list every individual recipient, each linking to their own account page
TransactionHistorySidebar.tsx

"From" and "To" address fields now use getExplorerLink with the tx hash, routing clicks to the recipient's account view
"View on StellarExpert" tx link consolidated to use the shared utility
How to test

Dispatch a bulk split with multiple recipients
Once a batch succeeds, click the tx hash — should open the transaction on Stellar.Expert
Expand the batch row — each recipient address should link to their account page
Open Transaction History sidebar — clicking any sender/receiver address should deep-link to their account

Closes #685 