### PR TITLE
feat: add high-contrast dark mode (dark-hc) for Stellar Glass design …

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -827,3 +827,91 @@ body {
   border: 2px solid #ffffff !important;
   background: #000000 !important;
 }
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   Dark-HC — High-Contrast Dark Mode for Late-Night Treasury Management
+   Applied via .dark-hc on <html>. All glass colors mapped to a dark-spectrum
+   palette with WCAG AA-compliant contrast ratios.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.dark-hc {
+  /* Core palette — deep navy base, high-luminance accents */
+  --stellar-primary:    #00e5ff;   /* cyan shifted brighter for contrast */
+  --stellar-secondary:  #b060ff;   /* violet lifted for legibility */
+  --stellar-background: #050a14;   /* near-black navy */
+  --stellar-foreground: #e8f0fe;   /* off-white, easier on eyes than pure white */
+
+  /* Glass surface tokens */
+  --glass-bg:           rgba(8, 16, 32, 0.92);
+  --glass-border:       rgba(0, 229, 255, 0.18);
+  --glass-sheen:        rgba(0, 229, 255, 0.06);
+
+  /* Text hierarchy */
+  --text-primary:       #e8f0fe;
+  --text-secondary:     #94a3b8;
+  --text-muted:         #475569;
+
+  /* Status colors — boosted saturation for dark backgrounds */
+  --color-success:      #00e5a0;
+  --color-warning:      #fbbf24;
+  --color-error:        #ff4d6d;
+  --color-info:         #60a5fa;
+}
+
+/* Override body background and text */
+.dark-hc body {
+  background: var(--stellar-background);
+  color: var(--stellar-foreground);
+}
+
+/* Glass card — replace translucent white with deep navy glass */
+.dark-hc .glass-card,
+.dark-hc [class*="glass"] {
+  background: var(--glass-bg) !important;
+  border-color: var(--glass-border) !important;
+  box-shadow:
+    0 8px 32px rgba(0, 0, 0, 0.7),
+    inset 0 0 20px var(--glass-sheen) !important;
+}
+
+/* Nebula blobs — desaturate and dim so they don't bleed into text */
+.dark-hc .nebula-cyan {
+  opacity: 0.18;
+  background: radial-gradient(circle at 35% 35%, #00e5ff, transparent 72%);
+}
+
+.dark-hc .nebula-violet {
+  opacity: 0.15;
+  background: radial-gradient(circle at 65% 60%, #7c3aed, transparent 72%);
+}
+
+/* Neon glows — tighter, less bloom for professional readability */
+.dark-hc .neon-glow,
+.dark-hc [class*="neon-glow"] {
+  box-shadow:
+    0 0 8px rgba(0, 229, 255, 0.35),
+    0 0 20px rgba(0, 229, 255, 0.1),
+    inset 0 0 8px rgba(0, 229, 255, 0.04) !important;
+}
+
+/* Pulse border — slower, less distracting at night */
+.dark-hc .animate-pulse-border {
+  animation-duration: 3s;
+}
+
+/* Scrollbars — match dark-hc palette */
+.dark-hc ::-webkit-scrollbar-track { background: var(--stellar-background); }
+.dark-hc ::-webkit-scrollbar-thumb { background: var(--stellar-primary); }
+.dark-hc ::-webkit-scrollbar-thumb:hover { background: var(--stellar-secondary); }
+
+/* Toast overrides */
+.dark-hc .stellar-toast {
+  background: rgba(5, 10, 20, 0.95);
+  border-color: var(--glass-border);
+}
+
+/* Focus rings — high-visibility for keyboard navigation */
+.dark-hc *:focus-visible {
+  outline: 2px solid var(--stellar-primary) !important;
+  outline-offset: 3px;
+}

--- a/frontend/components/ThemeToggle.tsx
+++ b/frontend/components/ThemeToggle.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useTheme } from '@/hooks/useTheme';
+import { Moon, Sun } from 'lucide-react';
+
+export function ThemeToggle({ className = '' }: { className?: string }) {
+  const { isDarkHC, toggleTheme } = useTheme();
+
+  return (
+    <button
+      onClick={toggleTheme}
+      aria-pressed={isDarkHC}
+      aria-label={isDarkHC ? 'Switch to default theme' : 'Switch to high-contrast dark mode'}
+      title={isDarkHC ? 'Default theme' : 'High-contrast dark'}
+      className={`flex items-center gap-2 px-3 py-2 rounded-xl border transition-all duration-200
+        ${isDarkHC
+          ? 'border-[#00e5ff]/40 bg-[#050a14] text-[#00e5ff] hover:border-[#00e5ff]/70 hover:bg-[#0a1628]'
+          : 'border-white/10 bg-white/5 text-gray-300 hover:border-white/20 hover:text-white'
+        } ${className}`}
+    >
+      {isDarkHC ? (
+        <Moon className="w-4 h-4" aria-hidden="true" />
+      ) : (
+        <Sun className="w-4 h-4" aria-hidden="true" />
+      )}
+      <span className="text-xs font-medium hidden sm:inline">
+        {isDarkHC ? 'Dark HC' : 'Default'}
+      </span>
+
+      {/* Toggle pill */}
+      <div
+        className={`w-8 h-4 rounded-full border relative transition-colors duration-200
+          ${isDarkHC ? 'bg-[#00e5ff]/20 border-[#00e5ff]/50' : 'bg-white/10 border-white/20'}`}
+      >
+        <div
+          className={`absolute top-0.5 w-3 h-3 rounded-full transition-all duration-200
+            ${isDarkHC
+              ? 'left-[calc(100%-14px)] bg-[#00e5ff]'
+              : 'left-0.5 bg-white/60'
+            }`}
+        />
+      </div>
+    </button>
+  );
+}

--- a/frontend/components/dashboard/sidebar.tsx
+++ b/frontend/components/dashboard/sidebar.tsx
@@ -30,6 +30,7 @@ import {
   ArrowRightLeft,
 } from "lucide-react";
 import { TransactionQueueManager } from "@/components/dashboard/TransactionQueueManager";
+import { ThemeToggle } from "@/components/ThemeToggle";
 
 type NavItem = {
   label: string;
@@ -268,6 +269,10 @@ export function Sidebar({ onOpenAuditLog }: SidebarProps) {
                   })}
                 </nav>
 
