### PR TITLE
feat: burn rate forecast  recharts area chart with liquidity warning …

### DIFF
--- a/frontend/app/api/v3/schedules/route.ts
+++ b/frontend/app/api/v3/schedules/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+
+export interface ScheduledSplit {
+  id: string;
+  title: string;
+  token: string;
+  /** Total amount per occurrence in token units */
+  amount: number;
+  /** ISO date of next execution */
+  nextRunAt: string;
+  /** Recurrence interval in days. null = one-shot */
+  intervalDays: number | null;
+  /** How many future occurrences to project (for recurring). Default 3. */
+  occurrences?: number;
+}
+
+// Mock data — replace with a real backend fetch when ready
+const MOCK_SCHEDULES: ScheduledSplit[] = [
+  {
+    id: "sched-001",
+    title: "Monthly Contributor Payroll",
+    token: "USDC",
+    amount: 18_500,
+    nextRunAt: new Date(Date.now() + 1000 * 60 * 60 * 24 * 5).toISOString(),
+    intervalDays: 30,
+    occurrences: 3,
+  },
+  {
+    id: "sched-002",
+    title: "Bi-weekly DAO Rewards",
+    token: "XLM",
+    amount: 8_000,
+    nextRunAt: new Date(Date.now() + 1000 * 60 * 60 * 24 * 3).toISOString(),
+    intervalDays: 14,
+    occurrences: 6,
+  },
+  {
+    id: "sched-003",
+    title: "Q2 Contractor Bonus",
+    token: "USDC",
+    amount: 12_000,
+    nextRunAt: new Date(Date.now() + 1000 * 60 * 60 * 24 * 22).toISOString(),
+    intervalDays: null,
+  },
+];
+
+export async function GET() {
+  // TODO: proxy to backend: GET /api/v3/schedules
+  return NextResponse.json(MOCK_SCHEDULES);
+}

--- a/frontend/app/dashboard/statistics/page.tsx
+++ b/frontend/app/dashboard/statistics/page.tsx
@@ -1,5 +1,6 @@
 import { ProtocolPulseCard } from "@/components/dashboard/ProtocolPulseCard";
 import { TreasuryHealthDashboard } from "@/components/dashboard/TreasuryHealthDashboard";
