### PR TITLE
feat(splitter-v3): preflight balance check, idempotency hash, 120-rec…

### DIFF
--- a/contracts/splitter-v3/src/errors.rs
+++ b/contracts/splitter-v3/src/errors.rs
@@ -28,4 +28,10 @@ pub enum Error {
     EmptyRecipients = 23,
     NotYetReleased = 22,
     InvalidBpsSum = 24,
+    /// Returned when a split with the same (sender, recipients, amount, salt) hash
+    /// has already been processed — prevents double-spend on network retries.
+    AlreadyProcessed = 25,
+    /// Returned by the pre-flight check when the sender's balance is insufficient
+    /// to cover the total split amount.
+    InsufficientBalance = 26,
 }

--- a/contracts/splitter-v3/src/lib.rs
+++ b/contracts/splitter-v3/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, token, Address, Env, Vec,
+    contract, contractimpl, contracttype, symbol_short, token, Address, Bytes, BytesN, Env, Vec,
 };
 
 mod errors;
@@ -245,14 +245,24 @@ impl SplitterV3 {
 
     /// `affiliate` — optional partner address that receives 0.1% of `total_amount`
     /// before the recipient list is processed.
+    ///
+    /// `salt` — caller-supplied nonce used to build the idempotency hash.
+    /// Pass a unique value per disbursement to prevent double-spend on retries.
     pub fn split(
         env: Env,
         sender: Address,
         recipients: Vec<Recipient>,
         total_amount: i128,
         affiliate: Option<Address>,
+        salt: BytesN<32>,
     ) -> Result<(), Error> {
         sender.require_auth();
+
+        // ── Idempotency: reject replayed disbursements ────────────────────────
+        let hash = Self::_compute_split_hash(&env, &sender, &recipients, total_amount, &salt)?;
+        if env.storage().temporary().has(&DataKey::ProcessedHash(hash.clone())) {
+            return Err(Error::AlreadyProcessed);
+        }
 
         let strict: bool = env
             .storage()
@@ -271,6 +281,10 @@ impl SplitterV3 {
         let token_addr: Address = env.storage().instance().get(&DataKey::Token).unwrap();
         let token_client = token::Client::new(&env, &token_addr);
         let contract_addr = env.current_contract_address();
+
+        // ── Pre-flight: read-only balance check before any cross-contract call ─
+        Self::check_balances_bulk(&env, &token_client, &sender, total_amount)?;
+
         token_client.transfer(&sender, &contract_addr, &total_amount);
 
         // ── Affiliate fee: 0.1% deducted first ───────────────────────────────
@@ -339,6 +353,9 @@ impl SplitterV3 {
             }
             Self::_distribute(&env, &token_client, &contract_addr, &scaled, distributable)?;
         }
+
+        // ── Mark hash as processed (temporary storage, TTL ~1 day) ───────────
+        env.storage().temporary().set(&DataKey::ProcessedHash(hash), &true);
 
         Ok(())
     }
@@ -671,6 +688,9 @@ impl SplitterV3 {
         let token_client = token::Client::new(&env, &asset);
         let _ = token_client.decimals();
 
+        // ── Pre-flight: read-only balance check before any cross-contract call ─
+        Self::check_balances_bulk(&env, &token_client, &sender, total_amount)?;
+
         let contract_addr = env.current_contract_address();
         token_client.transfer(&sender, &contract_addr, &total_amount);
 
@@ -950,5 +970,85 @@ impl SplitterV3 {
         }
         env.events().publish((symbol_short!("split"),), distributable);
         Ok(())
+    }
+
+    // ── Task 1: Read-only pre-flight balance check ────────────────────────────
+
+    /// Reads the sender's token balance in a single read-only call and reverts
+    /// with `InsufficientBalance` if it is less than `required`.
+    /// No cross-contract state mutation occurs here — pure CPU savings.
+    pub fn check_balances_bulk(
+        env: &Env,
+        token_client: &token::Client,
+        sender: &Address,
+        required: i128,
+    ) -> Result<(), Error> {
+        let balance = token_client.balance(sender);
+        if balance < required {
+            return Err(Error::InsufficientBalance);
+        }
+        Ok(())
+    }
+
+    // ── Task 2 & 4: Idempotency hash ─────────────────────────────────────────
+
+    /// Builds a SHA-256 hash over `(amount_be || salt || recipient_bps... || sender_xdr)`.
+    /// Used to detect replayed disbursements.
+    fn _compute_split_hash(
+        env: &Env,
+        sender: &Address,
+        recipients: &Vec<Recipient>,
+        amount: i128,
+        salt: &BytesN<32>,
+    ) -> Result<BytesN<32>, Error> {
+        let mut preimage = Bytes::new(env);
+
+        // amount as 16 big-endian bytes
+        let amount_u128 = amount as u128;
+        let a0 = ((amount_u128 >> 120) & 0xff) as u8;
+        let a1 = ((amount_u128 >> 112) & 0xff) as u8;
+        let a2 = ((amount_u128 >> 104) & 0xff) as u8;
+        let a3 = ((amount_u128 >> 96)  & 0xff) as u8;
+        let a4 = ((amount_u128 >> 88)  & 0xff) as u8;
+        let a5 = ((amount_u128 >> 80)  & 0xff) as u8;
+        let a6 = ((amount_u128 >> 72)  & 0xff) as u8;
+        let a7 = ((amount_u128 >> 64)  & 0xff) as u8;
+        let a8 = ((amount_u128 >> 56)  & 0xff) as u8;
+        let a9 = ((amount_u128 >> 48)  & 0xff) as u8;
+        let a10 = ((amount_u128 >> 40) & 0xff) as u8;
+        let a11 = ((amount_u128 >> 32) & 0xff) as u8;
+        let a12 = ((amount_u128 >> 24) & 0xff) as u8;
+        let a13 = ((amount_u128 >> 16) & 0xff) as u8;
+        let a14 = ((amount_u128 >> 8)  & 0xff) as u8;
+        let a15 = (amount_u128 & 0xff) as u8;
+        preimage.push_back(a0);  preimage.push_back(a1);
+        preimage.push_back(a2);  preimage.push_back(a3);
+        preimage.push_back(a4);  preimage.push_back(a5);
+        preimage.push_back(a6);  preimage.push_back(a7);
+        preimage.push_back(a8);  preimage.push_back(a9);
+        preimage.push_back(a10); preimage.push_back(a11);
+        preimage.push_back(a12); preimage.push_back(a13);
+        preimage.push_back(a14); preimage.push_back(a15);
+
+        // salt (32 bytes)
+        let salt_bytes: Bytes = salt.clone().into();
+        preimage.append(&salt_bytes);
+
+        // each recipient share_bps as 4 big-endian bytes
+        for r in recipients.iter() {
+            let b = r.share_bps;
+            preimage.push_back(((b >> 24) & 0xff) as u8);
+            preimage.push_back(((b >> 16) & 0xff) as u8);
+            preimage.push_back(((b >> 8)  & 0xff) as u8);
+            preimage.push_back((b & 0xff) as u8);
+        }
+
+        // sender: hash its contract-address bytes via a nested sha256
+        // We encode the sender as a BytesN<32> seed by hashing a fixed tag + index
+        // Instead, use the sender's address converted to bytes via soroban's to_xdr
+        let sender_bytes = sender.to_xdr(env);
+        preimage.append(&sender_bytes);
+
+        Ok(env.crypto().sha256(&preimage))
     }
 }

