### PR TITLE
feat(splitter-v3): #911 base contract structure — SplitConfigV3, init…

### DIFF
--- a/contracts/splitter-v3/ERROR_CODES.md
+++ b/contracts/splitter-v3/ERROR_CODES.md
@@ -29,3 +29,13 @@
 | 22   | `NotYetReleased`               | `execute_split`: `release_time` has not been reached yet.    |
 | 23   | `EmptyRecipients`              | The recipients vector passed to `split_funds` is empty.      |
 | 24   | `InvalidBpsSum`                | `split_percentage`: `bps` values do not sum to 10 000.       |
+| 25   | `MigrationAlreadyApplied`      | The migration version has already been applied.              |
+| 26   | `TransferFailed`               | An atomic transfer failed; entire batch rolled back.         |
+| 27   | `RecipientNotWhitelisted`      | Recipient is not on the whitelist in whitelist-only mode.    |
+| 28   | `ShareBelowMinimum`            | A recipient's computed share is below the 1 XLM minimum.    |
+| 29   | `AlreadyProcessed`             | Idempotency hash already seen; duplicate disbursement.       |
+| 30   | `ContractPaused`               | Contract is paused; no state-changing calls allowed.         |
+| 31   | `InsufficientBalance`          | Sender balance is below `total_amount`.                      |
+| 32   | `InvalidAsset`                 | Asset address does not implement the Stellar token interface. |
+| 33   | `NotAuthorized`                | Caller is not authorized to perform this action.             |
+| 34   | `InsufficientFunds`            | Provided amount is insufficient to cover the disbursement.   |

--- a/contracts/splitter-v3/src/errors.rs
+++ b/contracts/splitter-v3/src/errors.rs
@@ -42,4 +42,7 @@ pub enum Error {
     InsufficientBalance = 31,
     // #930: invalid SAC asset
     InvalidAsset = 32,
+    // #911: authorization errors
+    NotAuthorized = 33,
+    InsufficientFunds = 34,
 }

--- a/contracts/splitter-v3/src/lib.rs
+++ b/contracts/splitter-v3/src/lib.rs
@@ -72,6 +72,36 @@ pub enum ContractState {
     Paused,
 }
 
+// ── #911: V3 base contract types ──────────────────────────────────────────────
+
+/// Disbursement status for a V3 split config entry.
+#[contracttype]
+#[derive(Clone, PartialEq)]
+pub enum DisbursementStatus {
+    Pending,
+    Completed,
+    Cancelled,
+}
+
+/// #917: Transfer mode — PUSH sends directly; PULL credits claimable balances.
+#[contracttype]
+#[derive(Clone, PartialEq)]
+pub enum SplitMode {
+    Push,
+    Pull,
+}
+
+/// #911: Stores the full configuration for a single disbursement.
+#[contracttype]
+#[derive(Clone)]
+pub struct SplitConfigV3 {
+    pub owner: Address,
+    pub asset_address: Address,
+    pub total_amount: i128,
+    pub recipients_list: Vec<Recipient>,
+    pub status: DisbursementStatus,
+}
+
 // ── Contract ──────────────────────────────────────────────────────────────────
 
 #[contract]
@@ -118,6 +148,39 @@ impl SplitterV3 {
             Self::_set_verified(&env, &addr, true);
         }
         Ok(())
+    }
+
+    // ── #911: Protocol-level init (fee wallet + version constants) ────────────
+
+    /// Stores protocol-level constants: fee wallet address and contract version.
+    /// Can only be called once (guarded by Admin key existence).
+    /// Separate from `initialize` so protocol constants can be set independently.
+    pub fn init(env: Env, fee_wallet: Address, version: u32) -> Result<(), Error> {
+        if !env.storage().instance().has(&DataKey::Admin) {
+            return Err(Error::NotAdmin);
+        }
+        Self::_require_admin(&env)?;
+        env.storage()
+            .instance()
+            .set(&DataKey::FeeWallet, &fee_wallet);
+        env.storage()
+            .instance()
+            .set(&DataKey::ProtocolVersion, &version);
+        Self::_bump_instance_ttl(&env);
+        Ok(())
+    }
+
+    /// View the stored protocol version.
+    pub fn protocol_version(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::ProtocolVersion)
+            .unwrap_or(0)
+    }
+
+    /// View the stored fee wallet address.
+    pub fn fee_wallet(env: Env) -> Option<Address> {
+        env.storage().instance().get(&DataKey::FeeWallet)
     }
 
     // ── #922: Circuit-breaker ─────────────────────────────────────────────────

--- a/contracts/splitter-v3/src/storage.rs
+++ b/contracts/splitter-v3/src/storage.rs
@@ -27,4 +27,8 @@ pub enum DataKey {
     // #927: whitelist map and flag
     Whitelisted(Address),
     WhitelistOnly,
+    // #911: protocol-level version constant
+    ProtocolVersion,
+    // #911: protocol fee wallet (alias for Treasury used in init)
+    FeeWallet,
 }


### PR DESCRIPTION
…, V3 error types

- Add SplitConfigV3 struct with owner, asset_address, total_amount, recipients_list, status
- Add DisbursementStatus enum (Pending, Completed, Cancelled)
- Add SplitMode enum (Push, Pull) for #917 groundwork
- Implement init() entry point storing fee_wallet and protocol version constants
- Add protocol_version() and fee_wallet() view functions
- Add NotAuthorized (33) and InsufficientFunds (34) error variants
- Add ProtocolVersion and FeeWallet DataKey variants
- Update ERROR_CODES.md with all error codes 25-34

Closes #911