+import { BurnRateForecast } from "@/components/dashboard/BurnRateForecast";
 
 export default function StatisticsPage() {
   return (
@@ -17,6 +18,12 @@ export default function StatisticsPage() {
       </section>
 
       <ProtocolPulseCard />
+
+      <section className="rounded-3xl border border-white/10 bg-white/[0.04] p-6 backdrop-blur-xl md:p-8">
+        <p className="font-body text-xs tracking-[0.12em] text-white/60 uppercase mb-1">Forecasting</p>
+        <h2 className="font-heading text-2xl md:text-3xl mb-5">Asset Requirements</h2>
+        <BurnRateForecast walletBalance={45_000} />
+      </section>
 
       <section className="rounded-3xl border border-white/10 bg-white/[0.04] p-6 backdrop-blur-xl md:p-8">
         <p className="font-body text-xs tracking-[0.12em] text-white/60 uppercase mb-1">Admin</p>

--- a/frontend/components/dashboard/BurnRateForecast.tsx
+++ b/frontend/components/dashboard/BurnRateForecast.tsx
@@ -1,0 +1,375 @@
+"use client";
+
+// components/dashboard/BurnRateForecast.tsx
+// Visual forecasting tool — cumulative burn rate area chart with
+// a liquidity warning reference line.
+
+import { useState } from "react";
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ReferenceLine,
+  ResponsiveContainer,
+  type TooltipProps,
+} from "recharts";
+import { useBurnRateForecast, type ForecastWindow } from "@/lib/hooks/use-burn-rate-forecast";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function fmtUSD(n: number): string {
+  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `$${(n / 1_000).toFixed(1)}K`;
+  return `$${n.toFixed(0)}`;
+}
+
+// ─── Custom Tooltip ───────────────────────────────────────────────────────────
+
+function BurnTooltip({ active, payload, label }: TooltipProps<number, string>) {
+  if (!active || !payload?.length) return null;
+  const cumulative = payload.find((p) => p.dataKey === "cumulative")?.value ?? 0;
+  const daily = payload.find((p) => p.dataKey === "daily")?.value ?? 0;
+  return (
+    <div
+      style={{
+        background: "rgba(6,6,15,0.92)",
+        border: "1px solid rgba(0,245,255,0.2)",
+        borderRadius: 12,
+        padding: "10px 14px",
+        backdropFilter: "blur(12px)",
+        minWidth: 160,
+      }}
+    >
+      <p style={{ fontSize: 10, letterSpacing: 2, color: "rgba(255,255,255,0.35)", textTransform: "uppercase", marginBottom: 6 }}>
+        {label}
+      </p>
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 16 }}>
+          <span style={{ fontSize: 11, color: "rgba(255,255,255,0.45)" }}>Cumulative</span>
+          <span style={{ fontSize: 12, fontWeight: 700, color: "#00f5ff", fontVariantNumeric: "tabular-nums" }}>
+            {fmtUSD(Number(cumulative))}
+          </span>
+        </div>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 16 }}>
+          <span style={{ fontSize: 11, color: "rgba(255,255,255,0.45)" }}>This period</span>
+          <span style={{ fontSize: 12, fontWeight: 700, color: "#a78bfa", fontVariantNumeric: "tabular-nums" }}>
+            {fmtUSD(Number(daily))}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Window Pill ──────────────────────────────────────────────────────────────
+
+function WindowPill({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        padding: "4px 14px",
+        borderRadius: 99,
+        border: `1px solid ${active ? "rgba(0,245,255,0.4)" : "rgba(255,255,255,0.08)"}`,
+        background: active ? "rgba(0,245,255,0.08)" : "rgba(255,255,255,0.02)",
+        color: active ? "#00f5ff" : "rgba(255,255,255,0.35)",
+        fontSize: 11,
+        fontWeight: active ? 700 : 400,
+        cursor: "pointer",
+        transition: "all 0.15s",
+        letterSpacing: 0.5,
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+
+// ─── Main Component ───────────────────────────────────────────────────────────
+
+interface BurnRateForecastProps {
+  /** Wallet balance in USD-equivalent for the liquidity warning line */
+  walletBalance?: number;
+}
+
+export function BurnRateForecast({ walletBalance = 45_000 }: BurnRateForecastProps) {
+  const [window, setWindow] = useState<ForecastWindow>(30);
+  const { series, loading, error, liquidityWarningDay } = useBurnRateForecast(
+    walletBalance,
+    90,
+  );
+
+  // Slice series to the selected window
+  const maxDay = window;
+  const visible = series.filter((p) => p.day <= maxDay);
+  const finalCumulative = visible[visible.length - 1]?.cumulative ?? 0;
+  const exceedsBalance = finalCumulative > walletBalance;
+  const warningInWindow = liquidityWarningDay !== -1 &&
+    series[liquidityWarningDay]?.day <= maxDay;
+
+  return (
+    <div
+      style={{
+        background: "rgba(255,255,255,0.025)",
+        border: "1px solid rgba(255,255,255,0.07)",
+        borderRadius: 20,
+        overflow: "hidden",
+        backdropFilter: "blur(20px)",
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          padding: "18px 24px 14px",
+          borderBottom: "1px solid rgba(255,255,255,0.05)",
+          display: "flex",
+          flexWrap: "wrap",
+          alignItems: "flex-start",
+          justifyContent: "space-between",
+          gap: 12,
+        }}
+      >
+        <div>
+          <p style={{ fontSize: 10, letterSpacing: 3, color: "rgba(255,255,255,0.3)", textTransform: "uppercase", marginBottom: 4 }}>
+            Forecasting
+          </p>
+          <h2
+            style={{
+              fontSize: 20,
+              fontWeight: 800,
+              color: "#fff",
+              letterSpacing: -0.5,
+              lineHeight: 1,
+            }}
+          >
+            Burn Rate Forecast
+          </h2>
+          <p style={{ fontSize: 11, color: "rgba(255,255,255,0.3)", marginTop: 4 }}>
+            Cumulative asset requirements from scheduled splits
+          </p>
+        </div>
+
+        {/* Window selector */}
+        <div style={{ display: "flex", gap: 6 }}>
+          {([30, 60, 90] as ForecastWindow[]).map((w) => (
+            <WindowPill
+              key={w}
+              label={`${w}d`}
+              active={window === w}
+              onClick={() => setWindow(w)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Summary chips */}
+      <div
+        style={{
+          display: "flex",
+          gap: 10,
+          padding: "12px 24px",
+          borderBottom: "1px solid rgba(255,255,255,0.04)",
+          flexWrap: "wrap",
+        }}
+      >
+        {[
+          {
+            label: `${window}d Burn`,
+            value: fmtUSD(finalCumulative),
+            color: exceedsBalance ? "#f87171" : "#00f5ff",
+          },
+          {
+            label: "Wallet Balance",
+            value: fmtUSD(walletBalance),
+            color: "#34d399",
+          },
+          {
+            label: "Remaining",
+            value: fmtUSD(Math.max(0, walletBalance - finalCumulative)),
+            color: exceedsBalance ? "#f87171" : "#a78bfa",
+          },
+        ].map(({ label, value, color }) => (
+          <div
+            key={label}
+            style={{
+              padding: "6px 14px",
+              borderRadius: 10,
+              border: "1px solid rgba(255,255,255,0.06)",
+              background: "rgba(255,255,255,0.02)",
+            }}
+          >
+            <span style={{ fontSize: 9, letterSpacing: 2, color: "rgba(255,255,255,0.3)", textTransform: "uppercase" }}>
+              {label}{" "}
+            </span>
+            <span style={{ fontSize: 14, fontWeight: 700, color }}>{value}</span>
+          </div>
+        ))}
+
+        {/* Liquidity warning badge */}
+        {warningInWindow && (
+          <div
+            style={{
+              padding: "6px 14px",
+              borderRadius: 10,
+              border: "1px solid rgba(248,113,113,0.35)",
+              background: "rgba(248,113,113,0.07)",
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+            }}
+          >
+            <span style={{ fontSize: 12 }}>⚠</span>
+            <span style={{ fontSize: 11, color: "#f87171", fontWeight: 600 }}>
+              Liquidity warning at day {series[liquidityWarningDay]?.day}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Chart */}
+      <div style={{ padding: "20px 8px 16px" }}>
+        {loading ? (
+          <div
+            style={{
+              height: 280,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              color: "rgba(255,255,255,0.2)",
+              fontSize: 12,
+              gap: 10,
+            }}
+          >
+            <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z" />
+            </svg>
+            Loading forecast…
+          </div>
+        ) : error ? (
+          <div style={{ height: 280, display: "flex", alignItems: "center", justifyContent: "center" }}>
+            <p style={{ fontSize: 12, color: "#f87171" }}>{error}</p>
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height={280}>
+            <AreaChart data={visible} margin={{ top: 10, right: 24, left: 0, bottom: 0 }}>
+              <defs>
+                <linearGradient id="burnGradient" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor="#00f5ff" stopOpacity={0.25} />
+                  <stop offset="95%" stopColor="#00f5ff" stopOpacity={0.02} />
+                </linearGradient>
+                <linearGradient id="dailyGradient" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor="#a78bfa" stopOpacity={0.2} />
+                  <stop offset="95%" stopColor="#a78bfa" stopOpacity={0.01} />
+                </linearGradient>
+              </defs>
+
+              <CartesianGrid
+                strokeDasharray="3 3"
+                stroke="rgba(255,255,255,0.04)"
+                vertical={false}
+              />
+
+              <XAxis
+                dataKey="label"
+                tick={{ fill: "rgba(255,255,255,0.25)", fontSize: 10 }}
+                axisLine={false}
+                tickLine={false}
+                interval="preserveStartEnd"
+              />
+
+              <YAxis
+                tickFormatter={fmtUSD}
+                tick={{ fill: "rgba(255,255,255,0.25)", fontSize: 10 }}
+                axisLine={false}
+                tickLine={false}
+                width={56}
+              />
+
+              <Tooltip content={<BurnTooltip />} />
+
+              {/* Liquidity warning reference line */}
+              <ReferenceLine
+                y={walletBalance}
+                stroke="#f87171"
+                strokeDasharray="6 3"
+                strokeWidth={1.5}
+                label={{
+                  value: "Liquidity Limit",
+                  position: "insideTopRight",
+                  fill: "#f87171",
+                  fontSize: 10,
+                  fontWeight: 600,
+                }}
+              />
+
+              {/* Daily spend area (background) */}
+              <Area
+                type="monotone"
+                dataKey="daily"
+                stroke="#a78bfa"
+                strokeWidth={1}
+                fill="url(#dailyGradient)"
+                dot={false}
+                activeDot={false}
+              />
+
+              {/* Cumulative burn area (foreground) */}
+              <Area
+                type="monotone"
+                dataKey="cumulative"
+                stroke="#00f5ff"
+                strokeWidth={2}
+                fill="url(#burnGradient)"
+                dot={false}
+                activeDot={{ r: 4, fill: "#00f5ff", stroke: "rgba(0,245,255,0.3)", strokeWidth: 6 }}
+                style={{ filter: "drop-shadow(0 0 6px rgba(0,245,255,0.3))" }}
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+
+      {/* Legend */}
+      <div
+        style={{
+          padding: "0 24px 16px",
+          display: "flex",
+          gap: 16,
+          flexWrap: "wrap",
+        }}
+      >
+        {[
+          { color: "#00f5ff", label: "Cumulative burn" },
+          { color: "#a78bfa", label: "Period spend" },
+          { color: "#f87171", label: "Liquidity limit", dashed: true },
+        ].map(({ color, label, dashed }) => (
+          <div key={label} style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <svg width={20} height={10}>
+              <line
+                x1="0" y1="5" x2="20" y2="5"
+                stroke={color}
+                strokeWidth={dashed ? 1.5 : 2}
+                strokeDasharray={dashed ? "4 2" : undefined}
+              />
+            </svg>
+            <span style={{ fontSize: 10, color: "rgba(255,255,255,0.35)", letterSpacing: 0.5 }}>
+              {label}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/lib/hooks/use-burn-rate-forecast.ts
+++ b/frontend/lib/hooks/use-burn-rate-forecast.ts
@@ -1,0 +1,130 @@
+"use client";
+
+// lib/hooks/use-burn-rate-forecast.ts
+// Fetches upcoming scheduled splits and builds a cumulative burn-rate
+// time series for 30, 60, and 90-day windows.
+
+import { useEffect, useState } from "react";
+import type { ScheduledSplit } from "@/app/api/v3/schedules/route";
+
+export interface BurnDataPoint {
+  /** Days from today (0 = today) */
+  day: number;
+  /** Human-readable label e.g. "Mar 27" */
+  label: string;
+  /** Cumulative spend in USD-equivalent by this day */
+  cumulative: number;
+  /** Single-day spend on this day */
+  daily: number;
+}
+
+export type ForecastWindow = 30 | 60 | 90;
+
+export interface UseBurnRateForecastReturn {
+  /** Full 90-day series — slice to 30/60 as needed */
+  series: BurnDataPoint[];
+  loading: boolean;
+  error: string | null;
+  /** Wallet balance in USD-equivalent for the liquidity warning line */
+  walletBalance: number;
+  /** Day index where cumulative spend first exceeds walletBalance (-1 = never) */
+  liquidityWarningDay: number;
+}
+
+// Approximate USD rates for mock purposes — swap for real price feed
+const USD_RATES: Record<string, number> = {
+  USDC: 1,
+  USDT: 1,
+  XLM:  0.11,
+  AQUA: 0.003,
+  STRM: 0.05,
+};
+
+function toUSD(amount: number, token: string): number {
+  return amount * (USD_RATES[token] ?? 1);
+}
+
+/** Expand a schedule into individual payment dates within [0, maxDays] */
+function expandSchedule(s: ScheduledSplit, today: Date, maxDays: number): number[] {
+  const hits: number[] = [];
+  const first = Math.round(
+    (new Date(s.nextRunAt).getTime() - today.getTime()) / (1000 * 60 * 60 * 24),
+  );
+  if (first < 0 || first > maxDays) return hits;
+  hits.push(first);
+
+  if (s.intervalDays) {
+    const maxOccurrences = s.occurrences ?? 12;
+    for (let i = 1; i < maxOccurrences; i++) {
+      const day = first + s.intervalDays * i;
+      if (day > maxDays) break;
+      hits.push(day);
+    }
+  }
+  return hits;
+}
+
+export function useBurnRateForecast(
+  walletBalance = 45_000,
+  maxDays: ForecastWindow = 90,
+): UseBurnRateForecastReturn {
+  const [series, setSeries] = useState<BurnDataPoint[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    fetch("/api/v3/schedules")
+      .then((r) => {
+        if (!r.ok) throw new Error("Failed to fetch schedules");
+        return r.json() as Promise<ScheduledSplit[]>;
+      })
+      .then((schedules) => {
+        const today = new Date();
+        today.setHours(0, 0, 0, 0);
+
+        // Build a daily spend map
+        const dailySpend = new Array<number>(maxDays + 1).fill(0);
+        for (const s of schedules) {
+          const usdAmount = toUSD(s.amount, s.token);
+          for (const day of expandSchedule(s, today, maxDays)) {
+            dailySpend[day] += usdAmount;
+          }
+        }
+
+        // Build cumulative series — one point every 3 days for readability
+        const points: BurnDataPoint[] = [];
+        let cumulative = 0;
+        const STEP = 3;
+        for (let d = 0; d <= maxDays; d += STEP) {
+          // Sum daily spend in this step window
+          let windowSpend = 0;
+          for (let i = d; i < Math.min(d + STEP, maxDays + 1); i++) {
+            windowSpend += dailySpend[i];
+          }
+          cumulative += windowSpend;
+          const date = new Date(today);
+          date.setDate(today.getDate() + d);
+          points.push({
+            day: d,
+            label: date.toLocaleDateString("en-US", { month: "short", day: "numeric" }),
+            cumulative: Math.round(cumulative),
+            daily: Math.round(windowSpend),
+          });
+        }
+
+        setSeries(points);
+        setLoading(false);
+      })
+      .catch((e) => {
+        setError(e instanceof Error ? e.message : "Unknown error");
+        setLoading(false);
+      });
+  }, [maxDays, walletBalance]);
+
+  // Find first day cumulative exceeds wallet balance
+  const liquidityWarningDay =
+    series.findIndex((p: BurnDataPoint) => p.cumulative > walletBalance);
+
+  return { series, loading, error, walletBalance, liquidityWarningDay };
+}


### PR DESCRIPTION
What Adds a visual forecasting tool to the Statistics page that plots cumulative asset requirements from scheduled and recurring splits over 30, 60, and 90-day windows. A dashed liquidity warning line fires when projected burn is on track to exceed the current wallet balance.

Changes

route.ts
 — new API route

Returns upcoming ScheduledSplit[] with amount, token, next run date, and recurrence interval
Mock data covers one-shot and recurring schedules — swap the handler body for a real backend proxy when ready
use-burn-rate-forecast.ts
 — new hook

Fetches schedules, expands recurring splits across the full 90-day window, converts all tokens to USD-equivalent, and builds a cumulative burn series (one data point per 3 days)
Returns series, liquidityWarningDay (first day cumulative exceeds wallet balance), loading, and error
USD rate map is a stub — replace with a real price feed when available
BurnRateForecast.tsx
 — new component

Recharts AreaChart with two layered areas: cumulative burn (cyan) and per-period spend (violet)
Dashed ReferenceLine at wallet balance labeled "Liquidity Limit"
30 / 60 / 90d window toggle pills that slice the series without re-fetching
Summary chips: window burn total, wallet balance, remaining headroom
Liquidity warning badge appears when projected burn crosses the limit within the selected window
Custom tooltip showing cumulative and period spend per data point
page.tsx

Added "Asset Requirements" forecasting section between ProtocolPulseCard and TreasuryHealthDashboard
How to test

Navigate to Dashboard → Statistics
The "Asset Requirements" section should render the area chart with mock schedule data
Toggle between 30d / 60d / 90d — chart and summary chips should update
Lower walletBalance prop below the projected burn to trigger the liquidity warning badge and reference line crossing

Closes #688