### PR TITLE
feat(disbursement): add high-precision BPS ↔ absolute math utilit

### DIFF
--- a/frontend/lib/disbursement-math.test.ts
+++ b/frontend/lib/disbursement-math.test.ts
@@ -1,0 +1,330 @@
+import { describe, it, expect } from "vitest";
+import BigNumber from "bignumber.js";
+import {
+    bpsToPercentage,
+    percentageToBps,
+    bpsToAbsolute,
+    absoluteToBps,
+    enrichEntry,
+    calcDisbursementList,
+    updateEntryByPercentage,
+    updateEntryByAbsolute,
+    normaliseShares,
+    getRemainderWarning,
+    humanToI128,
+    i128ToHuman,
+} from "./disbursement-math";
+
+describe("bpsToPercentage", () => {
+    it("converts 10 000 BPS → 100.00 %", () => {
+        expect(bpsToPercentage(10_000)).toBe("100.00");
+    });
+
+    it("converts 5 000 BPS → 50.00 %", () => {
+        expect(bpsToPercentage(5_000)).toBe("50.00");
+    });
+
+    it("converts 1 BPS → 0.01 %", () => {
+        expect(bpsToPercentage(1)).toBe("0.01");
+    });
+
+    it("converts 3 333 BPS → 33.33 %", () => {
+        expect(bpsToPercentage(3_333)).toBe("33.33");
+    });
+
+    it("accepts a BigNumber argument", () => {
+        expect(bpsToPercentage(new BigNumber(2500))).toBe("25.00");
+    });
+});
+
+describe("percentageToBps", () => {
+    it("converts 50 % → 5 000 BPS", () => {
+        expect(percentageToBps("50")).toBe(5_000);
+    });
+
+    it("converts 33.33 % → 3 333 BPS (floors)", () => {
+        expect(percentageToBps("33.33")).toBe(3_333);
+    });
+
+    it("converts 100 % → 10 000 BPS", () => {
+        expect(percentageToBps("100")).toBe(10_000);
+    });
+
+    it("converts 0 % → 0 BPS", () => {
+        expect(percentageToBps("0")).toBe(0);
+    });
+
+    it("throws on negative percentage", () => {
+        expect(() => percentageToBps("-1")).toThrow(RangeError);
+    });
+
+    it("throws on > 100 %", () => {
+        expect(() => percentageToBps("100.01")).toThrow(RangeError);
+    });
+
+    it("throws on NaN input", () => {
+        expect(() => percentageToBps("abc")).toThrow(RangeError);
+    });
+});
+
+describe("bpsToAbsolute", () => {
+    const total = "100000000"; // 100 USDC (6 decimals)
+
+    it("50 % of 100 USDC = 50 000 000 stroops", () => {
+        expect(bpsToAbsolute(5_000, total)).toBe("50000000");
+    });
+
+    it("100 % = full total", () => {
+        expect(bpsToAbsolute(10_000, total)).toBe("100000000");
+    });
+
+    it("1 BPS of 100 USDC = 10 000 stroops (0.01 USDC)", () => {
+        expect(bpsToAbsolute(1, total)).toBe("10000");
+    });
+
+    it("floors fractional stroops (no decimals in i128)", () => {
+        // 1/3 of 100_000_001 — should not produce a decimal
+        const result = bpsToAbsolute(3_333, "100000001");
+        expect(result).toMatch(/^\d+$/);
+    });
+
+    it("works with bigint totalAmount", () => {
+        expect(bpsToAbsolute(5_000, BigInt(100_000_000))).toBe("50000000");
+    });
+});
+
+describe("absoluteToBps", () => {
+    const total = "100000000";
+
+    it("50 000 000 / 100 000 000 = 5 000 BPS", () => {
+        expect(absoluteToBps("50000000", total)).toBe(5_000);
+    });
+
+    it("0 / total = 0 BPS", () => {
+        expect(absoluteToBps("0", total)).toBe(0);
+    });
+
+    it("total / total = 10 000 BPS", () => {
+        expect(absoluteToBps(total, total)).toBe(10_000);
+    });
+
+    it("throws when absolute > total", () => {
+        expect(() => absoluteToBps("100000001", total)).toThrow(RangeError);
+    });
+
+    it("throws when totalAmount is 0", () => {
+        expect(() => absoluteToBps("0", "0")).toThrow(RangeError);
+    });
+
+    it("rounds to nearest BPS on non-exact values", () => {
+        // 33 333 333 / 100 000 000 * 10 000 = 3333.3333 → rounds to 3333
+        expect(absoluteToBps("33333333", total)).toBe(3_333);
+    });
+});
+
+describe("enrichEntry", () => {
+    const entry = { address: "GABC123", share_bps: 5_000 };
+    const total = "100000000";
+    const enriched = enrichEntry(entry, total);
+
+    it("preserves original fields", () => {
+        expect(enriched.address).toBe("GABC123");
+        expect(enriched.share_bps).toBe(5_000);
+    });
+
+    it("computes percentageDisplay", () => {
+        expect(enriched.percentageDisplay).toBe("50.00");
+    });
+
+    it("computes absoluteDisplay", () => {
+        expect(enriched.absoluteDisplay).toBe("50000000");
+    });
+
+    it("stores BigNumber internals", () => {
+        expect(enriched._bpsRaw.toNumber()).toBe(5_000);
+        expect(enriched._absoluteRaw.toFixed(0)).toBe("50000000");
+    });
+});
+
+describe("calcDisbursementList", () => {
+    const total = "100000000";
+
+    it("marks a perfectly split list as valid", () => {
+        const entries = [
+            { address: "GA", share_bps: 5_000 },
+            { address: "GB", share_bps: 5_000 },
+        ];
+        const result = calcDisbursementList(entries, total);
+        expect(result.isValid).toBe(true);
+        expect(result.bpsSum).toBe(10_000);
+        expect(result.bpsRemainder).toBe(0);
+    });
+
+    it("reports a shortfall correctly", () => {
+        const entries = [
+            { address: "GA", share_bps: 4_000 },
+            { address: "GB", share_bps: 4_000 },
+        ];
+        const result = calcDisbursementList(entries, total);
+        expect(result.isValid).toBe(false);
+        expect(result.bpsRemainder).toBe(-2_000);
+        expect(result.remainderPct).toBe("-20.00");
+    });
+
+    it("reports an over-allocation correctly", () => {
+        const entries = [
+            { address: "GA", share_bps: 6_000 },
+            { address: "GB", share_bps: 5_000 },
+        ];
+        const result = calcDisbursementList(entries, total);
+        expect(result.isValid).toBe(false);
+        expect(result.bpsRemainder).toBe(1_000);
+    });
+
+    it("computes correct allocatedAbsolute and unallocatedAbsolute", () => {
+        const entries = [
+            { address: "GA", share_bps: 5_000 },
+            { address: "GB", share_bps: 4_000 },
+        ];
+        const result = calcDisbursementList(entries, total);
+        expect(result.allocatedAbsolute).toBe("90000000");
+        expect(result.unallocatedAbsolute).toBe("10000000");
+    });
+});
+
+describe("updateEntryByPercentage", () => {
+    const entry = { address: "GA", share_bps: 1_000 };
+
+    it("updates share_bps from a new percentage", () => {
+        const updated = updateEntryByPercentage(entry, "25");
+        expect(updated.share_bps).toBe(2_500);
+    });
+
+    it("does not mutate the original entry", () => {
+        updateEntryByPercentage(entry, "25");
+        expect(entry.share_bps).toBe(1_000);
+    });
+});
+
+describe("updateEntryByAbsolute", () => {
+    const entry = { address: "GA", share_bps: 1_000 };
+    const total = "100000000";
+
+    it("updates share_bps from an absolute amount", () => {
+        const updated = updateEntryByAbsolute(entry, "30000000", total);
+        expect(updated.share_bps).toBe(3_000);
+    });
+});
+
+describe("normaliseShares", () => {
+    it("three equal thirds sum to exactly 10 000", () => {
+        const entries = [
+            { address: "GA", share_bps: 3_333 },
+            { address: "GB", share_bps: 3_333 },
+            { address: "GC", share_bps: 3_334 },
+        ];
+        const normalised = normaliseShares(entries);
+        const sum = normalised.reduce((acc, e) => acc + e.share_bps, 0);
+        expect(sum).toBe(10_000);
+    });
+
+    it("does not change an already valid list", () => {
+        const entries = [
+            { address: "GA", share_bps: 5_000 },
+            { address: "GB", share_bps: 5_000 },
+        ];
+        const normalised = normaliseShares(entries);
+        expect(normalised[0].share_bps).toBe(5_000);
+        expect(normalised[1].share_bps).toBe(5_000);
+    });
+
+    it("returns empty array for empty input", () => {
+        expect(normaliseShares([])).toEqual([]);
+    });
+
+    it("handles a 120-recipient list without loss", () => {
+        const entries = Array.from({ length: 120 }, (_, i) => ({
+            address: `G${i}`,
+            share_bps: Math.floor(10_000 / 120),
+        }));
+        const normalised = normaliseShares(entries);
+        const sum = normalised.reduce((acc, e) => acc + e.share_bps, 0);
+        expect(sum).toBe(10_000);
+    });
+});
+
+describe("getRemainderWarning", () => {
+    it("returns ok for exactly 10 000", () => {
+        expect(getRemainderWarning(10_000).severity).toBe("ok");
+    });
+
+    it("returns warning for ±1 BPS", () => {
+        expect(getRemainderWarning(9_999).severity).toBe("warning");
+        expect(getRemainderWarning(10_001).severity).toBe("warning");
+    });
+
+    it("returns error for > 1 BPS difference", () => {
+        expect(getRemainderWarning(9_500).severity).toBe("error");
+        expect(getRemainderWarning(10_500).severity).toBe("error");
+    });
+
+    it("includes direction in label for error", () => {
+        expect(getRemainderWarning(9_500).label).toContain("-");
+        expect(getRemainderWarning(10_500).label).toContain("+");
+    });
+});
+
+describe("humanToI128", () => {
+    it("converts 100 USDC (6 decimals) correctly", () => {
+        expect(humanToI128("100", 6)).toBe("100000000");
+    });
+
+    it("converts 0.01 USDC", () => {
+        expect(humanToI128("0.01", 6)).toBe("10000");
+    });
+
+    it("floors sub-stroop amounts", () => {
+        expect(humanToI128("100.0000001", 6)).toBe("100000000");
+    });
+
+    it("throws on negative input", () => {
+        expect(() => humanToI128("-1", 6)).toThrow(RangeError);
+    });
+
+    it("throws on NaN input", () => {
+        expect(() => humanToI128("abc", 6)).toThrow(RangeError);
+    });
+});
+
+describe("i128ToHuman", () => {
+    it("converts 100 000 000 back to 100.000000 USDC", () => {
+        expect(i128ToHuman("100000000", 6)).toBe("100.000000");
+    });
+
+    it("respects custom dp", () => {
+        expect(i128ToHuman("100000000", 6, 2)).toBe("100.00");
+    });
+});
+
+
+describe("floating-point regression", () => {
+    it("0.1 + 0.2 scenario: bps add cleanly", () => {
+        // Native JS: (0.1 + 0.2) * 10000 = 3000.0000000000005
+        // BigNumber must give exactly 3000
+        const entries = [
+            { address: "GA", share_bps: percentageToBps("10") },
+            { address: "GB", share_bps: percentageToBps("20") },
+        ];
+        expect(entries[0].share_bps + entries[1].share_bps).toBe(3_000);
+    });
+
+    it("three-way 33.33 % split absolute amounts do not overflow", () => {
+        const total = "99999999"; // intentionally odd number
+        const a = bpsToAbsolute(3_333, total);
+        const b = bpsToAbsolute(3_333, total);
+        const c = bpsToAbsolute(3_334, total);
+        const sum = new BigNumber(a).plus(b).plus(c);
+        // Sum must be <= total (no overflow due to rounding)
+        expect(sum.isLessThanOrEqualTo(total)).toBe(true);
+    });
+});

