### PR TITLE
feat(splitter-v3): #921 standardized event emission via #[contractevent]

### DIFF
--- a/contracts/splitter-v3/src/events.rs
+++ b/contracts/splitter-v3/src/events.rs
@@ -1,0 +1,72 @@
+// #921: Standardized event emission for the V3 Splitter.
+//
+// Using #[contractevent] ensures events are ABI-typed and indexable by the
+// Backend Indexer (Phase 3) — critical for tracking internal fund movements
+// that don't appear as top-level transaction results.
+
+use soroban_sdk::{contractevent, Address, Env};
+
+/// Emitted once per successful `split_funds` / `split` call.
+/// Topics: ["splitter", "executed", sender_address]
+#[contractevent]
+pub struct SplitExecutedEvent {
+    /// Total amount disbursed in this split (after fees).
+    pub amount: i128,
+    /// Timestamp of the ledger at execution time.
+    pub timestamp: u64,
+}
+
+/// Emitted once per individual recipient payment inside a split.
+/// Topics: ["payment", recipient_address, asset_address]
+#[contractevent]
+pub struct IndividualPaymentEvent {
+    /// Amount transferred to this recipient.
+    pub amount: i128,
+    /// Recipient's share in basis points (out of 10 000).
+    pub bps: u32,
+    /// Timestamp of the ledger at execution time.
+    pub timestamp: u64,
+}
+
+// ── Publish helpers ───────────────────────────────────────────────────────────
+
+/// Publish a SplitExecutedEvent.
+/// Topics: ["splitter", "executed", sender]
+pub fn emit_split_executed(env: &Env, sender: &Address, amount: i128) {
+    SplitExecutedEvent {
+        amount,
+        timestamp: env.ledger().timestamp(),
+    }
+    .publish(
+        env,
+        (
+            soroban_sdk::symbol_short!("splitter"),
+            soroban_sdk::symbol_short!("executed"),
+            sender.clone(),
+        ),
+    );
+}
+
+/// Publish an IndividualPaymentEvent.
+/// Topics: ["payment", recipient, asset]
+pub fn emit_individual_payment(
+    env: &Env,
+    recipient: &Address,
+    asset: &Address,
+    amount: i128,
+    bps: u32,
+) {
+    IndividualPaymentEvent {
+        amount,
+        bps,
+        timestamp: env.ledger().timestamp(),
+    }
+    .publish(
+        env,
+        (
+            soroban_sdk::symbol_short!("payment"),
+            recipient.clone(),
+            asset.clone(),
+        ),
+    );
+}

--- a/contracts/splitter-v3/src/lib.rs
+++ b/contracts/splitter-v3/src/lib.rs
@@ -5,8 +5,10 @@ use soroban_sdk::{
 };
 
 mod errors;
+mod events;
 mod storage;
 use errors::Error;
+use events::{emit_individual_payment, emit_split_executed};
 use storage::DataKey;
 
 #[cfg(test)]
@@ -423,6 +425,7 @@ impl SplitterV3 {
             Self::_distribute(
                 &env,
                 &token_client,
+                &token_addr,
                 &contract_addr,
                 &recipients,
                 distributable,
@@ -452,7 +455,7 @@ impl SplitterV3 {
                     share_bps: new_bps,
                 });
             }
-            Self::_distribute(&env, &token_client, &contract_addr, &scaled, distributable)?;
+            Self::_distribute(&env, &token_client, &token_addr, &contract_addr, &scaled, distributable)?;
         }
 
         // ── Mark hash as processed (temporary storage, TTL ~1 day) ───────────
@@ -553,6 +556,7 @@ impl SplitterV3 {
         Self::_distribute(
             &env,
             &token_client,
+            &token_addr,
             &contract_addr,
             &config.recipients,
             distributable,
@@ -779,8 +783,13 @@ impl SplitterV3 {
                 let _ = token_client
                     .try_transfer(&contract_addr, &r.address, &amount)
                     .map_err(|_| Error::TransferFailed)?;
+                // #921: emit per-recipient payment event
+                emit_individual_payment(&env, &r.address, &asset, amount, r.share_bps);
             }
         }
+
+        // #921: emit top-level split executed event after successful transfer loop
+        emit_split_executed(&env, &sender, total_amount);
 
         Ok(())
     }
@@ -966,6 +975,7 @@ impl SplitterV3 {
         Self::_distribute(
             &env,
             &token_client,
+            &token_addr,
             &contract_addr,
             &recipients,
             total_amount,
@@ -1079,6 +1089,7 @@ impl SplitterV3 {
     fn _distribute(
         env: &Env,
         token_client: &token::Client,
+        asset: &Address,
         from: &Address,
         recipients: &Vec<Recipient>,
         distributable: i128,
@@ -1099,6 +1110,8 @@ impl SplitterV3 {
                 / 10_000;
             if amount > 0 {
                 token_client.transfer(from, &r.address, &amount);
+                // #921: emit per-recipient payment event
+                emit_individual_payment(env, &r.address, asset, amount, r.share_bps);
             }
         }
         env.events()


### PR DESCRIPTION
- Add events.rs module with #[contractevent] typed structs:
  - SplitExecutedEvent: topics=["splitter","executed",sender], data={amount, timestamp}
  - IndividualPaymentEvent: topics=["payment",recipient,asset], data={amount, bps, timestamp}
- Add emit_split_executed() and emit_individual_payment() publish helpers
- Wire emit_individual_payment() inside split_funds transfer loop (per recipient)
- Wire emit_split_executed() after successful transfer loop in split_funds
- Wire emit_individual_payment() inside _distribute() helper (covers split, execute_split, recovery_split)
- Update _distribute() signature to accept asset: &Address for event topics
- Update all _distribute() call sites to pass token_addr

Closes #921