### PR TITLE
feat(backend): autopilot multi-sig notifier — ping signers 24h before  release

### DIFF
--- a/backend/src/__tests__/multisig-notifier.test.ts
+++ b/backend/src/__tests__/multisig-notifier.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Unit tests for MultisigNotifierService
+ * Mocks prisma and fetch — no real DB or network calls.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockFindMany = vi.fn();
+const mockUpdate = vi.fn();
+const mockSubFindMany = vi.fn();
+
+vi.mock("../../lib/db.js", () => ({
+  prisma: {
+    autopilotSchedule: {
+      findMany: mockFindMany,
+      update: mockUpdate,
+    },
+    notificationSubscription: {
+      findMany: mockSubFindMany,
+    },
+  },
+}));
+
+vi.mock("../../logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+// ── Import after mocks ────────────────────────────────────────────────────────
+
+import { MultisigNotifierService } from "../../services/multisig-notifier.service.js";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const NOW = new Date("2026-01-01T10:00:00Z");
+const IN_12H = new Date(NOW.getTime() + 12 * 60 * 60 * 1000);
+const IN_25H = new Date(NOW.getTime() + 25 * 60 * 60 * 1000);
+
+function makeSchedule(overrides: object = {}) {
+  return {
+    id: "sched-1",
+    name: "Payroll",
+    releaseTime: IN_12H,
+    signers: ["GABC123", "GDEF456"],
+    notifiedAt: null,
+    isActive: true,
+    ...overrides,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("MultisigNotifierService.notifyPendingSigners", () => {
+  let service: MultisigNotifierService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new MultisigNotifierService();
+    mockFetch.mockResolvedValue({ ok: true });
+  });
+
+  it("does nothing when no schedules are in the 24-hour window", async () => {
+    mockFindMany.mockResolvedValue([]);
+    await service.notifyPendingSigners();
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("sends Discord notification via registered subscription", async () => {
+    mockFindMany.mockResolvedValue([makeSchedule()]);
+    mockSubFindMany.mockResolvedValue([
+      { platform: "discord", webhookUrl: "https://discord.com/api/webhooks/test", chatId: null },
+    ]);
+
+    await service.notifyPendingSigners();
+
+    // fetch called once per signer (2 signers × 1 subscription each = 2 calls)
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls[0][0]).toBe("https://discord.com/api/webhooks/test");
+  });
+
+  it("marks schedule as notified after dispatching", async () => {
+    mockFindMany.mockResolvedValue([makeSchedule()]);
+    mockSubFindMany.mockResolvedValue([]);
+    process.env.MULTISIG_ALERT_DISCORD_WEBHOOK = "";
+
+    await service.notifyPendingSigners();
+
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "sched-1" },
+        data: expect.objectContaining({ notifiedAt: expect.any(Date) }),
+      })
+    );
+  });
+
+  it("uses fallback Discord webhook when no subscription exists", async () => {
+    process.env.MULTISIG_ALERT_DISCORD_WEBHOOK = "https://discord.com/api/webhooks/fallback";
+    mockFindMany.mockResolvedValue([makeSchedule({ signers: ["GABC123"] })]);
+    mockSubFindMany.mockResolvedValue([]);
+
+    await service.notifyPendingSigners();
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://discord.com/api/webhooks/fallback",
+      expect.objectContaining({ method: "POST" })
+    );
+  });
+
+  it("still marks notifiedAt even when a Discord call fails", async () => {
+    mockFindMany.mockResolvedValue([makeSchedule({ signers: ["GABC123"] })]);
+    mockSubFindMany.mockResolvedValue([
+      { platform: "discord", webhookUrl: "https://discord.com/api/webhooks/bad", chatId: null },
+    ]);
+    mockFetch.mockResolvedValue({ ok: false, status: 500, statusText: "Server Error" });
+
+    await service.notifyPendingSigners();
+
+    // notifiedAt must still be set — we don't retry on the next tick
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ notifiedAt: expect.any(Date) }) })
+    );
+  });
+
+  it("skips schedules with no signers", async () => {
+    mockFindMany.mockResolvedValue([makeSchedule({ signers: [] })]);
+
+    await service.notifyPendingSigners();
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/generated/client/schema.prisma
+++ b/backend/src/generated/client/schema.prisma
@@ -381,11 +381,20 @@ model AutopilotSchedule {
   lastRun         DateTime? @map("last_run")
   lastTxHash      String?   @map("last_tx_hash")
   lastError       String?   @map("last_error")
+  /// ISO-8601 timestamp of the scheduled release / execution time.
+  /// Used by the multi-sig notifier to detect the 24-hour window.
+  releaseTime     DateTime? @map("release_time")
+  /// JSON array of Stellar G-addresses that must co-sign before execution.
+  /// e.g. ["GABC...", "GDEF..."]
+  signers         String[]  @default([]) @map("signers")
+  /// Tracks whether the 24-hour pre-release notification has been sent.
+  notifiedAt      DateTime? @map("notified_at")
   createdAt       DateTime  @default(now()) @map("created_at")
   updatedAt       DateTime  @updatedAt @map("updated_at")
 
   @@index([isActive])
   @@index([lastRun])
+  @@index([releaseTime])
   @@map("AutopilotSchedule")
 }
 

--- a/backend/src/schedulers.ts
+++ b/backend/src/schedulers.ts
@@ -3,6 +3,7 @@ import { PriceService } from "./services/price.service.js";
 import { TvlAggregatorService } from "./services/tvl-aggregator.service.js";
 import { AssetMetadataService } from "./services/asset-metadata.service.js";
 import { AutopilotService } from "./services/autopilot.service.js";
+import { MultisigNotifierService } from "./services/multisig-notifier.service.js";
 import { archiveOldDisbursements } from "./services/disbursement-archive.service.js";
 import { LedgerConsistencyChecker } from "./services/ledger-consistency.service.js";
 import { logger } from "./logger.js";
@@ -89,6 +90,7 @@ export function initializeSchedulers() {
   scheduleDailyTvlSnapshot();
   scheduleAssetDiscovery();
   scheduleAutopilot();
+  scheduleMultisigNotifier();
   scheduleDisbursementArchive();
   scheduleLedgerConsistencyCheck();
 }
@@ -108,6 +110,26 @@ export function scheduleAutopilot() {
   });
 
   logger.info("Autopilot scheduler started (every hour)");
+}
+
+/**
+ * Multi-sig notifier: ping signers 24 hours before a scheduled split's release time.
+ * Runs every hour — idempotent (notifiedAt prevents duplicate alerts).
+ */
+export function scheduleMultisigNotifier() {
+  const notifier = new MultisigNotifierService();
+
+  cron.schedule("0 * * * *", async () => {
+    try {
+      logger.info("[MultisigNotifier] Starting 24-hour window scan");
+      await notifier.notifyPendingSigners();
+      logger.info("[MultisigNotifier] 24-hour window scan completed");
+    } catch (error) {
+      logger.error("[MultisigNotifier] Scan failed", error);
+    }
+  });
+
+  logger.info("Multi-sig notifier scheduler started (every hour)");
 }
 
 /**

--- a/backend/src/services/multisig-notifier.service.ts
+++ b/backend/src/services/multisig-notifier.service.ts
@@ -1,0 +1,189 @@
+/**
+ * Autopilot Multi-Sig Notifier
+ *
+ * Scans AutopilotSchedule rows that:
+ *   1. Have a releaseTime within the next 24 hours
+ *   2. Have at least one signer address
+ *   3. Have NOT already been notified (notifiedAt is null)
+ *
+ * For each matching schedule it pings every signer via their registered
+ * Discord/Telegram subscription (reusing NotificationSubscription).
+ * Falls back to a Discord webhook env-var when no subscription is found.
+ */
+
+import { prisma } from "../lib/db.js";
+import { logger } from "../logger.js";
+
+const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
+
+// Optional fallback Discord webhook for signers with no registered subscription.
+const FALLBACK_DISCORD_WEBHOOK = process.env.MULTISIG_ALERT_DISCORD_WEBHOOK ?? "";
+
+interface SignerNotification {
+  scheduleId: string;
+  scheduleName: string;
+  releaseTime: Date;
+  signerAddress: string;
+}
+
+// ── Discord helpers ───────────────────────────────────────────────────────────
+
+function buildDiscordPayload(n: SignerNotification): object {
+  return {
+    username: "StellarStream 🌊",
+    embeds: [
+      {
+        title: "🔏 Signature Required — Scheduled Split",
+        description: `Your signature is needed for **${n.scheduleName}** before it executes.`,
+        color: 0xf59e0b, // amber
+        fields: [
+          { name: "📅 Release Time", value: n.releaseTime.toUTCString(), inline: false },
+          { name: "🔑 Signer", value: `\`${n.signerAddress}\``, inline: false },
+          { name: "🆔 Schedule ID", value: `\`${n.scheduleId}\``, inline: false },
+        ],
+        footer: { text: "StellarStream Autopilot • Sign within 24 hours to avoid delay" },
+        timestamp: new Date().toISOString(),
+      },
+    ],
+  };
+}
+
+async function sendDiscord(webhookUrl: string, n: SignerNotification): Promise<void> {
+  const res = await fetch(webhookUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(buildDiscordPayload(n)),
+  });
+  if (!res.ok) {
+    throw new Error(`Discord webhook failed: ${res.status} ${res.statusText}`);
+  }
+}
+
+// ── Email helper (SMTP via env vars) ─────────────────────────────────────────
+
+async function sendEmail(to: string, n: SignerNotification): Promise<void> {
+  // Lazy-import nodemailer so the service still boots when it's not installed.
+  let nodemailer: typeof import("nodemailer");
+  try {
+    nodemailer = await import("nodemailer");
+  } catch {
+    throw new Error("nodemailer is not installed — skipping email notification");
+  }
+
+  const { SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS, SMTP_FROM } = process.env;
+  if (!SMTP_HOST || !SMTP_USER || !SMTP_PASS) {
+    throw new Error("SMTP env vars not configured");
+  }
+
+  const transporter = nodemailer.createTransport({
+    host: SMTP_HOST,
+    port: Number(SMTP_PORT ?? 587),
+    secure: false,
+    auth: { user: SMTP_USER, pass: SMTP_PASS },
+  });
+
+  await transporter.sendMail({
+    from: SMTP_FROM ?? SMTP_USER,
+    to,
+    subject: `[StellarStream] Signature required: ${n.scheduleName}`,
+    text: [
+      `Your signature is required for the scheduled split "${n.scheduleName}".`,
+      ``,
+      `Release time: ${n.releaseTime.toUTCString()}`,
+      `Signer address: ${n.signerAddress}`,
+      `Schedule ID: ${n.scheduleId}`,
+      ``,
+      `Please sign within 24 hours to avoid execution delay.`,
+    ].join("\n"),
+  });
+}
+
+// ── Core scan ─────────────────────────────────────────────────────────────────
+
+export class MultisigNotifierService {
+  /**
+   * Find schedules entering the 24-hour window and notify their signers.
+   * Marks each schedule with notifiedAt so it is not re-notified.
+   */
+  async notifyPendingSigners(): Promise<void> {
+    const now = new Date();
+    const windowEnd = new Date(now.getTime() + TWENTY_FOUR_HOURS_MS);
+
+    // Schedules due within 24 h that haven't been notified yet.
+    const schedules = await prisma.autopilotSchedule.findMany({
+      where: {
+        isActive: true,
+        notifiedAt: null,
+        releaseTime: { gte: now, lte: windowEnd },
+      },
+    });
+
+    if (schedules.length === 0) {
+      logger.debug("[MultisigNotifier] No schedules entering 24-hour window");
+      return;
+    }
+
+    logger.info(`[MultisigNotifier] Notifying signers for ${schedules.length} schedule(s)`);
+
+    for (const schedule of schedules) {
+      if (!schedule.releaseTime || schedule.signers.length === 0) continue;
+
+      const releaseTime = schedule.releaseTime;
+
+      await Promise.allSettled(
+        schedule.signers.map((signerAddress) =>
+          this.notifySigner({ scheduleId: schedule.id, scheduleName: schedule.name, releaseTime, signerAddress })
+        )
+      );
+
+      // Mark as notified regardless of individual delivery failures so we
+      // don't spam signers on the next hourly tick.
+      await prisma.autopilotSchedule.update({
+        where: { id: schedule.id },
+        data: { notifiedAt: now },
+      });
+
+      logger.info(`[MultisigNotifier] Marked schedule "${schedule.name}" as notified`);
+    }
+  }
+
+  private async notifySigner(n: SignerNotification): Promise<void> {
+    // Look up registered notification subscriptions for this signer address.
+    const subs = await (prisma as any).notificationSubscription.findMany({
+      where: { stellarAddress: n.signerAddress, isActive: true },
+    });
+
+    let dispatched = false;
+
+    for (const sub of subs) {
+      try {
+        if (sub.platform === "discord" && sub.webhookUrl) {
+          await sendDiscord(sub.webhookUrl, n);
+          logger.info(`[MultisigNotifier] Discord alert sent to ${n.signerAddress} for schedule ${n.scheduleId}`);
+          dispatched = true;
+        } else if (sub.platform === "email" && sub.chatId) {
+          // chatId stores the email address for email-platform subscriptions.
+          await sendEmail(sub.chatId, n);
+          logger.info(`[MultisigNotifier] Email alert sent to ${n.signerAddress} for schedule ${n.scheduleId}`);
+          dispatched = true;
+        }
+      } catch (err) {
+        logger.error(`[MultisigNotifier] Failed to notify ${n.signerAddress} via ${sub.platform}`, err);
+      }
+    }
+
+    // Fallback: use the global Discord webhook env var if no subscription found.
+    if (!dispatched && FALLBACK_DISCORD_WEBHOOK) {
+      try {
+        await sendDiscord(FALLBACK_DISCORD_WEBHOOK, n);
+        logger.info(`[MultisigNotifier] Fallback Discord alert sent for signer ${n.signerAddress}`);
+      } catch (err) {
+        logger.error(`[MultisigNotifier] Fallback Discord alert failed for ${n.signerAddress}`, err);
+      }
+    }
+
+    if (!dispatched && !FALLBACK_DISCORD_WEBHOOK) {
+      logger.warn(`[MultisigNotifier] No notification channel found for signer ${n.signerAddress} — schedule ${n.scheduleId}`);
+    }
+  }
+}


### PR DESCRIPTION
Hooks into AutopilotSchedule to detect scheduled splits that require co-signatures and notifies each signer via Discord/Email 24 hours before the release time.

Schema changes (AutopilotSchedule):
- releaseTime DateTime? — scheduled execution timestamp
- signers     String[]  — Stellar G-addresses that must co-sign
- notifiedAt  DateTime? — set after notification to prevent re-pinging
- Added @@index([releaseTime]) for efficient window queries

New: services/multisig-notifier.service.ts
- notifyPendingSigners(): queries schedules where isActive=true AND notifiedAt=null AND releaseTime IN [now, now+24h]
- Per signer: looks up NotificationSubscription (discord/email); falls back to MULTISIG_ALERT_DISCORD_WEBHOOK env var
- Marks notifiedAt after dispatching (idempotent — no duplicate alerts)
- Email via nodemailer (lazy import, graceful skip if not installed)
- Discord via existing webhook POST pattern from NotificationService




Closes #843 