### PR TITLE
[Frontend] Feature: "Organization-Avatar" Branding UI

### DIFF
--- a/frontend/app/api/v3/org/logo/upload/route.ts
+++ b/frontend/app/api/v3/org/logo/upload/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+
+interface UploadLogoPayload {
+  orgId: string;
+  fileName: string;
+  mimeType: string;
+  fileData: string;
+  provider: "s3" | "ipfs";
+}
+
+export async function POST(req: NextRequest) {
+  const body = (await req.json()) as UploadLogoPayload;
+
+  if (!body.orgId || !body.fileData || !body.provider) {
+    return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+  }
+
+  if (!body.fileData.startsWith("data:image/")) {
+    return NextResponse.json({ error: "Only image uploads are supported" }, { status: 400 });
+  }
+
+  // Demo storage strategy:
+  // - S3 mode returns a stable CDN-like URL pattern.
+  // - IPFS mode returns an ipfs:// URI.
+  // For local frontend demo purposes, we keep the data URL as a renderable fallback.
+  const hash = Buffer.from(`${body.orgId}:${body.fileName}:${Date.now()}`).toString("base64url");
+  const logoUrl =
+    body.provider === "ipfs"
+      ? `ipfs://${hash}`
+      : `https://cdn.stellarstream.local/orgs/${encodeURIComponent(body.orgId)}/logo/${hash}`;
+
+  return NextResponse.json(
+    {
+      ok: true,
+      provider: body.provider,
+      logoUrl,
+      previewUrl: body.fileData,
+      mimeType: body.mimeType,
+    },
+    { status: 201 },
+  );
+}

--- a/frontend/app/api/v3/org/metadata/route.ts
+++ b/frontend/app/api/v3/org/metadata/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getOrganizationMetadata, setOrganizationMetadata } from "@/lib/server/org-metadata-store";
+
+interface UpsertOrgMetadataPayload {
+  orgId: string;
+  logo_url?: string;
+  logo_provider?: "s3" | "ipfs";
+  logo_preview_url?: string;
+}
+
+export async function GET(req: NextRequest) {
+  const orgId = req.nextUrl.searchParams.get("orgId");
+
+  if (!orgId) {
+    return NextResponse.json({ error: "orgId is required" }, { status: 400 });
+  }
+
+  const metadata = getOrganizationMetadata(orgId);
+  return NextResponse.json({ ok: true, metadata });
+}
+
+export async function PUT(req: NextRequest) {
+  const body = (await req.json()) as UpsertOrgMetadataPayload;
+
+  if (!body.orgId) {
+    return NextResponse.json({ error: "orgId is required" }, { status: 400 });
+  }
+
+  const metadata = setOrganizationMetadata(body.orgId, {
+    logo_url: body.logo_preview_url || body.logo_url,
+    logo_provider: body.logo_provider,
+  });
+
+  return NextResponse.json({ ok: true, metadata }, { status: 200 });
+}

--- a/frontend/app/dashboard/settings/page.tsx
+++ b/frontend/app/dashboard/settings/page.tsx
@@ -2,6 +2,7 @@
 
 import SecurityPrivacyPage from "@/components/settings/SecurityPrivacyPage";
 import GasManagementTile from "@/components/settings/GasManagementTile";
