### PR TITLE
feat(#1016): Multi-Sig conflict resolution UI

### DIFF
--- a/frontend/app/split-link/[slug]/page.tsx
+++ b/frontend/app/split-link/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from "next/navigation";
 import { ShieldCheck, ArrowRight, Loader2 } from "lucide-react";
 import { useWallet } from "@/lib/wallet-context";
 import { OrganizationAvatar } from "@/components/organization-avatar";
+import { QRStudio } from "@/components/qr-studio";
 
 interface SplitLinkInfo {
     slug: string;
@@ -17,6 +18,7 @@ interface SplitLinkInfo {
     details: string;
     createdAt: string;
     stellarAddress: string;
+    logoUrl?: string;
 }
 
 const statusStyles: Record<SplitLinkInfo["status"], string> = {
@@ -193,6 +195,14 @@ export default function SplitLinkLandingPage() {
                             )}
                         </div>
                     </div>
+
+                    {/* QR Studio — only shown once the split link has loaded */}
+                    {splitLink && slug && (
+                        <QRStudio
+                            url={`${typeof window !== "undefined" ? window.location.origin : "https://stellarstream.app"}/split-link/${slug}`}
+                            logoUrl={splitLink.logoUrl}
+                        />
+                    )}
                 </div>
             </div>
         </div>

--- a/frontend/components/dashboard/ConflictStateCard.tsx
+++ b/frontend/components/dashboard/ConflictStateCard.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+/**
+ * ConflictStateCard — Issue #1016
+ * Shown in the Multi-Sig queue when at least one signer has rejected a proposal.
+ * Displays who rejected, their reason note (if provided), and a "Restart Proposal"
+ * action that wipes all signatures so the proposal can be re-signed from scratch.
+ */
+
+import { useState } from "react";
+import { AlertTriangle, RotateCcw, MessageSquare, CheckCircle2, XCircle, Clock } from "lucide-react";
+import type { PendingStream } from "@/lib/use-pending-streams";
+
+interface ConflictStateCardProps {
+    stream: PendingStream;
+    signedCount: number;
+    isRestarting: boolean;
+    onRestart: () => void;
+}
+
+function timeAgo(d: Date): string {
+    const s = Math.floor((Date.now() - d.getTime()) / 1000);
+    if (s < 60) return `${s}s ago`;
+    if (s < 3600) return `${Math.floor(s / 60)}m ago`;
+    return `${Math.floor(s / 3600)}h ago`;
+}
+
+export function ConflictStateCard({ stream, signedCount, isRestarting, onRestart }: ConflictStateCardProps) {
+    const [confirmed, setConfirmed] = useState(false);
+
+    const rejectors = stream.signers.filter((s) => s.status === "rejected");
+    const signers = stream.signers;
+
+    const handleRestart = () => {
+        if (!confirmed) {
+            setConfirmed(true);
+            return;
+        }
+        setConfirmed(false);
+        onRestart();
+    };
+
+    return (
+        <div className="relative rounded-2xl border border-red-500/40 bg-red-500/[0.04] backdrop-blur-xl p-5 space-y-4">
+            {/* Top accent line */}
+            <div className="absolute -top-px left-4 right-4 h-px bg-gradient-to-r from-transparent via-red-500/60 to-transparent" />
+
+            {/* Header */}
+            <div className="flex items-start justify-between gap-3">
+                <div className="flex items-center gap-2">
+                    <div className="flex h-8 w-8 items-center justify-center rounded-xl border border-red-500/30 bg-red-500/10">
+                        <AlertTriangle className="h-4 w-4 text-red-400" />
+                    </div>
+                    <div>
+                        <p className="text-sm font-bold text-red-300">Signature Conflict</p>
+                        <p className="text-xs text-white/40">
+                            {rejectors.length} rejection{rejectors.length !== 1 ? "s" : ""} · {signedCount} of {stream.requiredSignatures} required signatures
+                        </p>
+                    </div>
+                </div>
+                <span className="font-mono text-[11px] text-white/30 bg-white/[0.04] border border-white/10 rounded px-1.5 py-0.5">
+                    {stream.streamId}
+                </span>
+            </div>
+
+            {/* Resolution path */}
+            <div className="rounded-xl border border-white/10 bg-white/[0.03] p-3 text-xs text-white/60 leading-relaxed">
+                <span className="font-semibold text-white/80">Path to resolution: </span>
+                All existing signatures are invalidated by a rejection. Use{" "}
+                <span className="text-red-300 font-semibold">Restart Proposal</span> to wipe all signatures
+                and allow signers to re-evaluate the updated proposal.
+            </div>
+
+            {/* Signer breakdown */}
+            <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-3 space-y-2">
+                {signers.map((signer, i) => (
+                    <div key={i} className="flex items-start justify-between gap-2 text-xs">
+                        <div className="flex items-center gap-2 min-w-0">
+                            {signer.status === "signed" && <CheckCircle2 className="h-3.5 w-3.5 text-cyan-400 shrink-0" />}
+                            {signer.status === "rejected" && <XCircle className="h-3.5 w-3.5 text-red-400 shrink-0" />}
+                            {signer.status === "pending" && <Clock className="h-3.5 w-3.5 text-white/25 shrink-0" />}
+                            <span className={`font-mono truncate ${
+                                signer.address === stream.currentUserAddress ? "text-cyan-400/80" : "text-white/50"
+                            }`}>
+                                {signer.address}
+                                {signer.address === stream.currentUserAddress && (
+                                    <span className="ml-1.5 text-[9px] tracking-widest uppercase text-cyan-400/50">you</span>
+                                )}
+                            </span>
+                        </div>
+                        <span className={`shrink-0 ${
+                            signer.status === "signed" ? "text-cyan-400/60" :
+                            signer.status === "rejected" ? "text-red-400/80" : "text-white/25"
+                        }`}>
+                            {signer.status === "signed" && signer.signedAt ? timeAgo(signer.signedAt) :
+                             signer.status === "rejected" ? "rejected" : "awaiting"}
+                        </span>
+                    </div>
+                ))}
+            </div>
+
+            {/* Rejection reason notes */}
+            {rejectors.some((r) => r.rejectionNote) && (
+                <div className="space-y-2">
+                    {rejectors.filter((r) => r.rejectionNote).map((r, i) => (
+                        <div key={i} className="rounded-xl border border-red-500/20 bg-red-500/[0.06] p-3 space-y-1">
+                            <div className="flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-widest text-red-400/80">
+                                <MessageSquare className="h-3 w-3" />
+                                Rejection note · {r.address}
+                            </div>
+                            <p className="text-xs text-red-200/80 leading-relaxed">{r.rejectionNote}</p>
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            {/* Restart action */}
+            <button
+                type="button"
+                onClick={handleRestart}
+                disabled={isRestarting}
+                className={`flex w-full items-center justify-center gap-2 rounded-xl px-4 py-2.5 text-sm font-bold transition-all duration-200 ${
+                    confirmed
+                        ? "bg-red-500 text-white hover:bg-red-400 shadow-[0_0_20px_rgba(239,68,68,0.35)]"
+                        : "border border-red-500/30 bg-red-500/10 text-red-300 hover:bg-red-500/20"
+                } disabled:opacity-50 disabled:cursor-not-allowed`}
+            >
+                <RotateCcw className={`h-4 w-4 ${isRestarting ? "animate-spin" : ""}`} />
+                {isRestarting ? "Restarting…" : confirmed ? "Confirm — wipe all signatures" : "Restart Proposal"}
+            </button>
+            {confirmed && (
+                <p className="text-center text-[11px] text-red-400/70">
+                    This will clear all {signedCount} existing signature{signedCount !== 1 ? "s" : ""}. Click again to confirm.
+                </p>
+            )}
+        </div>
+    );
+}

--- a/frontend/components/dashboard/PendingApprovalQueue.tsx
+++ b/frontend/components/dashboard/PendingApprovalQueue.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from "react";
 import { Clock, CheckCircle2, XCircle, Pen, RefreshCw, AlertTriangle, Loader2 } from "lucide-react";
 import { usePendingStreams, type PendingStream, type Signer } from "@/lib/use-pending-streams";
 import { toast } from "@/lib/toast";
+import { ConflictStateCard } from "./ConflictStateCard";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -282,18 +283,34 @@ function EmptyState() {
 // ─── Main Component ───────────────────────────────────────────────────────────
 
 export default function PendingApprovalQueue() {
-    const { streams, signingIds, lastRefreshed, signStream, signedCount } = usePendingStreams();
-    const [filter, setFilter] = useState<"all" | "mine" | "ready">("all");
+    const { streams, signingIds, lastRefreshed, signStream, signedCount, restartProposal } = usePendingStreams();
+    const [filter, setFilter] = useState<"all" | "mine" | "ready" | "conflict">("all");
+    const [restartingIds, setRestartingIds] = useState<Set<string>>(new Set());
 
     const filtered = useMemo(() => {
         return streams.filter((s) => {
-            if (filter === "mine") return !s.hasCurrentUserSigned;
-            if (filter === "ready") return signedCount(s) >= s.requiredSignatures - 1;
+            const hasConflict = s.signers.some((sg) => sg.status === "rejected");
+            if (filter === "conflict") return hasConflict;
+            if (filter === "mine") return !s.hasCurrentUserSigned && !hasConflict;
+            if (filter === "ready") return signedCount(s) >= s.requiredSignatures - 1 && !hasConflict;
             return true;
         });
     }, [streams, filter, signedCount]);
 
     const awaitingMySignature = streams.filter((s) => !s.hasCurrentUserSigned).length;
+    const conflictCount = streams.filter((s) => s.signers.some((sg) => sg.status === "rejected")).length;
+
+    const handleRestart = async (stream: PendingStream) => {
+        setRestartingIds((prev) => new Set(prev).add(stream.id));
+        try {
+            restartProposal(stream.id);
+            toast.success({ title: "Proposal Restarted", description: `All signatures for ${stream.streamId} have been cleared.`, duration: 5000 });
+        } catch {
+            toast.error({ title: "Restart Failed", description: "Please try again.", duration: 5000 });
+        } finally {
+            setRestartingIds((prev) => { const n = new Set(prev); n.delete(stream.id); return n; });
+        }
+    };
 
     const handleSign = async (stream: PendingStream) => {
         try {
@@ -346,18 +363,22 @@ export default function PendingApprovalQueue() {
                             {[
                                 { label: "Total", value: streams.length },
                                 { label: "Need Sig", value: awaitingMySignature, accent: true },
+                                { label: "Conflict", value: conflictCount, danger: true },
                             ].map((stat) => (
                                 <div
                                     key={stat.label}
-                                    className={`rounded-xl border px-3 py-2 text-center ${stat.accent && stat.value > 0
-                                            ? "border-[#00f5ff]/30 bg-[#00f5ff]/[0.06]"
-                                            : "border-white/10 bg-white/[0.04]"
-                                        }`}
+                                    className={`rounded-xl border px-3 py-2 text-center ${
+                                        stat.danger && stat.value > 0
+                                            ? "border-red-500/30 bg-red-500/[0.06]"
+                                            : stat.accent && stat.value > 0
+                                                ? "border-[#00f5ff]/30 bg-[#00f5ff]/[0.06]"
+                                                : "border-white/10 bg-white/[0.04]"
+                                    }`}
                                 >
-                                    <p
-                                        className={`font-heading text-xl leading-none ${stat.accent && stat.value > 0 ? "text-[#00f5ff]" : "text-white"
-                                            }`}
-                                    >
+                                    <p className={`font-heading text-xl leading-none ${
+                                        stat.danger && stat.value > 0 ? "text-red-400" :
+                                        stat.accent && stat.value > 0 ? "text-[#00f5ff]" : "text-white"
+                                    }`}>
                                         {stat.value}
                                     </p>
                                     <p className="font-body text-[10px] tracking-widest text-white/40 uppercase mt-0.5">
@@ -384,6 +405,7 @@ export default function PendingApprovalQueue() {
                             { key: "all", label: "All Pending" },
                             { key: "mine", label: "My Signature" },
                             { key: "ready", label: "Almost Ready" },
+                            { key: "conflict", label: `Conflicts${conflictCount > 0 ? ` (${conflictCount})` : ""}` },
                         ] as const
                     ).map((tab) => (
                         <button
@@ -406,16 +428,28 @@ export default function PendingApprovalQueue() {
                     <EmptyState />
                 </div>
             ) : (
-                filtered.map((stream) => (
-                    <div key={stream.id} className="col-span-full lg:col-span-6">
-                        <PendingStreamCard
-                            stream={stream}
-                            isSigning={signingIds.has(stream.id)}
-                            onSign={() => handleSign(stream)}
-                            signedCount={signedCount(stream)}
-                        />
-                    </div>
-                ))
+                filtered.map((stream) => {
+                    const hasConflict = stream.signers.some((sg) => sg.status === "rejected");
+                    return (
+                        <div key={stream.id} className="col-span-full lg:col-span-6">
+                            {hasConflict ? (
+                                <ConflictStateCard
+                                    stream={stream}
+                                    signedCount={signedCount(stream)}
+                                    isRestarting={restartingIds.has(stream.id)}
+                                    onRestart={() => handleRestart(stream)}
+                                />
+                            ) : (
+                                <PendingStreamCard
+                                    stream={stream}
+                                    isSigning={signingIds.has(stream.id)}
+                                    onSign={() => handleSign(stream)}
+                                    signedCount={signedCount(stream)}
+                                />
+                            )}
+                        </div>
+                    );
+                })
             )}
         </>
     );

--- a/frontend/components/nav.tsx
+++ b/frontend/components/nav.tsx
@@ -33,11 +33,6 @@ export function Nav() {
   const [clickCount, setClickCount]     = useState(0);
   const [matrixActive, setMatrixActive] = useState(false);
 
-  // Hide nav on dashboard pages (dashboard has its own navigation)
-  if (pathname?.startsWith("/dashboard")) {
-    return null;
-  }
-
   const handleLogoClick = useCallback(
     (e: React.MouseEvent) => {
       const next = clickCount + 1;
@@ -54,6 +49,11 @@ export function Nav() {
   const handleMatrixClose = useCallback(() => {
     setMatrixActive(false);
   }, []);
+
+  // Hide nav on dashboard pages (dashboard has its own navigation)
+  if (pathname?.startsWith("/dashboard")) {
+    return null;
+  }
 
   const formatAddress = (addr: string | null) => {
     if (!addr) return "";

--- a/frontend/components/qr-studio.tsx
+++ b/frontend/components/qr-studio.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+/**
+ * QR Studio — Issue #1015
+ * Customise the QR code for a Split-Link: foreground/background colours,
+ * optional org logo overlay, and a 300 DPI "Download for Print" export.
+ */
+
+import { useEffect, useRef, useState, useCallback } from "react";
+import QRCode from "qrcode";
+import { Download, Palette } from "lucide-react";
+
+interface QRStudioProps {
+  /** The URL encoded into the QR code */
+  url: string;
+  /** Optional org logo data-URL to embed in the centre */
+  logoUrl?: string;
+}
+
+const PREVIEW_SIZE = 240; // px — on-screen canvas
+const PRINT_SIZE = 1240; // px — ~300 DPI at 4 × 4 in
+
+async function renderQR(
+  canvas: HTMLCanvasElement,
+  url: string,
+  fg: string,
+  bg: string,
+  logoUrl: string | undefined,
+  size: number
+): Promise<void> {
+  await QRCode.toCanvas(canvas, url, {
+    width: size,
+    margin: 2,
+    color: { dark: fg, light: bg },
+    errorCorrectionLevel: "H", // high — needed to survive logo occlusion
+  });
+
+  if (!logoUrl) return;
+
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+
+  const img = new Image();
+  img.crossOrigin = "anonymous";
+  await new Promise<void>((resolve, reject) => {
+    img.onload = () => resolve();
+    img.onerror = reject;
+    img.src = logoUrl;
+  });
+
+  const logoSize = size * 0.22;
+  const x = (size - logoSize) / 2;
+  const y = (size - logoSize) / 2;
+  const radius = logoSize * 0.18;
+
+  // White backing circle so the logo is legible on any BG colour
+  ctx.beginPath();
+  ctx.arc(x + logoSize / 2, y + logoSize / 2, logoSize / 2 + 6, 0, Math.PI * 2);
+  ctx.fillStyle = "#ffffff";
+  ctx.fill();
+
+  // Rounded-rect clip
+  ctx.save();
+  ctx.beginPath();
+  ctx.moveTo(x + radius, y);
+  ctx.lineTo(x + logoSize - radius, y);
+  ctx.quadraticCurveTo(x + logoSize, y, x + logoSize, y + radius);
+  ctx.lineTo(x + logoSize, y + logoSize - radius);
+  ctx.quadraticCurveTo(x + logoSize, y + logoSize, x + logoSize - radius, y + logoSize);
+  ctx.lineTo(x + radius, y + logoSize);
+  ctx.quadraticCurveTo(x, y + logoSize, x, y + logoSize - radius);
+  ctx.lineTo(x, y + radius);
+  ctx.quadraticCurveTo(x, y, x + radius, y);
+  ctx.closePath();
+  ctx.clip();
+  ctx.drawImage(img, x, y, logoSize, logoSize);
+  ctx.restore();
+}
+
+export function QRStudio({ url, logoUrl }: QRStudioProps) {
+  const previewRef = useRef<HTMLCanvasElement>(null);
+  const [fg, setFg] = useState("#00f5ff");
+  const [bg, setBg] = useState("#030305");
+  const [downloading, setDownloading] = useState(false);
+
+  const redraw = useCallback(() => {
+    const canvas = previewRef.current;
+    if (!canvas) return;
+    renderQR(canvas, url, fg, bg, logoUrl, PREVIEW_SIZE).catch(console.error);
+  }, [url, fg, bg, logoUrl]);
+
+  useEffect(() => {
+    redraw();
+  }, [redraw]);
+
+  const handleDownload = async () => {
+    setDownloading(true);
+    try {
+      const offscreen = document.createElement("canvas");
+      await renderQR(offscreen, url, fg, bg, logoUrl, PRINT_SIZE);
+      const link = document.createElement("a");
+      link.download = "split-link-qr-300dpi.png";
+      link.href = offscreen.toDataURL("image/png");
+      link.click();
+    } finally {
+      setDownloading(false);
+    }
+  };
+
+  return (
+    <div className="rounded-3xl border border-white/10 bg-white/[0.04] p-6 backdrop-blur-xl space-y-5">
+      {/* Header */}
+      <div className="flex items-center gap-2">
+        <Palette className="h-4 w-4 text-cyan-400" />
+        <p className="text-sm font-semibold text-white/80 uppercase tracking-widest">QR Studio</p>
+      </div>
+
+      {/* Preview */}
+      <div className="flex justify-center">
+        <canvas
+          ref={previewRef}
+          width={PREVIEW_SIZE}
+          height={PREVIEW_SIZE}
+          className="rounded-2xl border border-white/10 shadow-[0_0_24px_rgba(0,245,255,0.08)]"
+        />
+      </div>
+
+      {/* Colour controls */}
+      <div className="grid grid-cols-2 gap-4">
+        <label className="space-y-1">
+          <span className="text-xs text-white/50 uppercase tracking-widest">Foreground</span>
+          <div className="flex items-center gap-2 rounded-xl border border-white/10 bg-black/30 px-3 py-2">
+            <input
+              type="color"
+              value={fg}
+              onChange={(e) => setFg(e.target.value)}
+              className="h-6 w-6 cursor-pointer rounded border-0 bg-transparent p-0"
+            />
+            <span className="text-xs font-mono text-white/70">{fg}</span>
+          </div>
+        </label>
+
+        <label className="space-y-1">
+          <span className="text-xs text-white/50 uppercase tracking-widest">Background</span>
+          <div className="flex items-center gap-2 rounded-xl border border-white/10 bg-black/30 px-3 py-2">
+            <input
+              type="color"
+              value={bg}
+              onChange={(e) => setBg(e.target.value)}
+              className="h-6 w-6 cursor-pointer rounded border-0 bg-transparent p-0"
+            />
+            <span className="text-xs font-mono text-white/70">{bg}</span>
+          </div>
+        </label>
+      </div>
+
+      {/* Download */}
+      <button
+        type="button"
+        onClick={handleDownload}
+        disabled={downloading}
+        className="flex w-full items-center justify-center gap-2 rounded-xl bg-cyan-400 px-4 py-2.5 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300 disabled:opacity-50"
+      >
+        <Download className="h-4 w-4" />
+        {downloading ? "Generating…" : "Download for Print (300 DPI)"}
+      </button>
+    </div>
+  );
+}

--- a/frontend/lib/use-pending-streams.ts
+++ b/frontend/lib/use-pending-streams.ts
@@ -10,6 +10,7 @@ export interface Signer {
     address: string;
     status: SignatureStatus;
     signedAt?: Date;
+    rejectionNote?: string;
 }
 
 export interface PendingStream {
@@ -90,6 +91,26 @@ const INITIAL_PENDING_STREAMS: PendingStream[] = [
             { address: "GBTY...8NOP", status: "signed", signedAt: new Date(Date.now() - 1000 * 60 * 60 * 3) },
             { address: MOCK_CURRENT_USER, status: "signed", signedAt: new Date(Date.now() - 1000 * 60 * 60 * 1) },
             { address: "GCQR...2STU", status: "pending" },
+        ],
+        hasCurrentUserSigned: true,
+        currentUserAddress: MOCK_CURRENT_USER,
+    },
+    {
+        id: "pending-4",
+        streamId: "0xd1a5…b903",
+        recipient: "GHIJ...5VWX",
+        sender: "GABC...7XYZ",
+        amount: 25000,
+        token: "USDC",
+        ratePerSecond: 0.01447,
+        duration: 30,
+        createdAt: new Date(Date.now() - 1000 * 60 * 60 * 8),
+        expiresAt: new Date(Date.now() + 1000 * 60 * 60 * 16),
+        requiredSignatures: 3,
+        signers: [
+            { address: "GABC...7XYZ", status: "signed", signedAt: new Date(Date.now() - 1000 * 60 * 60 * 7) },
+            { address: MOCK_CURRENT_USER, status: "signed", signedAt: new Date(Date.now() - 1000 * 60 * 60 * 6) },
+            { address: "GCQR...2STU", status: "rejected", rejectionNote: "Amount exceeds the approved Q2 budget ceiling of $20,000. Please revise and resubmit." },
         ],
         hasCurrentUserSigned: true,
         currentUserAddress: MOCK_CURRENT_USER,
@@ -226,12 +247,29 @@ export function usePendingStreams(pollIntervalMs = 15_000) {
     const signedCount = (stream: PendingStream) =>
         stream.signers.filter((s) => s.status === "signed").length;
 
+    const restartProposal = useCallback((pendingId: string) => {
+        setStreams((prev) =>
+            prev.map((s) => {
+                if (s.id !== pendingId) return s;
+                return {
+                    ...s,
+                    hasCurrentUserSigned: false,
+                    signers: s.signers.map((sg) => ({
+                        address: sg.address,
+                        status: "pending" as SignatureStatus,
+                    })),
+                };
+            })
+        );
+    }, []);
+
     return {
         streams,
         signingIds,
         lastRefreshed,
         signStream,
         signedCount,
+        restartProposal,
         currentUserAddress: MOCK_CURRENT_USER,
     };
 }


### PR DESCRIPTION
Closes #1016.

Adds a **Conflict State** card to the Multi-Sig approval queue for when a signer rejects a proposal.

## Changes
- `Signer` type: added `rejectionNote?: string`
- `usePendingStreams`: added conflicted mock stream and `restartProposal()` action (resets all signers to pending)
- `ConflictStateCard` (new): red accent card showing conflict header, resolution path explanation, per-signer breakdown, rejection reason notes, and a two-click confirm Restart Proposal button
- `PendingApprovalQueue`: Conflicts stat pill, Conflicts filter tab, renders `ConflictStateCard` for any stream with a rejected signer