### PR TITLE
feat(frontend): add biometric quick-sign gate

### DIFF
--- a/frontend/app/dashboard/create-stream/page.tsx
+++ b/frontend/app/dashboard/create-stream/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
-import { ShieldAlert, ArrowLeftRight } from "lucide-react";
+import { ShieldAlert, ArrowLeftRight, Fingerprint, LockKeyhole, ShieldCheck } from "lucide-react";
 import { useProtocolStatus } from "@/lib/use-protocol-status";
 import { Can } from "@/components/Can";
 import PrivacyShieldToggle from "@/components/privacy-shield-toggle";
@@ -19,6 +19,12 @@ import { Horizon } from "@stellar/stellar-sdk";
 import { Server } from "@stellar/stellar-sdk";
 import { SimulationWaterfall } from "@/components/dashboard/simulation-waterfall";
 import { buildSimulationWaterfall } from "@/lib/simulation-waterfall";
+import {
+  isWebAuthnAvailable,
+  loadQuickSignCredential,
+  registerQuickSignCredential,
+  verifyQuickSignCredential,
+} from "@/lib/webauthn-quick-sign";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 interface FormData {
@@ -110,6 +116,15 @@ type BalanceValidationStatus =
   | "insufficient_xlm"
   | "not_connected"
   | "pending";
+
+type QuickSignStatus =
+  | "checking"
+  | "unsupported"
+  | "needs_setup"
+  | "locked"
+  | "verifying"
+  | "verified"
+  | "error";
 
 function getRecipientStatusLabel(status: RecipientValidationStatus): string {
   switch (status) {
@@ -1015,6 +1030,11 @@ function Step3({
   balanceValidation,
   validationLoading,
   validationError,
+  quickSignStatus,
+  quickSignError,
+  hasQuickSignCredential,
+  onSetupQuickSign,
+  onVerifyQuickSign,
 }: {
   form: FormData;
   onSign: () => void;
@@ -1029,6 +1049,11 @@ function Step3({
   balanceValidation: BalanceValidationStatus;
   validationLoading: boolean;
   validationError: string | null;
+  quickSignStatus: QuickSignStatus;
+  quickSignError: string | null;
+  hasQuickSignCredential: boolean;
+  onSetupQuickSign: () => void;
+  onVerifyQuickSign: () => void;
 }) {
   const asset = ASSETS.find((a) => a.symbol === form.asset);
   const durationSeconds =
@@ -1047,7 +1072,9 @@ function Step3({
   const invalidRecipients = Object.values(recipientValidation).filter((status) => status === "invalid_address");
   const hasRecipientIssues = invalidRecipients.length > 0;
   const balanceProblem = balanceValidation !== "ok" && balanceValidation !== "pending";
-  const confirmDisabled = signing || validationLoading || hasRecipientIssues || balanceProblem;
+  const quickSignReady = quickSignStatus === "verified";
+  const quickSignBusy = quickSignStatus === "checking" || quickSignStatus === "verifying";
+  const confirmDisabled = signing || validationLoading || hasRecipientIssues || balanceProblem || !quickSignReady;
 
   const rows = [
     { label: "Asset", value: `${asset?.icon ?? ""} ${form.asset}` },
@@ -1129,6 +1156,77 @@ function Step3({
         selected={priorityTier}
         onChange={onPriorityChange}
       />
+      <div
+        className={`rounded-2xl border px-4 py-4 ${
+          quickSignReady
+            ? "border-emerald-400/25 bg-emerald-400/[0.06]"
+            : "border-cyan-400/20 bg-cyan-400/[0.05]"
+        }`}
+      >
+        <div className="flex items-start gap-3">
+          <div
+            className={`mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border ${
+              quickSignReady
+                ? "border-emerald-400/30 bg-emerald-400/10 text-emerald-300"
+                : "border-cyan-400/30 bg-cyan-400/10 text-cyan-300"
+            }`}
+          >
+            {quickSignReady ? <ShieldCheck size={20} /> : <Fingerprint size={20} />}
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <p className="font-body text-[10px] tracking-[0.14em] text-white/40 uppercase">
+                  Biometric Quick-Sign
+                </p>
+                <p className="mt-1 font-body text-sm font-semibold text-white/85">
+                  {quickSignReady
+                    ? "Biometric check passed"
+                    : hasQuickSignCredential
+                      ? "Unlock signing with device biometrics"
+                      : "Set up Face ID, Touch ID, or device screen lock"}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={hasQuickSignCredential ? onVerifyQuickSign : onSetupQuickSign}
+                disabled={quickSignBusy || quickSignReady || quickSignStatus === "unsupported"}
+                className="inline-flex min-h-10 items-center justify-center gap-2 rounded-xl border border-white/10 bg-white/[0.04] px-3 py-2 font-body text-xs font-bold text-white/75 transition hover:bg-white/[0.08] disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {quickSignBusy ? (
+                  <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z" />
+                  </svg>
+                ) : quickSignReady ? (
+                  <ShieldCheck size={15} />
+                ) : (
+                  <LockKeyhole size={15} />
+                )}
+                {quickSignBusy
+                  ? "Waiting..."
+                  : quickSignReady
+                    ? "Ready"
+                    : hasQuickSignCredential
+                      ? "Verify"
+                      : "Set Up"}
+              </button>
+            </div>
+            <p className="mt-2 font-body text-xs leading-relaxed text-white/45">
+              The Sign button stays locked until this device verifies you with WebAuthn user verification.
+              StellarStream stores only a local passkey credential ID for this wallet.
+            </p>
+            {quickSignStatus === "unsupported" && (
+              <p className="mt-2 font-body text-xs text-orange-300/80">
+                Device biometrics require a secure browser context with WebAuthn support.
+              </p>
+            )}
+            {quickSignError && (
+              <p className="mt-2 font-body text-xs text-red-300/85">{quickSignError}</p>
+            )}
+          </div>
+        </div>
+      </div>
       {validationLoading && (
         <div className="rounded-2xl border border-cyan-400/20 bg-cyan-400/[0.06] px-4 py-3 text-cyan-100 text-sm">
           Verifying recipient trustlines and sender balance before allowing confirmation...
@@ -1288,6 +1386,9 @@ export default function CreateStreamPage() {
   const [balanceValidation, setBalanceValidation] = useState<BalanceValidationStatus>("pending");
   const [validationLoading, setValidationLoading] = useState(false);
   const [validationError, setValidationError] = useState<string | null>(null);
+  const [quickSignStatus, setQuickSignStatus] = useState<QuickSignStatus>("checking");
+  const [quickSignError, setQuickSignError] = useState<string | null>(null);
+  const [hasQuickSignCredential, setHasQuickSignCredential] = useState(false);
   const wallet = useWallet();
 
   // ── Transaction priority (#456) ──────────────────────────────────────────────
@@ -1309,6 +1410,62 @@ export default function CreateStreamPage() {
   const update = useCallback((patch: Partial<FormData>) => {
     setForm((prev) => ({ ...prev, ...patch }));
   }, []);
+
+  useEffect(() => {
+    setQuickSignError(null);
+
+    if (!wallet.address) {
+      setHasQuickSignCredential(false);
+      setQuickSignStatus("needs_setup");
+      return;
+    }
+
+    if (!isWebAuthnAvailable()) {
+      setHasQuickSignCredential(false);
+      setQuickSignStatus("unsupported");
+      return;
+    }
+
+    const credential = loadQuickSignCredential(wallet.address);
+    setHasQuickSignCredential(!!credential);
+    setQuickSignStatus(credential ? "locked" : "needs_setup");
+  }, [wallet.address]);
+
+  const setupQuickSign = useCallback(async () => {
+    if (!wallet.address) {
+      setQuickSignError("Connect your wallet before setting up Quick-Sign.");
+      return;
+    }
+
+    try {
+      setQuickSignStatus("verifying");
+      setQuickSignError(null);
+      await registerQuickSignCredential(wallet.address);
+      setHasQuickSignCredential(true);
+      setQuickSignStatus("verified");
+    } catch (error) {
+      setQuickSignStatus(hasQuickSignCredential ? "locked" : "needs_setup");
+      setQuickSignError(error instanceof Error ? error.message : "Quick-Sign setup failed.");
+    }
+  }, [hasQuickSignCredential, wallet.address]);
+
+  const verifyQuickSign = useCallback(async () => {
+    if (!wallet.address) {
+      setQuickSignError("Connect your wallet before verifying Quick-Sign.");
+      return;
+    }
+
+    try {
+      setQuickSignStatus("verifying");
+      setQuickSignError(null);
+      await verifyQuickSignCredential(wallet.address);
+      setHasQuickSignCredential(true);
+      setQuickSignStatus("verified");
+    } catch (error) {
+      setQuickSignStatus(hasQuickSignCredential ? "locked" : "needs_setup");
+      setQuickSignError(error instanceof Error ? error.message : "Biometric verification failed.");
+    }
+  }, [hasQuickSignCredential, wallet.address]);
 
   useEffect(() => {
     let cancelled = false;
@@ -1439,6 +1596,11 @@ export default function CreateStreamPage() {
   };
 
   const handleSign = async () => {
+    if (quickSignStatus !== "verified") {
+      setQuickSignError("Verify Quick-Sign before opening your wallet for signing.");
+      return;
+    }
+
     setSigning(true);
     // totalFeeStroops(0) gives the fee with no simulated resource fee.
     // In production, pass the real simulated resource fee here.
@@ -1612,6 +1774,11 @@ export default function CreateStreamPage() {
                     balanceValidation={balanceValidation}
                     validationLoading={validationLoading}
                     validationError={validationError}
+                    quickSignStatus={quickSignStatus}
+                    quickSignError={quickSignError}
+                    hasQuickSignCredential={hasQuickSignCredential}
+                    onSetupQuickSign={setupQuickSign}
+                    onVerifyQuickSign={verifyQuickSign}
                   />}
 
                   {step < 3 && (

--- a/frontend/lib/webauthn-quick-sign.test.ts
+++ b/frontend/lib/webauthn-quick-sign.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import {
+  base64UrlToBytes,
+  bytesToBase64Url,
+  getQuickSignStorageKey,
+  loadQuickSignCredential,
+} from "./webauthn-quick-sign";
+
+describe("webauthn quick sign helpers", () => {
+  it("round-trips credential IDs with base64url encoding", () => {
+    const credentialId = new Uint8Array([0, 1, 2, 250, 251, 252, 253, 254, 255]);
+    const encoded = bytesToBase64Url(credentialId);
+
+    expect(encoded).not.toContain("+");
+    expect(encoded).not.toContain("/");
+    expect(encoded).not.toContain("=");
+    expect(Array.from(base64UrlToBytes(encoded))).toEqual(Array.from(credentialId));
+  });
+
+  it("scopes stored credentials by wallet address", () => {
+    expect(getQuickSignStorageKey("GABC123")).toBe("stellarstream.quickSignCredential.gabc123");
+  });
+
+  it("does not read browser storage during server-side rendering", () => {
+    expect(loadQuickSignCredential("GABC123")).toBeNull();
+  });
+});

--- a/frontend/lib/webauthn-quick-sign.ts
+++ b/frontend/lib/webauthn-quick-sign.ts
@@ -1,0 +1,165 @@
+"use client";
+
+const STORAGE_PREFIX = "stellarstream.quickSignCredential";
+
+export interface StoredQuickSignCredential {
+  credentialId: string;
+  walletAddress: string;
+  createdAt: string;
+}
+
+export function isWebAuthnAvailable(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof navigator !== "undefined" &&
+    window.isSecureContext &&
+    typeof window.PublicKeyCredential !== "undefined" &&
+    !!navigator.credentials
+  );
+}
+
+export function getQuickSignStorageKey(walletAddress: string): string {
+  return `${STORAGE_PREFIX}.${walletAddress.toLowerCase()}`;
+}
+
+export function bytesToBase64Url(bytes: ArrayBuffer | Uint8Array): string {
+  const view = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  let binary = "";
+
+  view.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/u, "");
+}
+
+export function base64UrlToBytes(value: string): Uint8Array {
+  const padded = value.replace(/-/g, "+").replace(/_/g, "/").padEnd(Math.ceil(value.length / 4) * 4, "=");
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+
+  return bytes;
+}
+
+function bytesToArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+export function createWebAuthnChallenge(): ArrayBuffer {
+  const challenge = new Uint8Array(32);
+  crypto.getRandomValues(challenge);
+  return bytesToArrayBuffer(challenge);
+}
+
+export function loadQuickSignCredential(walletAddress: string): StoredQuickSignCredential | null {
+  if (typeof window === "undefined") return null;
+
+  const raw = window.localStorage.getItem(getQuickSignStorageKey(walletAddress));
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(raw) as StoredQuickSignCredential;
+    return parsed.walletAddress.toLowerCase() === walletAddress.toLowerCase() && parsed.credentialId
+      ? parsed
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export function storeQuickSignCredential(credential: StoredQuickSignCredential): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(getQuickSignStorageKey(credential.walletAddress), JSON.stringify(credential));
+}
+
+export async function registerQuickSignCredential(walletAddress: string): Promise<StoredQuickSignCredential> {
+  if (!isWebAuthnAvailable()) {
+    throw new Error("Device biometrics are not available in this browser.");
+  }
+
+  const existing = loadQuickSignCredential(walletAddress);
+  const credential = await navigator.credentials.create({
+    publicKey: {
+      challenge: createWebAuthnChallenge(),
+      rp: {
+        name: "StellarStream",
+        id: window.location.hostname,
+      },
+      user: {
+        id: bytesToArrayBuffer(new TextEncoder().encode(walletAddress)),
+        name: walletAddress,
+        displayName: "StellarStream wallet signer",
+      },
+      pubKeyCredParams: [
+        { alg: -7, type: "public-key" },
+        { alg: -257, type: "public-key" },
+      ],
+      authenticatorSelection: {
+        authenticatorAttachment: "platform",
+        residentKey: "preferred",
+        requireResidentKey: false,
+        userVerification: "required",
+      },
+      excludeCredentials: existing
+        ? [
+            {
+              id: bytesToArrayBuffer(base64UrlToBytes(existing.credentialId)),
+              type: "public-key",
+              transports: ["internal"],
+            },
+          ]
+        : [],
+      timeout: 60_000,
+      attestation: "none",
+    },
+  });
+
+  if (!(credential instanceof PublicKeyCredential)) {
+    throw new Error("Quick-Sign setup was cancelled.");
+  }
+
+  const stored = {
+    credentialId: bytesToBase64Url(credential.rawId),
+    walletAddress,
+    createdAt: new Date().toISOString(),
+  };
+
+  storeQuickSignCredential(stored);
+  return stored;
+}
+
+export async function verifyQuickSignCredential(walletAddress: string): Promise<StoredQuickSignCredential> {
+  if (!isWebAuthnAvailable()) {
+    throw new Error("Device biometrics are not available in this browser.");
+  }
+
+  const credential = loadQuickSignCredential(walletAddress);
+  if (!credential) {
+    throw new Error("Set up Quick-Sign before signing.");
+  }
+
+  const assertion = await navigator.credentials.get({
+    publicKey: {
+      challenge: createWebAuthnChallenge(),
+      allowCredentials: [
+        {
+          id: bytesToArrayBuffer(base64UrlToBytes(credential.credentialId)),
+          type: "public-key",
+          transports: ["internal"],
+        },
+      ],
+      timeout: 60_000,
+      userVerification: "required",
+    },
+  });
+
+  if (!(assertion instanceof PublicKeyCredential)) {
+    throw new Error("Biometric verification was cancelled.");
+  }
+
+  return credential;
+}


### PR DESCRIPTION
Closes #1021

---

## Summary

Adds a mobile-focused Biometric Quick-Sign gate before wallet signing in the Create Stream flow.

## Changes

- Integrated WebAuthn helper utilities for local passkey registration and verification.
- Stores a local credential ID per wallet address in browser storage.
- Adds a Biometric Quick-Sign panel to the Review & Sign step.
- Keeps the `Sign & Create Stream` button disabled until WebAuthn user verification succeeds.
- Adds a defensive guard in `handleSign` so signing cannot proceed without Quick-Sign verification.
- Adds focused tests for credential ID encoding and wallet-scoped storage keys.

## Validation

- `npm run lint` passes.
- `npm run build` is blocked by existing unrelated TypeScript issues, including the Next 16 route handler type for `app/api/v3/split-links/[slug]/route.ts`.