+import { OrganizationAvatarBrandingCard } from "@/components/settings/OrganizationAvatarBrandingCard";
 
 export default function SettingsPage() {
   return (
@@ -19,6 +20,9 @@ export default function SettingsPage() {
           Manage wallet profile, notifications, and governance-related defaults.
         </p>
       </section>
+
+      {/* ── Organization Branding (#797) ── */}
+      <OrganizationAvatarBrandingCard />
 
       {/* ── Gas Management (#683) ── */}
       <GasManagementTile />

--- a/frontend/components/settings/OrganizationAvatarBrandingCard.tsx
+++ b/frontend/components/settings/OrganizationAvatarBrandingCard.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const DEFAULT_ORG_ID = "demo-org";
+
+type StorageProvider = "s3" | "ipfs";
+
+export function OrganizationAvatarBrandingCard() {
+  const [orgId] = useState(DEFAULT_ORG_ID);
+  const [provider, setProvider] = useState<StorageProvider>("s3");
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string>("");
+  const [logoUrl, setLogoUrl] = useState<string>("");
+  const [isUploading, setIsUploading] = useState(false);
+  const [status, setStatus] = useState<string>("");
+
+  useEffect(() => {
+    const loadMetadata = async () => {
+      try {
+        const resp = await fetch(`/api/v3/org/metadata?orgId=${encodeURIComponent(orgId)}`);
+        if (!resp.ok) return;
+
+        const body = (await resp.json()) as {
+          metadata: {
+            logo_url?: string;
+            logo_provider?: StorageProvider;
+          } | null;
+        };
+
+        if (body.metadata?.logo_url) {
+          setPreviewUrl(body.metadata.logo_url);
+          setLogoUrl(body.metadata.logo_url);
+        }
+
+        if (body.metadata?.logo_provider) {
+          setProvider(body.metadata.logo_provider);
+        }
+      } catch (error) {
+        console.error("[OrganizationAvatarBrandingCard] failed to load metadata", error);
+      }
+    };
+
+    loadMetadata();
+  }, [orgId]);
+
+  const handleFileChange = async (file: File | null) => {
+    setSelectedFile(file);
+    setStatus("");
+
+    if (!file) {
+      setPreviewUrl("");
+      return;
+    }
+
+    if (!file.type.startsWith("image/")) {
+      setStatus("Please select an image file.");
+      return;
+    }
+
+    const dataUrl = await toDataUrl(file);
+    setPreviewUrl(dataUrl);
+  };
+
+  const handleUpload = async () => {
+    if (!selectedFile || !previewUrl) {
+      setStatus("Select a logo file first.");
+      return;
+    }
+
+    setIsUploading(true);
+    setStatus("Uploading logo...");
+
+    try {
+      const uploadResp = await fetch("/api/v3/org/logo/upload", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          orgId,
+          fileName: selectedFile.name,
+          mimeType: selectedFile.type,
+          fileData: previewUrl,
+          provider,
+        }),
+      });
+
+      if (!uploadResp.ok) {
+        throw new Error(`Upload failed (${uploadResp.status})`);
+      }
+
+      const uploadBody = (await uploadResp.json()) as {
+        logoUrl: string;
+        previewUrl: string;
+        provider: StorageProvider;
+      };
+
+      const metadataResp = await fetch("/api/v3/org/metadata", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          orgId,
+          logo_url: uploadBody.logoUrl,
+          logo_preview_url: uploadBody.previewUrl,
+          logo_provider: uploadBody.provider,
+        }),
+      });
+
+      if (!metadataResp.ok) {
+        throw new Error(`Metadata update failed (${metadataResp.status})`);
+      }
+
+      setLogoUrl(uploadBody.logoUrl);
+      setStatus("Organization avatar saved. New split-links will show this branding.");
+    } catch (error) {
+      console.error("[OrganizationAvatarBrandingCard] upload failed", error);
+      setStatus("Failed to upload logo. Please try again.");
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-white/[0.04] p-6 backdrop-blur-xl md:p-8">
+      <p className="font-body text-xs tracking-[0.12em] text-white/60 uppercase">Organization Branding</p>
+      <h2 className="font-heading mt-2 text-2xl md:text-3xl">Organization Avatar</h2>
+      <p className="font-body mt-3 text-sm text-white/60">
+        Upload a logo shown on split-links shared with recipients. Stored in organization metadata as <code>logo_url</code>.
+      </p>
+
+      <div className="mt-6 grid gap-4 md:grid-cols-[220px_1fr]">
+        <div className="flex h-40 items-center justify-center rounded-2xl border border-dashed border-white/20 bg-black/20">
+          {previewUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={previewUrl} alt="Organization logo preview" className="h-full w-full rounded-2xl object-cover" />
+          ) : (
+            <span className="text-xs text-white/40">Logo preview</span>
+          )}
+        </div>
+
+        <div className="space-y-4">
+          <label className="block text-sm text-white/80">
+            Storage Provider
+            <select
+              value={provider}
+              onChange={(e) => setProvider(e.target.value as StorageProvider)}
+              className="mt-2 w-full rounded-xl border border-white/15 bg-black/40 px-3 py-2 text-sm"
+            >
+              <option value="s3">S3</option>
+              <option value="ipfs">IPFS</option>
+            </select>
+          </label>
+
+          <label className="block text-sm text-white/80">
+            Logo File
+            <input
+              type="file"
+              accept="image/*"
+              onChange={(e) => handleFileChange(e.target.files?.[0] ?? null)}
+              className="mt-2 block w-full text-sm text-white/70 file:mr-3 file:rounded-lg file:border-0 file:bg-cyan-400/20 file:px-3 file:py-2 file:text-cyan-200"
+            />
+          </label>
+
+          <button
+            type="button"
+            onClick={handleUpload}
+            disabled={isUploading || !selectedFile}
+            className="rounded-xl bg-cyan-400 px-4 py-2 text-sm font-semibold text-black transition hover:bg-cyan-300 disabled:opacity-50"
+          >
+            {isUploading ? "Uploading..." : "Upload Organization Avatar"}
+          </button>
+
+          {logoUrl && <p className="text-xs text-white/40 break-all">Stored logo_url: {logoUrl}</p>}
+          {status && <p className="text-sm text-cyan-200">{status}</p>}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function toDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result ?? ""));
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}

--- a/frontend/components/view-stream-client.tsx
+++ b/frontend/components/view-stream-client.tsx
@@ -25,6 +25,11 @@ export interface StreamData {
   startTime: string; // ISO string — serialisable across server→client boundary
   endTime: string;
   apy?: number;
+  organization?: {
+    id: string;
+    name: string;
+    logo_url?: string;
+  };
 }
 
 // ─── Live counter ─────────────────────────────────────────────────────────────
