### PR TITLE
feat(contracts): add reclaim_dust for fee_collector treasury sweep

### DIFF
--- a/contracts/Contract-V2/src/contracterror.rs
+++ b/contracts/Contract-V2/src/contracterror.rs
@@ -38,6 +38,8 @@ pub enum Error {
     AssetNotWhitelisted = 29,
     /// Asset contract does not implement required token interface (balance/transfer)
     AssetInterfaceNotSupported = 67,
+    /// No fee collector address configured; admin must call set_fee_collector first
+    NoFeeCollector = 68,
     /// penalty_bps exceeds 10000 (100%)
     InvalidPenalty = 30,
     /// migrate_stream is blocked; standard V2 streams remain active.

--- a/contracts/Contract-V2/src/lib.rs
+++ b/contracts/Contract-V2/src/lib.rs
@@ -4167,6 +4167,32 @@ impl Contract {
         storage::get_fee_collector(&env)
     }
 
+    /// Sweep rounding dust accumulated in the contract into the fee collector (treasury).
+    ///
+    /// Transfers the entire on-contract balance of `asset` that exceeds the sum of
+    /// all pending protocol fees for that asset — i.e. the "dust" left behind by
+    /// fixed-point rounding — to the configured `fee_collector` address.
+    ///
+    /// Auth: only the `fee_collector` itself may call this function.
+    pub fn reclaim_dust(env: Env, asset: Address) -> Result<i128, Error> {
+        let fee_collector = storage::get_fee_collector(&env).ok_or(Error::NoFeeCollector)?;
+        fee_collector.require_auth();
+
+        let token_client = soroban_sdk::token::TokenClient::new(&env, &asset);
+        let contract_balance = token_client.balance(&env.current_contract_address());
+
+        let pending_fees = storage::get_pending_fees(&env, &fee_collector, &asset);
+        let dust = contract_balance - pending_fees;
+
+        if dust <= 0 {
+            return Err(Error::NothingToWithdraw);
+        }
+
+        token_client.transfer(&env.current_contract_address(), &fee_collector, &dust);
+
+        Ok(dust)
+    }
+
     /// Set the token used to pay disbursement fees. Admin-only.
     pub fn set_fee_token(env: Env, token: Address) -> Result<(), Error> {
         storage::try_get_admin(&env)?.require_auth();


### PR DESCRIPTION
## Summary
Implements `reclaim_dust(asset: Address)` on Contract-V2 as described in the issue.

## Changes
- **`contracterror.rs`**: Added `NoFeeCollector = 68` error variant
- **`lib.rs`**: Added `reclaim_dust` function

## Behaviour
- Calculates dust as `contract_balance - pending_fees` for the given asset
- Transfers the dust to the `fee_collector` address
- Returns `NoFeeCollector` if `set_fee_collector` was never called
- Returns `NothingToWithdraw` if dust <= 0

## Auth
Only the configured `fee_collector` can invoke this function (`fee_collector.require_auth()`).

closes #839 