### PR TITLE
feat(contract): emergency recovery multi-sig split

### DIFF
--- a/contracts/Contract-V2/src/contracterror.rs
+++ b/contracts/Contract-V2/src/contracterror.rs
@@ -116,4 +116,19 @@ pub enum Error {
     SimulationStorageLimitExceeded = 65,
     /// Simulation: Invalid parameters for stream creation
     SimulationInvalidParams = 66,
+    // -- Emergency Recovery Multi-Sig (Issue: Security Critical) --------
+    /// Recovery council has not been configured
+    RecoveryCouncilNotSet = 69,
+    /// Signer is not a member of the recovery council
+    NotCouncilMember = 70,
+    /// Recovery has already been initiated; cannot re-initiate
+    RecoveryAlreadyInitiated = 71,
+    /// Recovery grace period (7 days) has not elapsed yet
+    RecoveryGracePeriodActive = 72,
+    /// No active recovery has been initiated
+    RecoveryNotInitiated = 73,
+    /// Signer has already approved this recovery
+    RecoveryAlreadyApproved = 74,
+    /// Not enough council signatures to execute recovery
+    RecoveryInsufficientSignatures = 75,
 }

--- a/contracts/Contract-V2/src/lib.rs
+++ b/contracts/Contract-V2/src/lib.rs
@@ -4266,6 +4266,144 @@ impl Contract {
     pub fn get_gas_buffer_balance(env: Env, user: Address) -> i128 {
         storage::get_gas_buffer(&env, &user)
     }
+
+    // ----------------------------------------------------------------
+    // Emergency Recovery Multi-Sig (Issue: Security Critical)
+    // ----------------------------------------------------------------
+
+    /// Configure the recovery council and required signature threshold.
+    ///
+    /// Can only be called by the current admin. The council addresses are
+    /// stored on-chain and cannot be changed without another admin call,
+    /// preventing a compromised admin from silently swapping council members
+    /// after the fact.
+    ///
+    /// # Parameters
+    /// - `admin`: Current contract admin (must sign).
+    /// - `council`: Vec of council member addresses (hardcoded or set here at init).
+    /// - `threshold`: Minimum signatures required to execute recovery.
+    pub fn set_recovery_council(
+        env: Env,
+        admin: Address,
+        council: Vec<Address>,
+        threshold: u32,
+    ) -> Result<(), Error> {
+        storage::try_get_admin(&env)?.require_auth();
+
+        if threshold == 0 || threshold > council.len() {
+            return Err(Error::InvalidThreshold);
+        }
+
+        storage::set_recovery_council(&env, &council, threshold);
+        Ok(())
+    }
+
+    /// Return the configured recovery council.
+    pub fn get_recovery_council(env: Env) -> Option<Vec<Address>> {
+        storage::get_recovery_council(&env)
+    }
+
+    /// Initiate the 7-day recovery grace period.
+    ///
+    /// Any single council member can call this to start the clock. Once
+    /// initiated, the council has 7 days to gather enough signatures before
+    /// calling `recovery_split`.
+    ///
+    /// # Parameters
+    /// - `initiator`: A council member address (must sign).
+    pub fn init_recovery(env: Env, initiator: Address) -> Result<(), Error> {
+        let council = storage::get_recovery_council(&env)
+            .ok_or(Error::RecoveryCouncilNotSet)?;
+
+        if !council.contains(&initiator) {
+            return Err(Error::NotCouncilMember);
+        }
+        initiator.require_auth();
+
+        if storage::get_recovery_initiated_at(&env).is_some() {
+            return Err(Error::RecoveryAlreadyInitiated);
+        }
+
+        let now = env.ledger().timestamp();
+        storage::set_recovery_initiated_at(&env, now);
+
+        env.events().publish(
+            (soroban_sdk::symbol_short!("rec_init"), initiator),
+            now,
+        );
+
+        Ok(())
+    }
+
+    /// Execute an emergency recovery split after the 7-day grace period.
+    ///
+    /// Requires at least `recovery_threshold` council signatures. Transfers
+    /// the full contract token balance to `destination`.
+    ///
+    /// # Parameters
+    /// - `council_signatures`: Vec of council member addresses signing this call.
+    /// - `token`: The token to recover.
+    /// - `destination`: Address that receives the recovered funds.
+    pub fn recovery_split(
+        env: Env,
+        council_signatures: Vec<Address>,
+        token: Address,
+        destination: Address,
+    ) -> Result<i128, Error> {
+        let council = storage::get_recovery_council(&env)
+            .ok_or(Error::RecoveryCouncilNotSet)?;
+
+        let initiated_at = storage::get_recovery_initiated_at(&env)
+            .ok_or(Error::RecoveryNotInitiated)?;
+
+        // Enforce 7-day grace period.
+        let now = env.ledger().timestamp();
+        if now < initiated_at.saturating_add(storage::RECOVERY_GRACE_PERIOD) {
+            return Err(Error::RecoveryGracePeriodActive);
+        }
+
+        let threshold = storage::get_recovery_threshold(&env);
+        let mut approvals = storage::get_recovery_approvals(&env);
+
+        // Validate and auth each signer; deduplicate.
+        for signer in council_signatures.iter() {
+            if !council.contains(&signer) {
+                return Err(Error::NotCouncilMember);
+            }
+            if approvals.contains(&signer) {
+                return Err(Error::RecoveryAlreadyApproved);
+            }
+            signer.require_auth();
+            approvals.push_back(signer.clone());
+        }
+
+        if approvals.len() < threshold {
+            // Persist partial approvals so subsequent calls can accumulate.
+            env.storage()
+                .instance()
+                .set(&crate::storage::DataKeyV2::RecoveryApprovals, &approvals);
+            storage::bump_instance(&env);
+            return Err(Error::RecoveryInsufficientSignatures);
+        }
+
+        // Transfer the full balance of `token` to `destination`.
+        let token_client = soroban_sdk::token::TokenClient::new(&env, &token);
+        let balance = token_client.balance(&env.current_contract_address());
+
+        if balance > 0 {
+            token_client.transfer(&env.current_contract_address(), &destination, &balance);
+        }
+
+        // Clear recovery state to prevent replay.
+        storage::clear_recovery(&env);
+
+        env.events().publish(
+            (soroban_sdk::symbol_short!("rec_exec"), destination.clone()),
+            balance,
+        );
+
+        Ok(balance)
+    }
 }
 
 mod test;