@@ -64,7 +69,15 @@ export function ViewStreamClient({ stream }: { stream: StreamData }) {
       className="glass-card max-w-lg w-full mx-auto p-8 space-y-6"
     >
       {/* Verified Badge Header */}
-      <div className="flex justify-center -mt-12 mb-8">
+      <div className="flex flex-col items-center justify-center -mt-12 mb-8 gap-3">
+        {stream.organization?.logo_url && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={stream.organization.logo_url}
+            alt={`${stream.organization.name} logo`}
+            className="h-14 w-14 rounded-2xl border border-white/20 object-cover shadow-[0_0_24px_rgba(0,245,255,0.2)]"
+          />
+        )}
         <VerifiedNebulaBadge />
       </div>
 

--- a/frontend/lib/fetch-public-stream.ts
+++ b/frontend/lib/fetch-public-stream.ts
@@ -1,5 +1,6 @@
 import { Contract, rpc as SorobanRpc, scValToNative, xdr } from "@stellar/stellar-sdk";
 import type { StreamData } from "@/components/view-stream-client";
+import { getOrganizationMetadata } from "@/lib/server/org-metadata-store";
 
 const RPC_URL = process.env.NEXT_PUBLIC_RPC_URL || "https://soroban-rpc.stellar.org";
 const CONTRACT_ID = process.env.NEXT_PUBLIC_NEBULA_CONTRACT_ID || process.env.NEXT_PUBLIC_CONTRACT_ID || "";
@@ -40,6 +41,9 @@ export async function fetchPublicStream(streamId: string): Promise<StreamData | 
     await new Promise(resolve => setTimeout(resolve, 800));
 
     // Mock response that would normally come from scValToNative(result.retval)
+    const orgId = "demo-org";
+    const orgMetadata = getOrganizationMetadata(orgId);
+
     return {
       id: streamId,
       name: `Stream #${streamId.slice(0, 4)}`,
@@ -52,6 +56,11 @@ export async function fetchPublicStream(streamId: string): Promise<StreamData | 
       receiver: "GA3...9R1T",
       startTime: new Date(Date.now() - 1000 * 60 * 60 * 24 * 7).toISOString(),
       endTime: new Date(Date.now() + 1000 * 60 * 60 * 24 * 14).toISOString(),
+      organization: {
+        id: orgId,
+        name: "Demo Organization",
+        logo_url: orgMetadata?.logo_url,
+      },
     };
   } catch (error) {
     console.error("Error fetching public stream:", error);

--- a/frontend/lib/server/org-metadata-store.ts
+++ b/frontend/lib/server/org-metadata-store.ts
@@ -1,0 +1,41 @@
+export interface OrganizationMetadata {
+  orgId: string;
+  logo_url?: string;
+  logo_provider?: "s3" | "ipfs";
+  updatedAt: string;
+}
+
+type OrgMetadataStore = Map<string, OrganizationMetadata>;
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __orgMetadataStore: OrgMetadataStore | undefined;
+}
+
+function getStore(): OrgMetadataStore {
+  if (!globalThis.__orgMetadataStore) {
+    globalThis.__orgMetadataStore = new Map<string, OrganizationMetadata>();
+  }
+
+  return globalThis.__orgMetadataStore;
+}
+
+export function getOrganizationMetadata(orgId: string): OrganizationMetadata | null {
+  return getStore().get(orgId) ?? null;
+}
+
+export function setOrganizationMetadata(
+  orgId: string,
+  patch: Partial<Omit<OrganizationMetadata, "orgId" | "updatedAt">>,
+): OrganizationMetadata {
+  const current = getStore().get(orgId);
+  const next: OrganizationMetadata = {
+    orgId,
+    logo_url: patch.logo_url ?? current?.logo_url,
+    logo_provider: patch.logo_provider ?? current?.logo_provider,
+    updatedAt: new Date().toISOString(),
+  };
+
+  getStore().set(orgId, next);
+  return next;
+}


### PR DESCRIPTION
closes #797 


Description
Added a new settings UI OrganizationAvatarBrandingCard that lets admins pick an image, choose s3 or ipfs, preview the image, and trigger an upload flow.
Implemented POST /api/v3/org/logo/upload which validates image payloads and returns a mocked provider-specific logoUrl plus a previewUrl for frontend rendering.
Implemented GET and PUT /api/v3/org/metadata backed by a lightweight in-memory store at frontend/lib/server/org-metadata-store.ts to read and write logo_url and logo_provider.
Wired branding into the public stream path by attaching organization metadata in fetch-public-stream.ts and rendering the organization.logo_url in ViewStreamClient so the logo appears on shared stream/split-link pages.
Testing
Ran lint with cd frontend && npm run lint, which completed successfully.
Attempted a production build with cd frontend && npm run build, which failed due to environment/project issues unrelated to this change (Google Fonts fetch blocked in the environment and a pre-existing module resolution error for @stellar/stellar-sdk/lib/rpc), so build failure is not caused by the new feature.
Manual dev flow validated: uploading an image via the new settings card returns a preview and the PUT /api/v3/org/metadata persists the in-memory logo_url used by the public stream preview.