+                <div className="mt-4">
+                  <ThemeToggle className="w-full justify-between" />
+                </div>
+
                 <div className="mt-5 rounded-2xl border border-white/10 bg-black/25 p-4">
                   <div className="flex items-center gap-3">
                     <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-[#00F5FF]/35 bg-[#00F5FF]/12 text-sm font-semibold text-[#CCFAFF]">
@@ -384,6 +389,13 @@ export function Sidebar({ onOpenAuditLog }: SidebarProps) {
             }
           })}
         </nav>
+
+        {/* Theme toggle — hidden when collapsed */}
+        {!collapsed && (
+          <div className="mt-4">
+            <ThemeToggle className="w-full justify-between" />
+          </div>
+        )}
 
         <div
           className={`mt-5 rounded-2xl border border-white/10 bg-black/25 transition-all duration-300 ease-in-out ${collapsed ? "h-10 w-10 flex items-center justify-center p-0" : "p-3"

--- a/frontend/hooks/useTheme.ts
+++ b/frontend/hooks/useTheme.ts
@@ -1,0 +1,34 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+export type Theme = 'default' | 'dark-hc';
+
+const STORAGE_KEY = 'stellar-theme';
+const HC_CLASS = 'dark-hc';
+
+export function useTheme() {
+  const [theme, setThemeState] = useState<Theme>('default');
+
+  useEffect(() => {
+    const saved = localStorage.getItem(STORAGE_KEY) as Theme | null;
+    if (saved === 'dark-hc') {
+      setThemeState('dark-hc');
+      document.documentElement.classList.add(HC_CLASS);
+    }
+  }, []);
+
+  const setTheme = (next: Theme) => {
+    setThemeState(next);
+    localStorage.setItem(STORAGE_KEY, next);
+    if (next === 'dark-hc') {
+      document.documentElement.classList.add(HC_CLASS);
+    } else {
+      document.documentElement.classList.remove(HC_CLASS);
+    }
+  };
+
+  const toggleTheme = () => setTheme(theme === 'dark-hc' ? 'default' : 'dark-hc');
+
+  return { theme, setTheme, toggleTheme, isDarkHC: theme === 'dark-hc' };
+}


### PR DESCRIPTION
this pr closes #1037 
this pr closes #1038 

- Add useTheme hook with localStorage persistence (stellar-theme key)
- Map all glass colors to dark-spectrum palette in globals.css (.dark-hc)
- Add ThemeToggle component with Moon/Sun icons and aria-pressed
- Wire ThemeToggle into dashboard sidebar (desktop + mobile)