### PR TITLE
feat:implement organization-avatar Identicon Generator

### DIFF
--- a/frontend/app/api/v3/split-links/[slug]/route.ts
+++ b/frontend/app/api/v3/split-links/[slug]/route.ts
@@ -10,6 +10,7 @@ export interface SplitLinkPublicPayload {
     trustScore: number;
     details: string;
     createdAt: string;
+    stellarAddress: string;
 }
 
 function buildMockSplitLink(slug: string): SplitLinkPublicPayload {
@@ -30,6 +31,7 @@ function buildMockSplitLink(slug: string): SplitLinkPublicPayload {
             ? "This payment is held for your wallet. Connect to claim the funds instantly."
             : "Your split is being prepared. Connect your wallet to monitor the claim status and view payment details.",
         createdAt: new Date().toISOString(),
+        stellarAddress: claimBased ? "GDTY3P5W4J52X3743Y3JXVHY2342" : "GATX2Y3X4J52X3743Y3JXVHY9999",
     };
 }
 

--- a/frontend/app/split-link/[slug]/page.tsx
+++ b/frontend/app/split-link/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useParams } from "next/navigation";
 import { ShieldCheck, ArrowRight, Loader2 } from "lucide-react";
 import { useWallet } from "@/lib/wallet-context";
+import { OrganizationAvatar } from "@/components/organization-avatar";
 
 interface SplitLinkInfo {
     slug: string;
@@ -15,6 +16,7 @@ interface SplitLinkInfo {
     trustScore: number;
     details: string;
     createdAt: string;
+    stellarAddress: string;
 }
 
 const statusStyles: Record<SplitLinkInfo["status"], string> = {
@@ -82,11 +84,27 @@ export default function SplitLinkLandingPage() {
                 <div className="glass-card border-white/10 shadow-[0_0_40px_rgba(0,0,0,0.3)] mx-auto max-w-3xl p-8 md:p-12">
                     <div className="flex flex-col gap-6">
                         <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
-                            <div>
-                                <p className="text-sm uppercase tracking-[0.32em] text-white/50">Split Link</p>
-                                <h1 className="mt-2 text-3xl font-black tracking-tight text-white sm:text-4xl">
-                                    {splitLink?.orgName ?? "Loading organization..."}
-                                </h1>
+                            <div className="flex items-center gap-4">
+                                {splitLink && (
+                                    <OrganizationAvatar
+                                        stellarAddress={splitLink.stellarAddress}
+                                        size={48}
+                                        className="rounded-xl border border-white/20 shadow-[0_0_16px_rgba(0,245,255,0.15)] hidden sm:block"
+                                    />
+                                )}
+                                <div>
+                                    <p className="text-sm uppercase tracking-[0.32em] text-white/50">Split Link</p>
+                                    <h1 className="mt-2 text-3xl font-black tracking-tight text-white sm:text-4xl flex items-center gap-3">
+                                        {splitLink && (
+                                            <OrganizationAvatar
+                                                stellarAddress={splitLink.stellarAddress}
+                                                size={32}
+                                                className="rounded-lg sm:hidden border border-white/20"
+                                            />
+                                        )}
+                                        {splitLink?.orgName ?? "Loading organization..."}
+                                    </h1>
+                                </div>
                             </div>
                             <div className={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-semibold ${trustBadgeClass}`}>
                                 <ShieldCheck className="h-4 w-4" />

--- a/frontend/components/organization-avatar.tsx
+++ b/frontend/components/organization-avatar.tsx
@@ -1,0 +1,43 @@
+import Avatar from "boring-avatars";
+
+interface OrganizationAvatarProps {
+  logoUrl?: string;
+  stellarAddress: string;
+  size?: number;
+  className?: string;
+  altText?: string;
+}
+
+export function OrganizationAvatar({
+  logoUrl,
+  stellarAddress,
+  size = 40,
+  className = "",
+  altText = "Organization logo",
+}: OrganizationAvatarProps) {
+  if (logoUrl) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        src={logoUrl}
+        alt={altText}
+        className={`object-cover ${className}`}
+        style={{ width: size, height: size }}
+      />
+    );
+  }
+
+  return (
+    <div
+      className={`overflow-hidden flex-shrink-0 ${className}`}
+      style={{ width: size, height: size }}
+    >
+      <Avatar
+        size={size}
+        name={stellarAddress}
+        variant="beam"
+        colors={["#00f5ff", "#8a00ff", "#ffffff", "#22d3ee", "#1e1e24"]}
+      />
+    </div>
+  );
+}

--- a/frontend/components/settings/OrganizationAvatarBrandingCard.tsx
+++ b/frontend/components/settings/OrganizationAvatarBrandingCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { OrganizationAvatar } from "@/components/organization-avatar";
 
 const DEFAULT_ORG_ID = "demo-org";
 
@@ -133,7 +134,7 @@ export function OrganizationAvatarBrandingCard() {
             // eslint-disable-next-line @next/next/no-img-element
             <img src={previewUrl} alt="Organization logo preview" className="h-full w-full rounded-2xl object-cover" />
           ) : (
-            <span className="text-xs text-white/40">Logo preview</span>
+            <OrganizationAvatar stellarAddress={orgId} size={160} className="rounded-2xl" />
           )}
         </div>
 

--- a/frontend/components/view-stream-client.tsx
+++ b/frontend/components/view-stream-client.tsx
@@ -9,6 +9,7 @@ import { useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import { TrendingUp, ShieldCheck } from "lucide-react";
 import { VerifiedNebulaBadge } from "@/components/VerifiedNebulaBadge";
+import { OrganizationAvatar } from "@/components/organization-avatar";
 
 // ─── Types (duplicated here to avoid importing from the server page) ──────────
 
@@ -70,12 +71,13 @@ export function ViewStreamClient({ stream }: { stream: StreamData }) {
     >
       {/* Verified Badge Header */}
       <div className="flex flex-col items-center justify-center -mt-12 mb-8 gap-3">
-        {stream.organization?.logo_url && (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            src={stream.organization.logo_url}
-            alt={`${stream.organization.name} logo`}
-            className="h-14 w-14 rounded-2xl border border-white/20 object-cover shadow-[0_0_24px_rgba(0,245,255,0.2)]"
+        {stream.organization && (
+          <OrganizationAvatar
+            logoUrl={stream.organization.logo_url}
+            stellarAddress={stream.organization.id}
+            size={56}
+            className="rounded-2xl border border-white/20 shadow-[0_0_24px_rgba(0,245,255,0.2)]"
+            altText={`${stream.organization.name} logo`}
           />
         )}
         <VerifiedNebulaBadge />


### PR DESCRIPTION
## Closes #1027 

This PR introduces **fallback identicons** for organizations without uploaded logos, ensuring a consistent and polished UI across the app.

### Highlights
- Created reusable `OrganizationAvatar` component using **boring-avatars** with a branded color palette
- Deterministic identicons generated from `stellarAddress` (or `orgId`)
- Integrated across:
  - Dashboard settings (branding card)
  - Public stream view
  - Split link pages (with fallback data support)
- Seamless fallback to identicon when no `logoUrl` is provided

This ensures a professional and consistent visual experience across all organization views.