### PR TITLE
qa(backend): v3 mainnet-readiness final pass — enforce auth on all sensitive endpoints

### DIFF
--- a/backend/src/__tests__/auth-coverage.test.ts
+++ b/backend/src/__tests__/auth-coverage.test.ts
@@ -1,0 +1,52 @@
+/**
+ * QA: V3 Mainnet-Readiness — Auth coverage audit
+ *
+ * Verifies that all sensitive API endpoints reject unauthenticated requests
+ * with HTTP 401 before any business logic runs.
+ */
+
+import request from 'supertest';
+import app from '../../index.js';
+
+// Endpoints that must require authentication
+const PROTECTED_ENDPOINTS: Array<{ method: 'get' | 'post'; path: string }> = [
+  // V3 — history
+  { method: 'get',  path: '/api/v3/history/GABC1234567890123456789012345678901234567890123456' },
+  // V3 — disbursement file
+  { method: 'post', path: '/api/v3/process-disbursement-file' },
+  // V3 — safe vault routes
+  { method: 'post', path: '/api/v3/resolve-vault-routes' },
+  // V3 — invoice report
+  { method: 'post', path: '/api/v3/reports/invoice' },
+  // V1 — governance proposal creation (write)
+  { method: 'post', path: '/api/v1/governance/proposals' },
+];
+
+// Endpoints that must remain publicly accessible (no auth required)
+const PUBLIC_ENDPOINTS: Array<{ method: 'get'; path: string }> = [
+  { method: 'get', path: '/api/v1/stats' },
+  { method: 'get', path: '/api/v1/health' },
+  { method: 'get', path: '/api/v1/auth/nonce' },
+];
+
+describe('Auth coverage audit', () => {
+  describe('Protected endpoints return 401 without credentials', () => {
+    for (const { method, path } of PROTECTED_ENDPOINTS) {
+      it(`${method.toUpperCase()} ${path}`, async () => {
+        const res = await (request(app) as any)[method](path).send({});
+        expect(res.status).toBe(401);
+        expect(res.body).toMatchObject({ code: 'MISSING_AUTH' });
+      });
+    }
+  });
+
+  describe('Public endpoints remain accessible without credentials', () => {
+    for (const { method, path } of PUBLIC_ENDPOINTS) {
+      it(`${method.toUpperCase()} ${path}`, async () => {
+        const res = await (request(app) as any)[method](path);
+        // Must not be 401 — any other status (200, 404, 500) is acceptable here
+        expect(res.status).not.toBe(401);
+      });
+    }
+  });
+});

--- a/backend/src/api/governance.routes.ts
+++ b/backend/src/api/governance.routes.ts
@@ -5,6 +5,7 @@ import asyncHandler from "../utils/asyncHandler.js";
 import validateRequest from "../middleware/validateRequest.js";
 import stellarAddressSchema from "../validation/stellar.js";
 import { VotingPowerService } from "../services/voting-power.service.js";
+import { requireAuth } from "../middleware/requireAuth.js";
 
 interface IndexedProposalRow {
   id: string;
@@ -30,6 +31,7 @@ const votingPowerParamsSchema = z.object({
  */
 router.post(
   "/governance/proposals",
+  requireAuth,
   validateRequest({
     body: z.object({
       creator: stellarAddressSchema,

--- a/backend/src/api/v3/index.ts
+++ b/backend/src/api/v3/index.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { responseWrapper } from "../../middleware/responseWrapper.js";
 import { orgPolicyMiddleware } from "../../middleware/orgPolicy.js";
 import { draftRateLimitMiddleware } from "../../middleware/draftRateLimit.js";
+import { requireAuth } from "../../middleware/requireAuth.js";
 import disbursementFileRouter from "./disbursement-file.routes.js";
 import safeVaultRouter from "./safe-vault.routes.js";
 import historyRouter from "./history.routes.js";
@@ -10,6 +11,8 @@ import invoiceReportRouter from "./invoice-report.routes.js";
 const router = Router();
 
 router.use(responseWrapper);
+// All V3 endpoints require a valid API key.
+router.use(requireAuth);
 
 // #848 — per-org rate limit on all V3 split-draft endpoints
 router.use("/process-disbursement-file", draftRateLimitMiddleware);

--- a/backend/src/middleware/requireAuth.ts
+++ b/backend/src/middleware/requireAuth.ts
@@ -1,0 +1,14 @@
+import { Request, Response, NextFunction } from 'express';
+
+/**
+ * Enforces that the request has been authenticated by authMiddleware.
+ * Must be placed after authMiddleware in the middleware chain.
+ * Returns 401 if no valid API key / Bearer token was provided.
+ */
+export function requireAuth(req: Request, res: Response, next: NextFunction): void {
+  if (!req.authenticated) {
+    res.status(401).json({ error: 'Unauthorized', code: 'MISSING_AUTH' });
+    return;
+  }
+  next();
+}


### PR DESCRIPTION
- Add requireAuth middleware: enforces req.authenticated, returns 401 with code MISSING_AUTH if not set — zero logic, single responsibility
- Apply requireAuth to entire V3 router (history, disbursement-file, safe-vault, invoice-report) via router.use() in v3/index.ts
- Apply requireAuth to POST /api/v1/governance/proposals (write op)
- Add auth-coverage.test.ts: audits all sensitive endpoints return 401 without credentials; verifies public endpoints remain accessible

Closes #851 