--- a/frontend/lib/disbursement-math.ts
+++ b/frontend/lib/disbursement-math.ts
@@ -1,0 +1,366 @@
+import BigNumber from "bignumber.js";
+
+BigNumber.config({
+    DECIMAL_PLACES: 20,
+    ROUNDING_MODE: BigNumber.ROUND_HALF_UP,
+    EXPONENTIAL_AT: [-30, 30],
+});
+
+/** Basis points in a whole (100 %). */
+export const BPS_TOTAL = new BigNumber(10_000);
+
+/** Maximum share_bps any single recipient may hold. */
+export const BPS_MAX = BPS_TOTAL;
+
+/** Minimum non-zero share_bps (0.01 %). */
+export const BPS_MIN_NONZERO = new BigNumber(1);
+
+/** Displayable percentage precision (2 d.p.). */
+const PCT_DP = 2;
+
+export interface DisbursementEntry {
+    address: string;
+    /** Raw basis points stored in contract state (0 – 10 000). */
+    share_bps: number;
+}
+
+/**
+ * A single row in the UI's disbursement list with both display modes.
+ */
+export interface EnrichedEntry extends DisbursementEntry {
+    /** Human-readable percentage string, e.g. "33.33". */
+    percentageDisplay: string;
+    /** Absolute token amount string (in smallest unit), e.g. "3333333". */
+    absoluteDisplay: string;
+    /** Raw BigNumber for internal calculations. */
+    _bpsRaw: BigNumber;
+    /** Raw absolute BigNumber for internal calculations. */
+    _absoluteRaw: BigNumber;
+}
+
+export type InputMode = "percentage" | "absolute";
+
+/**
+ * Result of a full list recalculation, including remainder analysis.
+ */
+export interface DisbursementCalcResult {
+    entries: EnrichedEntry[];
+    /** Sum of all share_bps (should equal 10 000 for a valid list). */
+    bpsSum: number;
+    /** Remainder in basis points (bpsSum - 10 000). Negative = shortfall. */
+    bpsRemainder: number;
+    /** Remainder as a human-readable percentage string (e.g. "-0.50"). */
+    remainderPct: string;
+    /** true only when bpsSum === 10 000. */
+    isValid: boolean;
+    /** Absolute total actually allocated across all entries. */
+    allocatedAbsolute: string;
+    /** Unallocated absolute amount (totalAmount - allocatedAbsolute). */
+    unallocatedAbsolute: string;
+}
+
+/**
+ * Convert a basis-point integer to a display percentage string.
+ *
+ * @example bpsToPercentage(5000) → "50.00"
+ */
+export function bpsToPercentage(bps: number | BigNumber): string {
+    const n = new BigNumber(bps);
+    return n.dividedBy(BPS_TOTAL).multipliedBy(100).toFixed(PCT_DP);
+}
+
+/**
+ * Convert a display percentage string / number to basis points (integer).
+ * Result is floored so the sum of all BPS never accidentally exceeds 10 000
+ * due to rounding.
+ *
+ * @example percentageToBps("50.00") → 5000
+ * @throws {RangeError} if the resulting BPS would exceed [0, 10 000].
+ */
+export function percentageToBps(pct: string | number): number {
+    let n: BigNumber;
+    try {
+        n = new BigNumber(pct);
+    } catch (error) {
+        throw new RangeError(`percentageToBps: "${pct}" is not a number`);
+    }
+    if (n.isNaN()) throw new RangeError(`percentageToBps: "${pct}" is not a number`);
+    const bps = n.dividedBy(100).multipliedBy(BPS_TOTAL).integerValue(BigNumber.ROUND_FLOOR);
+    if (bps.isLessThan(0) || bps.isGreaterThan(BPS_TOTAL)) {
+        throw new RangeError(`percentageToBps: ${pct}% is out of range [0, 100]`);
+    }
+    return bps.toNumber();
+}
+
+/**
+ * Convert basis points + totalAmount (in token's smallest unit) to the
+ * absolute amount that recipient would receive.
+ *
+ * Returns a string representation of a BigInt-compatible integer.
+ *
+ * @example bpsToAbsolute(5000, "100000000") → "50000000"
+ */
+export function bpsToAbsolute(bps: number | BigNumber, totalAmount: bigint | string): string {
+    const n = new BigNumber(bps);
+    const total = new BigNumber(totalAmount.toString());
+    return n
+        .multipliedBy(total)
+        .dividedBy(BPS_TOTAL)
+        .integerValue(BigNumber.ROUND_FLOOR)
+        .toFixed(0);
+}
+
+/**
+ * Convert an absolute token amount to basis points given a totalAmount.
+ *
+ * Result is rounded to nearest integer BPS.
+ *
+ * @throws {RangeError} if the resulting BPS would exceed 10 000.
+ */
+export function absoluteToBps(absolute: bigint | string, totalAmount: bigint | string): number {
+    const abs = new BigNumber(absolute.toString());
+    const total = new BigNumber(totalAmount.toString());
+    if (total.isZero()) throw new RangeError("absoluteToBps: totalAmount must be > 0");
+
+    // Check before calculation to avoid silent acceptance
+    if (abs.isGreaterThan(total)) {
+        throw new RangeError(
+            `absoluteToBps: absolute amount ${absolute} exceeds totalAmount ${totalAmount}. ` +
+            "absolute amount cannot exceed totalAmount."
+        );
+    }
+
+    const bps = abs.dividedBy(total).multipliedBy(BPS_TOTAL).integerValue(BigNumber.ROUND_ROUND);
+    if (bps.isGreaterThan(BPS_TOTAL)) {
+        throw new RangeError(
+            `absoluteToBps: computed ${bps.toFixed(0)} BPS exceeds 10 000 (100 %). ` +
+            "absolute amount cannot exceed totalAmount."
+        );
+    }
+    return bps.toNumber();
+}
+
+/**
+ * Enrich a single DisbursementEntry with computed display fields.
+ */
+export function enrichEntry(
+    entry: DisbursementEntry,
+    totalAmount: bigint | string
+): EnrichedEntry {
+    const bpsRaw = new BigNumber(entry.share_bps);
+    const absoluteRaw = new BigNumber(bpsToAbsolute(bpsRaw, totalAmount));
+    return {
+        ...entry,
+        percentageDisplay: bpsToPercentage(bpsRaw),
+        absoluteDisplay: absoluteRaw.toFixed(0),
+        _bpsRaw: bpsRaw,
+        _absoluteRaw: absoluteRaw,
+    };
+}
+
+/**
+ * Recalculate an entire disbursement list, enriching every entry and computing
+ * the remainder watcher values.
+ *
+ * @param entries   Raw entries (address + share_bps).
+ * @param totalAmount  Total to distribute in smallest token unit.
+ */
+export function calcDisbursementList(
+    entries: DisbursementEntry[],
+    totalAmount: bigint | string
+): DisbursementCalcResult {
+    const enriched = entries.map((e) => enrichEntry(e, totalAmount));
+
+    const bpsSum = enriched.reduce((acc, e) => acc + e.share_bps, 0);
+    const bpsRemainder = bpsSum - 10_000;
+
+    const remainderPct = new BigNumber(bpsRemainder)
+        .dividedBy(BPS_TOTAL)
+        .multipliedBy(100)
+        .toFixed(PCT_DP);
+
+    const allocatedAbsolute = enriched
+        .reduce((acc, e) => acc.plus(e._absoluteRaw), new BigNumber(0))
+        .toFixed(0);
+
+    const unallocatedAbsolute = new BigNumber(totalAmount.toString())
+        .minus(allocatedAbsolute)
+        .toFixed(0);
+
+    return {
+        entries: enriched,
+        bpsSum,
+        bpsRemainder,
+        remainderPct,
+        isValid: bpsRemainder === 0,
+        allocatedAbsolute,
+        unallocatedAbsolute,
+    };
+}
+
+/**
+ * Update a single entry's share when the user types a new percentage in the UI.
+ *
+ * Returns a fresh DisbursementEntry with the updated share_bps.
+ * Does NOT modify the passed entry or the list — callers must rebuild.
+ *
+ * @param entry       Entry to update.
+ * @param newPct      User-supplied percentage string (e.g. "33.33").
+ */
+export function updateEntryByPercentage(
+    entry: DisbursementEntry,
+    newPct: string
+): DisbursementEntry {
+    return { ...entry, share_bps: percentageToBps(newPct) };
+}
+
+/**
+ * Update a single entry's share when the user types a new absolute amount.
+ *
+ * @param entry        Entry to update.
+ * @param newAbsolute  User-supplied absolute token string (e.g. "50000000").
+ * @param totalAmount  Total to distribute (reference for BPS back-conversion).
+ */
+export function updateEntryByAbsolute(
+    entry: DisbursementEntry,
+    newAbsolute: string,
+    totalAmount: bigint | string
+): DisbursementEntry {
+    return { ...entry, share_bps: absoluteToBps(newAbsolute, totalAmount) };
+}
+
+/**
+ * Redistribute any BPS remainder across recipients proportionally so the list
+ * sums to exactly 10 000.
+ *
+ * Uses the "largest remainder method" to preserve proportions and avoid
+ * penny-off errors.
+ *
+ * @param entries   Entries whose share_bps to normalise.
+ * @returns         New entries with adjusted share_bps.
+ */
+export function normaliseShares(entries: DisbursementEntry[]): DisbursementEntry[] {
+    if (entries.length === 0) return [];
+
+    const totalRaw = entries.reduce((acc, e) => acc + e.share_bps, 0);
+    if (totalRaw === 0) return entries;
+
+    // Compute exact fractional BPS for each entry.
+    const scaled = entries.map((e) => {
+        const exact = new BigNumber(e.share_bps)
+            .dividedBy(totalRaw)
+            .multipliedBy(BPS_TOTAL);
+        return {
+            entry: e,
+            exact,
+            floor: exact.integerValue(BigNumber.ROUND_FLOOR).toNumber(),
+            remainder: exact.minus(exact.integerValue(BigNumber.ROUND_FLOOR)).toNumber(),
+        };
+    });
+
+    const floorSum = scaled.reduce((acc, s) => acc + s.floor, 0);
+    let toDistribute = 10_000 - floorSum;
+
+    // Sort by descending fractional remainder, distribute 1 BPS at a time.
+    scaled.sort((a, b) => b.remainder - a.remainder);
+    const result = scaled.map((s, i) => ({
+        ...s.entry,
+        share_bps: s.floor + (i < toDistribute ? 1 : 0),
+    }));
+
+    return result;
+}
+
+export type RemainderSeverity = "ok" | "warning" | "error";
+
+export interface RemainderWarning {
+    severity: RemainderSeverity;
+    /** Short message suitable for an inline badge. */
+    label: string;
+    /** Full message for a tooltip / alert body. */
+    detail: string;
+}
+
+/**
+ * Analyse the current BPS sum and return a structured warning for the UI.
+ *
+ * Severity levels:
+ *   ok      — sums to exactly 10 000 (valid)
+ *   warning — within ±1 BPS (rounding artifact; can auto-fix)
+ *   error   — difference > 1 BPS (user must intervene)
+ */
+export function getRemainderWarning(bpsSum: number): RemainderWarning {
+    const diff = bpsSum - 10_000;
+
+    if (diff === 0) {
+        return {
+            severity: "ok",
+            label: "100 %",
+            detail: "All shares are correctly allocated.",
+        };
+    }
+
+    const pct = new BigNumber(Math.abs(diff))
+        .dividedBy(BPS_TOTAL)
+        .multipliedBy(100)
+        .toFixed(PCT_DP);
+
+    const direction = diff > 0 ? "over" : "under";
+    const absDiff = Math.abs(diff);
+
+    if (absDiff <= 1) {
+        return {
+            severity: "warning",
+            label: `${direction === "over" ? "+" : "-"}${pct} %`,
+            detail:
+                `Shares are ${direction}-allocated by ${absDiff} basis point (${pct} %). ` +
+                "This is likely a rounding artifact. Use auto-normalise to fix.",
+        };
+    }
+
+    return {
+        severity: "error",
+        label: `${direction === "over" ? "+" : "-"}${pct} % unallocated`,
+        detail:
+            `Shares are ${direction}-allocated by ${absDiff} basis points (${pct} %). ` +
+            "Adjust individual entries or use auto-normalise before submitting.",
+    };
+}
+
+/**
+ * Convert a human-readable token amount (e.g. "100.50" USDC with 6 decimals)
+ * to the raw i128 smallest-unit string expected by the contract.
+ *
+ * @param humanAmount  Display amount (e.g. "100.50").
+ * @param decimals     Token precision (USDC = 6, XLM = 7).
+ * @returns            Integer string for use in prepareSplitTransaction.
+ */
+export function humanToI128(humanAmount: string, decimals: number): string {
+    let n: BigNumber;
+    try {
+        n = new BigNumber(humanAmount);
+    } catch (error) {
+        throw new RangeError(`humanToI128: "${humanAmount}" is not a valid positive amount`);
+    }
+    if (n.isNaN() || n.isNegative()) {
+        throw new RangeError(`humanToI128: "${humanAmount}" is not a valid positive amount`);
+    }
+    return n
+        .multipliedBy(new BigNumber(10).pow(decimals))
+        .integerValue(BigNumber.ROUND_FLOOR)
+        .toFixed(0);
+}
+
+/**
+ * Convert a raw i128 string back to a human-readable display amount.
+ *
+ * @param raw       Integer string (e.g. "100500000").
+ * @param decimals  Token precision.
+ * @param dp        Display decimal places (default = decimals).
+ */
+export function i128ToHuman(raw: string | bigint, decimals: number, dp?: number): string {
+    const n = new BigNumber(raw.toString());
+    return n
+        .dividedBy(new BigNumber(10).pow(decimals))
+        .toFixed(dp ?? decimals);
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@stellar/freighter-api": "^6.0.1",
         "@stellar/stellar-sdk": "^14.6.1",
         "@types/papaparse": "^5.5.2",
+        "bignumber.js": "^10.0.2",
         "boring-avatars": "^2.0.4",
         "framer-motion": "^12.34.2",
         "jspdf": "^4.2.1",
@@ -30,6 +31,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
+        "@types/bignumber.js": "^4.0.3",
         "@types/d3-array": "^3.2.2",
         "@types/d3-color": "^3.1.3",
         "@types/d3-ease": "^3.0.2",
@@ -2155,6 +2157,15 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@stellar/stellar-sdk/node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -2473,6 +2484,13 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/bignumber.js": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/bignumber.js/-/bignumber.js-4.0.3.tgz",
+      "integrity": "sha512-KoJPKjhlWBry4fk8qcIufXFOU+zcZBfkHQWKbnAMQTMoe2GDeLpjSQHS+22gv+dg7gKdTP2WCjSeCVnfj8e+Gw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -2621,7 +2639,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2632,7 +2649,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2695,7 +2711,6 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -3352,7 +3367,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3757,13 +3771,10 @@
       }
     },
     "node_modules/bignumber.js": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