--- a/contracts/Contract-V2/src/storage.rs
+++ b/contracts/Contract-V2/src/storage.rs
@@ -143,6 +143,16 @@ pub enum DataKeyV2 {
     // -- Issue #632 — Gas Tank Buffer ----------------------------------
     /// Per-sender XLM gas buffer in stroops.
     GasBuffer(Address), // 30
+
+    // -- Emergency Recovery Multi-Sig (Issue: Security Critical) --------
+    /// Vec<Address> of pre-approved recovery council members
+    RecoveryCouncil, // 31
+    /// Required number of council signatures to execute recovery
+    RecoveryThreshold, // 32
+    /// Timestamp when recovery was initiated (None = not initiated)
+    RecoveryInitiatedAt, // 33
+    /// Addresses that have already approved the current recovery
+    RecoveryApprovals, // 34
 }
 
 /// Global stream counter.
@@ -921,4 +931,69 @@ pub fn has_pending_rate_update(env: &Env, stream_id: u64) -> bool {
     env.storage()
         .instance()
         .has(&DataKeyV2::PendingRateUpdate(stream_id))
+}
+
+
+// ----------------------------------------------------------------
+// Emergency Recovery Multi-Sig (Issue: Security Critical)
+// ----------------------------------------------------------------
+
+/// 7-day grace period before recovery funds can move.
+pub const RECOVERY_GRACE_PERIOD: u64 = 604_800;
+
+/// Persist the recovery council and required threshold.
+pub fn set_recovery_council(env: &Env, council: &Vec<Address>, threshold: u32) {
+    env.storage().instance().set(&DataKeyV2::RecoveryCouncil, council);
+    env.storage().instance().set(&DataKeyV2::RecoveryThreshold, &threshold);
+    bump_instance(env);
+}
+
+/// Return the recovery council, if configured.
+pub fn get_recovery_council(env: &Env) -> Option<Vec<Address>> {
+    env.storage().instance().get(&DataKeyV2::RecoveryCouncil)
+}
+
+/// Return the recovery threshold (default 1).
+pub fn get_recovery_threshold(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKeyV2::RecoveryThreshold)
+        .unwrap_or(1)
+}
+
+/// Record the timestamp when recovery was initiated.
+pub fn set_recovery_initiated_at(env: &Env, ts: u64) {
+    env.storage().instance().set(&DataKeyV2::RecoveryInitiatedAt, &ts);
+    // Reset approvals list on new initiation.
+    let empty: Vec<Address> = Vec::new(env);
+    env.storage().instance().set(&DataKeyV2::RecoveryApprovals, &empty);
+    bump_instance(env);
+}
+
+/// Return the timestamp when recovery was initiated, if any.
+pub fn get_recovery_initiated_at(env: &Env) -> Option<u64> {
+    env.storage().instance().get(&DataKeyV2::RecoveryInitiatedAt)
+}
+
+/// Clear recovery state (after execution or cancellation).
+pub fn clear_recovery(env: &Env) {
+    env.storage().instance().remove(&DataKeyV2::RecoveryInitiatedAt);
+    env.storage().instance().remove(&DataKeyV2::RecoveryApprovals);
+    bump_instance(env);
+}
+
+/// Return the list of addresses that have approved the current recovery.
+pub fn get_recovery_approvals(env: &Env) -> Vec<Address> {
+    env.storage()
+        .instance()
+        .get(&DataKeyV2::RecoveryApprovals)
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+/// Append `signer` to the recovery approvals list.
+pub fn add_recovery_approval(env: &Env, signer: &Address) {
+    let mut approvals = get_recovery_approvals(env);
+    approvals.push_back(signer.clone());
+    env.storage().instance().set(&DataKeyV2::RecoveryApprovals, &approvals);
+    bump_instance(env);
 }

--- a/contracts/Contract-V2/src/test.rs
+++ b/contracts/Contract-V2/src/test.rs
@@ -3786,3 +3786,198 @@ fn test_create_via_signature_fails_for_non_whitelisted_asset() {
     let result = client.try_create_via_signature(&params, &bad_sig);
     assert_eq!(result, Err(Ok(Error::AssetNotWhitelisted)));
 }
+
+// ── Emergency Recovery Multi-Sig Tests ───────────────────────────────────────
+
+#[test]
+fn test_set_recovery_council_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let (_, client) = setup_v2(&env, &admin);
+
+    let c1 = Address::generate(&env);
+    let c2 = Address::generate(&env);
+    let c3 = Address::generate(&env);
+    let council = vec![&env, c1.clone(), c2.clone(), c3.clone()];
+
+    client.set_recovery_council(&admin, &council, &2);
+    let stored = client.get_recovery_council().unwrap();
+    assert_eq!(stored.len(), 3);
+}
+
+#[test]
+fn test_set_recovery_council_invalid_threshold() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let (_, client) = setup_v2(&env, &admin);
+
+    let c1 = Address::generate(&env);
+    let council = vec![&env, c1.clone()];
+
+    // threshold > council size
+    let result = client.try_set_recovery_council(&admin, &council, &5);
+    assert_eq!(result, Err(Ok(Error::InvalidThreshold)));
+
+    // threshold = 0
+    let result2 = client.try_set_recovery_council(&admin, &council, &0);
+    assert_eq!(result2, Err(Ok(Error::InvalidThreshold)));
+}
+
+#[test]
+fn test_init_recovery_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let (_, client) = setup_v2(&env, &admin);
+
+    let c1 = Address::generate(&env);
+    let council = vec![&env, c1.clone()];
+    client.set_recovery_council(&admin, &council, &1);
+
+    client.init_recovery(&c1);
+}
+
+#[test]
+fn test_init_recovery_not_council_member() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let (_, client) = setup_v2(&env, &admin);
+
+    let c1 = Address::generate(&env);
+    let outsider = Address::generate(&env);
+    let council = vec![&env, c1.clone()];
+    client.set_recovery_council(&admin, &council, &1);
+
+    let result = client.try_init_recovery(&outsider);
+    assert_eq!(result, Err(Ok(Error::NotCouncilMember)));
+}
+
+#[test]
+fn test_init_recovery_already_initiated() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let (_, client) = setup_v2(&env, &admin);
+
+    let c1 = Address::generate(&env);
+    let council = vec![&env, c1.clone()];
+    client.set_recovery_council(&admin, &council, &1);
+    client.init_recovery(&c1);
+
+    let result = client.try_init_recovery(&c1);
+    assert_eq!(result, Err(Ok(Error::RecoveryAlreadyInitiated)));
+}
+
+#[test]
+fn test_recovery_split_grace_period_active() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let (_, client) = setup_v2(&env, &admin);
+
+    let c1 = Address::generate(&env);
+    let council = vec![&env, c1.clone()];
+    client.set_recovery_council(&admin, &council, &1);
+    client.init_recovery(&c1);
+
+    let (token_id, _, sac) = create_token(&env, &admin);
+    let destination = Address::generate(&env);
+    let signers = vec![&env, c1.clone()];
+
+    // Grace period not elapsed — should fail
+    let result = client.try_recovery_split(&signers, &token_id, &destination);
+    assert_eq!(result, Err(Ok(Error::RecoveryGracePeriodActive)));
+}
+
+#[test]
+fn test_recovery_split_success_after_grace_period() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let (contract_id, client) = setup_v2(&env, &admin);
+
+    let c1 = Address::generate(&env);
+    let council = vec![&env, c1.clone()];
+    client.set_recovery_council(&admin, &council, &1);
+
+    // Set ledger time and initiate recovery
+    env.ledger().with_mut(|l| l.timestamp = 1_000_000);
+    client.init_recovery(&c1);
+
+    // Advance past 7-day grace period
+    env.ledger().with_mut(|l| l.timestamp = 1_000_000 + 604_801);
+
+    let (token_id, token_client, sac) = create_token(&env, &admin);
+    // Fund the contract
+    sac.mint(&contract_id, &5_000_000);
+
+    let destination = Address::generate(&env);
+    let signers = vec![&env, c1.clone()];
+
+    let recovered = client.recovery_split(&signers, &token_id, &destination);
+    assert_eq!(recovered, 5_000_000);
+    assert_eq!(token_client.balance(&destination), 5_000_000);
+}
+
+#[test]
+fn test_recovery_split_insufficient_signatures() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let (_, client) = setup_v2(&env, &admin);
+
+    let c1 = Address::generate(&env);
+    let c2 = Address::generate(&env);
+    let council = vec![&env, c1.clone(), c2.clone()];
+    client.set_recovery_council(&admin, &council, &2);
+
+    env.ledger().with_mut(|l| l.timestamp = 1_000_000);
+    client.init_recovery(&c1);
+    env.ledger().with_mut(|l| l.timestamp = 1_000_000 + 604_801);
+
+    let (token_id, _, _) = create_token(&env, &admin);
+    let destination = Address::generate(&env);
+
+    // Only 1 signer, threshold is 2
+    let signers = vec![&env, c1.clone()];
+    let result = client.try_recovery_split(&signers, &token_id, &destination);
+    assert_eq!(result, Err(Ok(Error::RecoveryInsufficientSignatures)));
+}
+
+#[test]
+fn test_recovery_split_no_council_set() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let (_, client) = setup_v2(&env, &admin);
+
+    let (token_id, _, _) = create_token(&env, &admin);
+    let destination = Address::generate(&env);
+    let c1 = Address::generate(&env);
+    let signers = vec![&env, c1.clone()];
+
+    let result = client.try_recovery_split(&signers, &token_id, &destination);
+    assert_eq!(result, Err(Ok(Error::RecoveryCouncilNotSet)));
+}
+
+#[test]
+fn test_recovery_split_not_initiated() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let (_, client) = setup_v2(&env, &admin);
+
+    let c1 = Address::generate(&env);
+    let council = vec![&env, c1.clone()];
+    client.set_recovery_council(&admin, &council, &1);
+
+    let (token_id, _, _) = create_token(&env, &admin);
+    let destination = Address::generate(&env);
+    let signers = vec![&env, c1.clone()];
+
+    let result = client.try_recovery_split(&signers, &token_id, &destination);
+    assert_eq!(result, Err(Ok(Error::RecoveryNotInitiated)));
+}


### PR DESCRIPTION
- Add set_recovery_council(): admin sets council addresses + threshold at init time; stored on-chain, immutable without another admin call
- Add init_recovery(): any council member can start the 7-day grace period clock; emits rec_init event
- Add recovery_split(): after grace period, council_signatures (Vec<Address>) are validated against the stored council, require_auth() is called on each, and the full token balance is transferred to destination; approvals accumulate across calls so the threshold can be reached incrementally; emits rec_exec event and clears recovery state
- Add 7 new Error variants (69-75) covering all failure paths
- Add 4 new DataKeyV2 storage keys (31-34) for council, threshold, initiated_at, and approvals
- Add 9 tests covering: happy path, grace period enforcement, insufficient signatures, non-member rejection, double-initiation, no council set, and not-initiated guard

Closes #837