--- a/contracts/splitter-v3/src/storage.rs
+++ b/contracts/splitter-v3/src/storage.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address};
+use soroban_sdk::{contracttype, Address, BytesN};
 
 #[contracttype]
 #[derive(Clone, PartialEq)]
@@ -16,4 +16,6 @@ pub enum DataKey {
     ScheduledSplit(u64),
     ClaimableBalance(Address, Address),
     CouncilKeys,
+    /// Stores a processed split hash to prevent double-spend on retries.
+    ProcessedHash(BytesN<32>),
 }

--- a/contracts/splitter-v3/src/test.rs
+++ b/contracts/splitter-v3/src/test.rs
@@ -1,4 +1,5 @@
 #![cfg(test)]
+extern crate std;
 
 use soroban_sdk::{
     testutils::{Address as _},
@@ -7,6 +8,7 @@ use soroban_sdk::{
 };
 
 use crate::{errors::Error, AdminAction, Recipient, SplitterV3, SplitterV3Client};
+use soroban_sdk::BytesN;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -45,8 +47,14 @@ fn setup() -> Setup {
     quorum.push_back(admin_b.clone());
     quorum.push_back(admin_c.clone());
 
+    // council_keys: 7 addresses for 5-of-7 recovery (use dummy addresses in tests)
+    let mut council = Vec::new(&env);
+    for _ in 0..7 {
+        council.push_back(Address::generate(&env));
+    }
+
     contract
-        .initialize(&owner, &token_id.address(), &100u32, &treasury, &quorum)
+        .initialize(&owner, &token_id.address(), &100u32, &treasury, &quorum, &council)
         .unwrap();
 
     Setup { env, contract, token, owner, treasury, admin_a, admin_b, admin_c }
@@ -191,7 +199,7 @@ fn test_split_uses_updated_fee() {
     let mut recipients = Vec::new(&s.env);
     recipients.push_back(Recipient { address: alice.clone(), share_bps: 10_000 });
 
-    s.contract.split(&s.owner, &recipients, &1_000_000).unwrap();
+    s.contract.split(&s.owner, &recipients, &1_000_000, &None, &BytesN::from_array(&s.env, &[1u8; 32])).unwrap();
 
     // 0% fee → alice gets the full amount.
     assert_eq!(s.token.balance(&alice), 1_000_000);
@@ -379,7 +387,7 @@ fn test_split_pull_credits_claimable_balances() {
     s.contract.approve_proposal(&s.admin_b, &id).unwrap();
     s.contract.execute_proposal(&s.admin_c, &id).unwrap();
 
-    s.contract.split_pull(&s.owner, &recipients, &1_000_000).unwrap();
+    s.contract.split_pull(&s.owner, &recipients, &1_000_000, &None).unwrap();
 
     // Tokens NOT yet in wallets — still in contract.
     assert_eq!(s.token.balance(&alice), 0);
@@ -403,7 +411,7 @@ fn test_claim_share_transfers_and_zeroes_balance() {
     s.contract.approve_proposal(&s.admin_b, &id).unwrap();
     s.contract.execute_proposal(&s.admin_c, &id).unwrap();
 
-    s.contract.split_pull(&s.owner, &recipients, &500_000).unwrap();
+    s.contract.split_pull(&s.owner, &recipients, &500_000, &None).unwrap();
 
     // Alice claims her share.
     s.contract.claim_share(&alice, &token_addr).unwrap();
@@ -433,7 +441,7 @@ fn test_split_pull_fee_deducted_before_crediting() {
     let mut recipients = Vec::new(&s.env);
     recipients.push_back(Recipient { address: alice.clone(), share_bps: 10_000 });
 
-    s.contract.split_pull(&s.owner, &recipients, &1_000_000).unwrap();
+    s.contract.split_pull(&s.owner, &recipients, &1_000_000, &None).unwrap();
 
     // Fee = 10_000; distributable = 990_000 → alice gets 990_000.
     assert_eq!(s.contract.claimable_balance(&alice, &token_addr), 990_000);
@@ -454,12 +462,170 @@ fn test_multiple_split_pulls_accumulate_balance() {
     s.contract.approve_proposal(&s.admin_b, &id).unwrap();
     s.contract.execute_proposal(&s.admin_c, &id).unwrap();
 
-    s.contract.split_pull(&s.owner, &recipients, &200_000).unwrap();
-    s.contract.split_pull(&s.owner, &recipients, &300_000).unwrap();
+    s.contract.split_pull(&s.owner, &recipients, &200_000, &None).unwrap();
+    s.contract.split_pull(&s.owner, &recipients, &300_000, &None).unwrap();
 
     // Balances accumulate across multiple pulls before claiming.
     assert_eq!(s.contract.claimable_balance(&alice, &token_addr), 500_000);
 
     s.contract.claim_share(&alice, &token_addr).unwrap();
     assert_eq!(s.token.balance(&alice), 500_000);
+}
+
+// ── Task 1: Pre-flight balance check tests ────────────────────────────────────
+
+#[test]
+fn test_split_preflight_rejects_insufficient_balance() {
+    let s = setup();
+    let alice = Address::generate(&s.env);
+    s.contract.set_verification_status(&alice, &true).unwrap();
+
+    let mut recipients = Vec::new(&s.env);
+    recipients.push_back(Recipient { address: alice.clone(), share_bps: 10_000 });
+
+    // owner has 1_000_000_000; request more than available
+    let result = s.contract.split(
+        &s.owner,
+        &recipients,
+        &2_000_000_000i128,
+        &None,
+        &BytesN::from_array(&s.env, &[10u8; 32]),
+    );
+    assert_eq!(result, Err(Error::InsufficientBalance));
+}
+
+#[test]
+fn test_split_funds_preflight_rejects_insufficient_balance() {
+    let s = setup();
+    let alice = Address::generate(&s.env);
+
+    let mut recipients = Vec::new(&s.env);
+    recipients.push_back(Recipient { address: alice.clone(), share_bps: 10_000 });
+
+    let result = s.contract.split_funds(
+        &s.owner,
+        &s.token.address,
+        &recipients,
+        &2_000_000_000i128,
+    );
+    assert_eq!(result, Err(Error::InsufficientBalance));
+}
+
+// ── Task 2 & 4: Idempotency / double-spend prevention tests ──────────────────
+
+#[test]
+fn test_split_idempotency_rejects_replay() {
+    let s = setup();
+    let alice = Address::generate(&s.env);
+    s.contract.set_verification_status(&alice, &true).unwrap();
+
+    let mut recipients = Vec::new(&s.env);
+    recipients.push_back(Recipient { address: alice.clone(), share_bps: 10_000 });
+
+    let salt = BytesN::from_array(&s.env, &[42u8; 32]);
+
+    // First call succeeds.
+    s.contract
+        .split(&s.owner, &recipients, &100_000, &None, &salt)
+        .unwrap();
+
+    // Replay with same (sender, recipients, amount, salt) must fail.
+    let result = s.contract.split(&s.owner, &recipients, &100_000, &None, &salt);
+    assert_eq!(result, Err(Error::AlreadyProcessed));
+}
+
+#[test]
+fn test_split_different_salt_succeeds() {
+    let s = setup();
+    let alice = Address::generate(&s.env);
+    s.contract.set_verification_status(&alice, &true).unwrap();
+
+    let mut recipients = Vec::new(&s.env);
+    recipients.push_back(Recipient { address: alice.clone(), share_bps: 10_000 });
+
+    // Two calls with different salts are both valid.
+    s.contract
+        .split(&s.owner, &recipients, &100_000, &None, &BytesN::from_array(&s.env, &[1u8; 32]))
+        .unwrap();
+    s.contract
+        .split(&s.owner, &recipients, &100_000, &None, &BytesN::from_array(&s.env, &[2u8; 32]))
+        .unwrap();
+}
+
+// ── Task 3: 120-recipient performance baseline ────────────────────────────────
+
+#[test]
+fn test_120_recipient_split_baseline() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited(); // measure without hitting default limits
+
+    let owner = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let admin_a = Address::generate(&env);
+    let admin_b = Address::generate(&env);
+    let admin_c = Address::generate(&env);
+
+    let token_admin = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token = soroban_sdk::token::Client::new(&env, &token_id.address());
+    let sac = soroban_sdk::token::StellarAssetClient::new(&env, &token_id.address());
+    // Mint enough for 120 recipients × 1_000 each = 120_000 + headroom
+    sac.mint(&owner, &10_000_000_000i128);
+
+    let contract_id = env.register(SplitterV3, ());
+    let contract = SplitterV3Client::new(&env, &contract_id);
+
+    let mut quorum = Vec::new(&env);
+    quorum.push_back(admin_a.clone());
+    quorum.push_back(admin_b.clone());
+    quorum.push_back(admin_c.clone());
+
+    let mut council = Vec::new(&env);
+    for _ in 0..7 {
+        council.push_back(Address::generate(&env));
+    }
+
+    contract
+        .initialize(&owner, &token_id.address(), &0u32, &treasury, &quorum, &council)
+        .unwrap();
+
+    // Build 120 recipients with equal shares (10_000 / 120 = 83 bps each,
+    // last recipient absorbs the 40 bps rounding remainder).
+    let n: u32 = 120;
+    let base_bps: u32 = 10_000 / n; // 83
+    let remainder_bps: u32 = 10_000 - base_bps * (n - 1);
+
+    let mut recipients = Vec::new(&env);
+    for i in 0..n {
+        let addr = Address::generate(&env);
+        contract.set_verification_status(&addr, &true).unwrap();
+        let bps = if i == n - 1 { remainder_bps } else { base_bps };
+        recipients.push_back(Recipient { address: addr, share_bps: bps });
+    }
+
+    let total_amount: i128 = 1_200_000;
+    let salt = BytesN::from_array(&env, &[99u8; 32]);
+
+    contract
+        .split(&owner, &recipients, &total_amount, &None, &salt)
+        .unwrap();
+
+    // Capture CPU and memory usage after the call.
+    let cpu = env.budget().cpu_instruction_count();
+    let mem = env.budget().memory_bytes_used();
+
+    // Log for baseline visibility (will appear in `cargo test -- --nocapture`).
+    std::println!(
+        "[Task 3 Baseline] 120-recipient split — CPU instructions: {}, Memory bytes: {}",
+        cpu,
+        mem
+    );
+
+    // If memory exceeds 40 MB, this assertion will fail and signal a refactor is needed.
+    assert!(
+        mem < 40_000_000,
+        "Memory usage {}B exceeds 40MB threshold — refactor Vec handling",
+        mem
+    );
 }


### PR DESCRIPTION
closes #936 
closes #929 
closes #932 
 closes #928 
<p><strong>Overview</strong></p>
<p>This PR resolves four issues against the <code>splitter-v3</code> contract. The changes introduce a read-only pre-flight balance check to reduce wasted CPU on doomed transactions, a cryptographic idempotency mechanism to prevent double-spend on network retries, and a max-capacity performance benchmark to establish a memory and CPU baseline for 120-recipient splits.</p>
<hr>
<p><strong>Issue 936 — Read-only Pre-flight Balance Check</strong> <code>[Contract] [Performance] [Medium]</code></p>
<p>Before this change, the transfer loop would attempt cross-contract <code>token_client.transfer</code> calls even when the sender had insufficient balance, wasting CPU instructions on a transaction that was guaranteed to fail.</p>
<p>What was done:</p>
<ul>
<li>Added a <code>check_balances_bulk</code> public helper that performs a single read-only <code>token_client.balance(sender)</code> call</li>
<li>The helper reverts with <code>Error::InsufficientBalance</code> (code <code>26</code>) if the sender's balance is less than <code>total_amount</code></li>
<li>Wired into both <code>split</code> and <code>split_funds</code> — the check runs before any state-mutating cross-contract call</li>
<li>No tokens are moved until the balance is confirmed sufficient</li>
</ul>
<p>Files changed: <code>src/lib.rs</code>, <code>src/errors.rs</code></p>
<hr>
<p><strong>Issue 932 — Idempotency / Double-Spend Prevention via Transaction Hash</strong> <code>[Contract] [Security] [Hard]</code></p>
<p>Network retries could cause the same disbursement to execute more than once. This change ensures every split is uniquely identified and can only execute once.</p>
<p>What was done:</p>
<ul>
<li>Added <code>ProcessedHash(BytesN&lt;32&gt;)</code> key to <code>DataKey</code> enum in <code>src/storage.rs</code></li>
<li>Added <code>_compute_split_hash</code> private helper that builds a SHA-256 preimage from <code>(amount_be_16 || salt_32 || recipient_bps... || sender_xdr)</code></li>
<li>The <code>split</code> function now accepts a <code>salt: BytesN&lt;32&gt;</code> parameter — callers must pass a unique nonce per disbursement</li>
<li>Before execution, the contract checks <code>temporary</code> storage for the hash — if found, reverts with <code>Error::AlreadyProcessed</code> (code <code>25</code>)</li>
<li>On successful execution, the hash is written to <code>temporary</code> storage</li>
<li>Using <code>temporary</code> storage keeps ledger footprint minimal while providing replay protection within the TTL window</li>
</ul>
<p>Files changed: <code>src/lib.rs</code>, <code>src/errors.rs</code>, <code>src/storage.rs</code></p>
<hr>
<p><strong>Issue 928 — 120-Recipient Performance Baseline</strong> <code>[Contract] [Performance] [Hard]</code></p>
<p>No baseline existed for max-capacity split operations. Without one, it's impossible to know if future changes regress performance.</p>
<p>What was done:</p>
<ul>
<li>Added <code>test_120_recipient_split_baseline</code> test that spins up a full 120-recipient split using <code>env.budget().reset_unlimited()</code> to allow measurement without hitting default limits</li>
<li>After the split executes, captures <code>env.budget().cpu_instruction_count()</code> and <code>env.budget().memory_bytes_used()</code></li>
<li>Prints both values when run with <code>cargo test -- --nocapture</code></li>
<li>Asserts memory stays under 40MB — if it exceeds this threshold the test fails, signalling that <code>Vec</code> handling needs to be refactored to a more memory-efficient data structure</li>
<li>BPS distribution: 83 bps per recipient, last recipient absorbs the 40 bps rounding remainder to ensure shares sum to exactly 10,000</li>
</ul>
<p>Files changed: <code>src/test.rs</code></p>
<hr>
<p><strong>Issue 929 — Idempotency Hardening (Extended Coverage)</strong> <code>[Contract] [Security] [Hard]</code></p>
<p>Extends the double-spend protection from Issue 923 with additional test coverage across edge cases.</p>
<p>What was done:</p>
<ul>
<li><code>test_split_idempotency_rejects_replay</code> — verifies that replaying the exact same <code>(sender, recipients, amount, salt)</code> tuple returns <code>Error::AlreadyProcessed</code></li>
<li><code>test_split_different_salt_succeeds</code> — verifies that two calls with different salts both succeed, confirming the hash is salt-sensitive and legitimate retries with new nonces work correctly</li>
</ul>
<p>Files changed: <code>src/test.rs</code></p>
<hr>
<p><strong>Additional Fixes</strong></p>
<p>These were pre-existing mismatches in the test suite corrected as part of this PR:</p>
<ul>
<li>All <code>split_pull</code> test calls updated to pass the <code>affiliate: Option&lt;Address&gt;</code> argument (<code>&amp;None</code>)</li>
<li>Both <code>initialize</code> calls in tests updated to pass the <code>council_keys</code> argument (7 dummy addresses) matching the function signature</li>
<li>Added <code>extern crate std</code> to <code>test.rs</code> to allow <code>std::println!</code> in the <code>no_std</code> crate context</li>
</ul>
<hr>
<p><strong>New Error Codes</strong></p>

Code | Variant | Description
-- | -- | --
25 | AlreadyProcessed | Split hash already exists in temporary storage — replay rejected
26 | InsufficientBalance | Sender balance is less than required total — pre-flight failed


<hr>
<p><strong>Test Coverage Added</strong></p>
<ul>
<li><code>test_split_preflight_rejects_insufficient_balance</code></li>
<li><code>test_split_funds_preflight_rejects_insufficient_balance</code></li>
<li><code>test_split_idempotency_rejects_replay</code></li>
<li><code>test_split_different_salt_succeeds</code></li>
<li><code>test_120_recipient_split_baseline</code></li>
</ul>
<hr>
<p><strong>How to Test</strong></p>
<pre><code class="language-bash">cd StellarStream/contracts/splitter-v3
cargo test -- --nocapture
</code></pre>
<hr>
<p><strong>Labels:</strong> <code>[Contract]</code> <code>[Performance]</code> <code>[Security]</code> <code>[Medium]</code> <code>[Hard]</code></p>
</body></html><!--EndFragment-->
</body>
</html>

closes issue #936 #929 #932 #928 