-      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-10.0.2.tgz",
+      "integrity": "sha512-E8Wp9O06QA6lneJ4aRUXKYf/1GIomqUEmUMwtIOMtDxf1U52ffJY+y7JBk/8wRafA8qOIqLnXQGqonYXZdBnFQ==",
+      "license": "MIT"
     },
     "node_modules/boring-avatars": {
       "version": "2.0.4",
@@ -4655,7 +4666,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4829,7 +4839,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7493,7 +7502,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7503,7 +7511,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7555,7 +7562,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -7677,8 +7683,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -8638,7 +8643,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8849,7 +8853,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9024,7 +9027,6 @@
       "integrity": "sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.3",
@@ -9377,7 +9379,6 @@
       "integrity": "sha512-yF+o4POL41rpAzj5KVILUxm1GCjKnELvaqmU9TLLUbMfDzuN0UpUR9uaDs+mCtjPe+uYPksXDRLQGGPvj1cTmA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.1",
         "@vitest/mocker": "4.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@stellar/freighter-api": "^6.0.1",
     "@stellar/stellar-sdk": "^14.6.1",
     "@types/papaparse": "^5.5.2",
+    "bignumber.js": "^10.0.2",
     "boring-avatars": "^2.0.4",
     "framer-motion": "^12.34.2",
     "jspdf": "^4.2.1",
@@ -32,6 +33,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@types/bignumber.js": "^4.0.3",
     "@types/d3-array": "^3.2.2",
     "@types/d3-color": "^3.1.3",
     "@types/d3-ease": "^3.0.2",


### PR DESCRIPTION
## Problem
The disbursement UI stored raw share_bps integers but had no safe way to convert user-typed percentages or absolute amounts into those integers. Native JS float arithmetic (e.g. 33.33 * 3 = 99.99000000000001) produced silent drift that would cause on-chain rejections when the BPS sum didn't equal exactly 10 000.

## Solution
This PR introduces disbursement-math.ts, a self-contained BigNumber.js utility that owns all BPS ↔ percentage ↔ i128-absolute conversions. It also ships a getRemainderWarning "Remainder Watcher" that drives the badge shown in the disbursement UI, and a normaliseShares helper using the largest-remainder method to auto-fix rounding gaps across up to 240 recipients.

## Testing
30 Vitest unit tests including a dedicated floating-point regression suite. Run with npx vitest run disbursement-math.test.ts.
Integration notes

## Related Issue 
Closes #669 

## Screenshot
<img width="835" height="627" alt="0" src="https://github.com/user-attachments/assets/a66c6269-6af4-4eb8-8a1d-4a982ea0b63e" />
