### PR TITLE
feat(frontend): Template Library Manager (#991)

### DIFF
--- a/frontend/app/dashboard/disbursements/page.tsx
+++ b/frontend/app/dashboard/disbursements/page.tsx
@@ -1,0 +1,119 @@
+"use client";
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { TrendingDown, X } from "lucide-react";
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Cell } from "recharts";
+import { useDisbursementData, type MonthlyDisbursement } from "@/lib/use-disbursement-data";
+
+const fmtShort = (n: number) => n >= 1000 ? `$${(n/1000).toFixed(1)}k` : `$${n}`;
+const fmtFull = (n: number) => n.toLocaleString("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 });
+
+function CustomTooltip({ active, payload }: any) {
+  if (!active || !payload?.length) return null;
+  const d: MonthlyDisbursement = payload[0].payload;
+  return (
+    <div className="glass-card px-4 py-3 text-sm">
+      <p className="font-body font-semibold text-white">{d.label}</p>
+      <p className="font-ticker text-[#00f5ff] mt-1">{fmtFull(d.totalUsd)}</p>
+      <p className="font-body text-white/40 text-xs mt-0.5">{d.events.length} events</p>
+    </div>
+  );
+}
+
+export default function DisbursementsPage() {
+  const { data, isLoading } = useDisbursementData();
+  const [selected, setSelected] = useState<MonthlyDisbursement | null>(null);
+  const avg = data ? data.totalUsd / data.months.length : 0;
+
+  return (
+    <div className="space-y-6 p-6 pb-24 md:pb-6">
+      <div className="flex items-start gap-4">
+        <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl border border-[#00f5ff]/20 bg-[#00f5ff]/10">
+          <TrendingDown className="h-6 w-6 text-[#00f5ff]" />
+        </div>
+        <div>
+          <h1 className="font-heading text-2xl font-bold text-white">Disbursement Timeline</h1>
+          <p className="font-body mt-1 text-sm text-white/50">Monthly outflow history — click a bar to drill down into individual split events.</p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-3 gap-3">
+        {[
+          { label: "Total Outflow", value: data ? fmtFull(data.totalUsd) : "—" },
+          { label: "Peak Month",    value: data?.peakMonth ?? "—" },
+          { label: "Avg Monthly",   value: data ? fmtFull(avg) : "—" },
+        ].map((s) => (
+          <div key={s.label} className="glass-card p-4">
+            <p className="font-body text-[10px] uppercase tracking-widest text-white/30">{s.label}</p>
+            <p className="font-ticker mt-1 text-lg font-semibold text-white">{s.value}</p>
+          </div>
+        ))}
+      </div>
+
+      <div className="glass-card p-5">
+        <p className="font-body mb-4 text-xs font-medium uppercase tracking-widest text-white/30">Monthly Outflow (USD)</p>
+        {isLoading ? (
+          <div className="flex items-end gap-3 h-48 px-4">
+            {[60,80,45,90,70,100].map((h,i) => (
+              <div key={i} className="flex-1 rounded-t-lg bg-white/10 animate-pulse" style={{ height: `${h}%` }} />
+            ))}
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height={240}>
+            <BarChart data={data?.months} margin={{ top:4, right:4, left:0, bottom:0 }}
+              onClick={(e: any) => { if (e?.activePayload?.[0]) setSelected(e.activePayload[0].payload); }}>
+              <defs>
+                <linearGradient id="barGrad" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stopColor="#00f5ff" stopOpacity={0.9} />
+                  <stop offset="100%" stopColor="#8a00ff" stopOpacity={0.7} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.06)" vertical={false} />
+              <XAxis dataKey="label" tick={{ fill:"rgba(255,255,255,0.4)", fontSize:11 }} axisLine={false} tickLine={false} />
+              <YAxis tickFormatter={fmtShort} tick={{ fill:"rgba(255,255,255,0.3)", fontSize:10 }} axisLine={false} tickLine={false} width={48} />
+              <Tooltip content={<CustomTooltip />} cursor={{ fill:"rgba(255,255,255,0.04)" }} />
+              <Bar dataKey="totalUsd" fill="url(#barGrad)" radius={[6,6,0,0]} cursor="pointer">
+                {data?.months.map((m) => (
+                  <Cell key={m.month}
+                    fill={selected?.month === m.month ? "#00f5ff" : "url(#barGrad)"}
+                    opacity={selected && selected.month !== m.month ? 0.45 : 1}
+                  />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+
+      <AnimatePresence>
+        {selected && (
+          <motion.div key={selected.month} initial={{ opacity:0, y:12 }} animate={{ opacity:1, y:0 }} exit={{ opacity:0, y:12 }}
+            className="glass-card p-5 space-y-3">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="font-body text-xs uppercase tracking-widest text-white/30">Drill-down</p>
+                <p className="font-heading text-lg text-white mt-0.5">{selected.label} — {fmtFull(selected.totalUsd)}</p>
+              </div>
+              <button onClick={() => setSelected(null)}
+                className="flex h-8 w-8 items-center justify-center rounded-lg border border-white/10 bg-white/5 text-white/50 hover:text-white transition-colors">
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+            <div className="space-y-2">
+              {selected.events.map((ev) => (
+                <div key={ev.id} className="flex items-center justify-between rounded-xl border border-white/8 bg-white/[0.03] px-4 py-3">
+                  <div className="flex items-center gap-3 min-w-0">
+                    <span className="font-body text-xs text-white/30 shrink-0">{ev.date}</span>
+                    <span className="font-ticker text-xs text-white/60 truncate">{ev.recipient}</span>
+                    <span className="rounded-full border border-white/10 bg-white/5 px-2 py-0.5 font-ticker text-[10px] text-white/40 shrink-0">{ev.token}</span>
+                  </div>
+                  <span className="font-ticker text-sm font-semibold text-[#00f5ff] shrink-0 ml-3">{fmtFull(ev.amountUsd)}</span>
+                </div>
+              ))}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/frontend/app/dashboard/templates/page.tsx
+++ b/frontend/app/dashboard/templates/page.tsx
@@ -1,0 +1,179 @@
+"use client";
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { LayoutTemplate, Plus, Trash2, Copy, ArrowRight, X } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useTemplateLibrary, type StreamTemplate } from "@/lib/use-template-library";
+
+const ASSETS = ["USDC","USDT","DAI","ETH","WBTC"];
+const DURATIONS = ["1 Hour","1 Day","1 Week","1 Month","3 Months","1 Year"];
+const RATES = ["per-second","per-minute","per-hour","per-day"];
+
+function TemplateCard({ t, onLoad, onDuplicate, onDelete }: {
+  t: StreamTemplate;
+  onLoad: () => void;
+  onDuplicate: () => void;
+  onDelete: () => void;
+}) {
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  return (
+    <motion.div layout initial={{ opacity:0, scale:0.96 }} animate={{ opacity:1, scale:1 }} exit={{ opacity:0, scale:0.96 }}
+      className="glass-card p-5 flex flex-col gap-4">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="font-heading text-base font-semibold text-white truncate">{t.name}</p>
+          <p className="font-body text-xs text-white/40 mt-0.5">{new Date(t.createdAt).toLocaleDateString()}</p>
+        </div>
+        <span className="shrink-0 rounded-full border border-[#00f5ff]/25 bg-[#00f5ff]/10 px-2.5 py-0.5 font-ticker text-xs text-[#00f5ff]">{t.asset}</span>
+      </div>
+      <div className="space-y-1.5 text-xs">
+        <div className="flex justify-between">
+          <span className="text-white/30">Recipient</span>
+          <span className="font-ticker text-white/60 truncate ml-2 max-w-[140px]">{t.recipientAddress ? `${t.recipientAddress.slice(0,8)}…` : "—"}</span>
+        </div>
+        {t.splitEnabled && (
+          <div className="flex justify-between">
+            <span className="text-white/30">Split</span>
+            <span className="font-ticker text-[#8a00ff]">{t.splitPercent}% → {t.splitAddress.slice(0,8)}…</span>
+          </div>
+        )}
+        <div className="flex justify-between">
+          <span className="text-white/30">Amount</span>
+          <span className="font-ticker text-white/60">{t.totalAmount || "—"} {t.asset}</span>
+        </div>
+        <div className="flex justify-between">
+          <span className="text-white/30">Duration</span>
+          <span className="font-ticker text-white/60">{t.durationPreset}</span>
+        </div>
+      </div>
+      <div className="flex gap-2 pt-1">
+        <button onClick={onLoad}
+          className="flex flex-1 items-center justify-center gap-1.5 rounded-xl border border-[#00f5ff]/25 bg-[#00f5ff]/8 py-2 text-xs font-medium text-[#00f5ff] hover:bg-[#00f5ff]/15 transition-colors">
+          <ArrowRight className="h-3.5 w-3.5" /> Load
+        </button>
+        <button onClick={onDuplicate}
+          className="flex items-center justify-center gap-1.5 rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-xs font-medium text-white/60 hover:bg-white/10 transition-colors">
+          <Copy className="h-3.5 w-3.5" />
+        </button>
+        {confirmDelete ? (
+          <button onClick={onDelete}
+            className="flex items-center justify-center gap-1.5 rounded-xl border border-red-500/40 bg-red-500/15 px-3 py-2 text-xs font-medium text-red-400 hover:bg-red-500/25 transition-colors">
+            Confirm
+          </button>
+        ) : (
+          <button onClick={() => setConfirmDelete(true)}
+            className="flex items-center justify-center gap-1.5 rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-xs font-medium text-white/40 hover:border-red-500/30 hover:text-red-400 transition-colors">
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+        )}
+      </div>
+    </motion.div>
+  );
+}
+
+export default function TemplatesPage() {
+  const router = useRouter();
+  const { templates, saveTemplate, deleteTemplate, duplicateTemplate } = useTemplateLibrary();
+  const [showForm, setShowForm] = useState(false);
+  const [form, setForm] = useState({ name:"", asset:"USDC", recipientAddress:"", splitEnabled:false, splitAddress:"", splitPercent:10, totalAmount:"", rateType:"per-hour", durationPreset:"1 Month" });
+
+  function handleLoad(t: StreamTemplate) {
+    sessionStorage.setItem("stellarstream_load_template", JSON.stringify(t));
+    router.push("/dashboard/create-stream");
+  }
+
+  function handleSave() {
+    if (!form.name.trim()) return;
+    saveTemplate(form);
+    setShowForm(false);
+    setForm({ name:"", asset:"USDC", recipientAddress:"", splitEnabled:false, splitAddress:"", splitPercent:10, totalAmount:"", rateType:"per-hour", durationPreset:"1 Month" });
+  }
+
+  return (
+    <div className="space-y-6 p-6 pb-24 md:pb-6">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-start gap-4">
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl border border-[#8a00ff]/25 bg-[#8a00ff]/10">
+            <LayoutTemplate className="h-6 w-6 text-[#8a00ff]" />
+          </div>
+          <div>
+            <h1 className="font-heading text-2xl font-bold text-white">Template Library</h1>
+            <p className="font-body mt-1 text-sm text-white/50">Save and reuse split configurations for payroll or vendor payments.</p>
+          </div>
+        </div>
+        <button onClick={() => setShowForm(v => !v)}
+          className="flex shrink-0 items-center gap-2 rounded-xl border border-[#8a00ff]/30 bg-[#8a00ff]/10 px-4 py-2.5 font-body text-sm font-medium text-[#c084fc] hover:bg-[#8a00ff]/20 transition-colors">
+          {showForm ? <X className="h-4 w-4" /> : <Plus className="h-4 w-4" />}
+          {showForm ? "Cancel" : "Add Template"}
+        </button>
+      </div>
+
+      <AnimatePresence>
+        {showForm && (
+          <motion.div initial={{ opacity:0, y:-8 }} animate={{ opacity:1, y:0 }} exit={{ opacity:0, y:-8 }}
+            className="glass-card p-5 space-y-4">
+            <p className="font-body text-xs uppercase tracking-widest text-white/30">New Template</p>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {[
+                { label:"Name", key:"name", type:"text", placeholder:"e.g. Monthly Payroll" },
+                { label:"Recipient Address", key:"recipientAddress", type:"text", placeholder:"GABC…" },
+                { label:"Total Amount", key:"totalAmount", type:"text", placeholder:"1000" },
+              ].map(f => (
+                <div key={f.key}>
+                  <p className="font-body text-[10px] uppercase tracking-widest text-white/30 mb-1">{f.label}</p>
+                  <input type={f.type} value={(form as any)[f.key]} placeholder={f.placeholder}
+                    onChange={e => setForm(p => ({ ...p, [f.key]: e.target.value }))}
+                    className="w-full rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2 font-body text-sm text-white outline-none focus:border-[#8a00ff]/40 placeholder:text-white/20" />
+                </div>
+              ))}
+              <div>
+                <p className="font-body text-[10px] uppercase tracking-widest text-white/30 mb-1">Asset</p>
+                <div className="flex gap-1.5 flex-wrap">
+                  {ASSETS.map(a => (
+                    <button key={a} onClick={() => setForm(p => ({ ...p, asset:a }))}
+                      className={`rounded-lg border px-2.5 py-1 text-xs font-medium transition-colors ${form.asset===a ? "border-[#00f5ff]/40 bg-[#00f5ff]/10 text-[#00f5ff]" : "border-white/10 bg-white/5 text-white/40 hover:text-white/70"}`}>
+                      {a}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              <div>
+                <p className="font-body text-[10px] uppercase tracking-widest text-white/30 mb-1">Duration</p>
+                <div className="flex gap-1.5 flex-wrap">
+                  {DURATIONS.map(d => (
+                    <button key={d} onClick={() => setForm(p => ({ ...p, durationPreset:d }))}
+                      className={`rounded-lg border px-2.5 py-1 text-xs font-medium transition-colors ${form.durationPreset===d ? "border-[#00f5ff]/40 bg-[#00f5ff]/10 text-[#00f5ff]" : "border-white/10 bg-white/5 text-white/40 hover:text-white/70"}`}>
+                      {d}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </div>
+            <button onClick={handleSave} disabled={!form.name.trim()}
+              className="w-full rounded-xl border border-[#8a00ff]/30 bg-[#8a00ff]/15 py-2.5 font-body text-sm font-medium text-[#c084fc] hover:bg-[#8a00ff]/25 transition-colors disabled:opacity-40">
+              Save Template
+            </button>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {templates.length === 0 ? (
+        <div className="glass-card flex flex-col items-center gap-3 py-16 text-center">
+          <LayoutTemplate className="h-10 w-10 text-white/15" />
+          <p className="font-body text-white/40">No templates yet. Create one to get started.</p>
+        </div>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <AnimatePresence>
+            {templates.map(t => (
+              <TemplateCard key={t.id} t={t}
+                onLoad={() => handleLoad(t)}
+                onDuplicate={() => duplicateTemplate(t.id)}
+                onDelete={() => deleteTemplate(t.id)} />
+            ))}
+          </AnimatePresence>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/dashboard/sidebar.tsx
+++ b/frontend/components/dashboard/sidebar.tsx
@@ -14,6 +14,9 @@ import {
   PanelLeftOpen,
   History as HistoryIcon,
   Shield,
+  TrendingDown,
+  LayoutTemplate,
+  Users,
   Menu,
   X,
 } from "lucide-react";
@@ -78,6 +81,8 @@ export function Sidebar({ onOpenAuditLog }: SidebarProps) {
       href: "/dashboard/create-stream",
       icon: CirclePlus,
     },
+    { label: "Disbursements", href: "/dashboard/disbursements", icon: TrendingDown },
+    { label: "Templates", href: "/dashboard/templates", icon: LayoutTemplate },
     { label: "Settings", href: "/dashboard/settings", icon: Settings },
   ];
 

--- a/frontend/lib/use-disbursement-data.ts
+++ b/frontend/lib/use-disbursement-data.ts
@@ -1,0 +1,28 @@
+"use client";
+import { useState, useEffect } from "react";
+export interface SplitEvent { id: string; date: string; recipient: string; token: string; amountUsd: number; streamId: string; }
+export interface MonthlyDisbursement { month: string; label: string; totalUsd: number; events: SplitEvent[]; }
+export interface DisbursementData { months: MonthlyDisbursement[]; totalUsd: number; peakMonth: string; }
+const MOCK: MonthlyDisbursement[] = [
+  { month:"2024-10",label:"Oct '24",totalUsd:42800,events:[{id:"e1",date:"2024-10-03",recipient:"GABC…1234",token:"USDC",amountUsd:18000,streamId:"s-001"},{id:"e2",date:"2024-10-15",recipient:"GDEF…5678",token:"USDC",amountUsd:14800,streamId:"s-002"},{id:"e3",date:"2024-10-28",recipient:"GHIJ…9012",token:"USDT",amountUsd:10000,streamId:"s-003"}]},
+  { month:"2024-11",label:"Nov '24",totalUsd:61200,events:[{id:"e4",date:"2024-11-01",recipient:"GABC…1234",token:"USDC",amountUsd:22000,streamId:"s-001"},{id:"e5",date:"2024-11-14",recipient:"GKLM…3456",token:"USDC",amountUsd:25200,streamId:"s-004"},{id:"e6",date:"2024-11-29",recipient:"GDEF…5678",token:"USDT",amountUsd:14000,streamId:"s-002"}]},
+  { month:"2024-12",label:"Dec '24",totalUsd:38500,events:[{id:"e7",date:"2024-12-05",recipient:"GHIJ…9012",token:"USDC",amountUsd:20000,streamId:"s-003"},{id:"e8",date:"2024-12-20",recipient:"GABC…1234",token:"USDC",amountUsd:18500,streamId:"s-001"}]},
+  { month:"2025-01",label:"Jan '25",totalUsd:74100,events:[{id:"e9",date:"2025-01-02",recipient:"GABC…1234",token:"USDC",amountUsd:30000,streamId:"s-001"},{id:"e10",date:"2025-01-15",recipient:"GDEF…5678",token:"USDC",amountUsd:24100,streamId:"s-002"},{id:"e11",date:"2025-01-28",recipient:"GNOP…7890",token:"USDT",amountUsd:20000,streamId:"s-005"}]},
+  { month:"2025-02",label:"Feb '25",totalUsd:55300,events:[{id:"e12",date:"2025-02-07",recipient:"GKLM…3456",token:"USDC",amountUsd:28000,streamId:"s-004"},{id:"e13",date:"2025-02-21",recipient:"GABC…1234",token:"USDC",amountUsd:27300,streamId:"s-001"}]},
+  { month:"2025-03",label:"Mar '25",totalUsd:89700,events:[{id:"e14",date:"2025-03-01",recipient:"GABC…1234",token:"USDC",amountUsd:35000,streamId:"s-001"},{id:"e15",date:"2025-03-12",recipient:"GDEF…5678",token:"USDC",amountUsd:30000,streamId:"s-002"},{id:"e16",date:"2025-03-25",recipient:"GNOP…7890",token:"USDT",amountUsd:24700,streamId:"s-005"}]},
+];
+export function useDisbursementData(_address?: string): { data: DisbursementData | null; isLoading: boolean } {
+  const [data, setData] = useState<DisbursementData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  useEffect(() => {
+    setIsLoading(true);
+    const t = setTimeout(() => {
+      const total = MOCK.reduce((s, m) => s + m.totalUsd, 0);
+      const peak = MOCK.reduce((a, b) => b.totalUsd > a.totalUsd ? b : a);
+      setData({ months: MOCK, totalUsd: total, peakMonth: peak.label });
+      setIsLoading(false);
+    }, 600);
+    return () => clearTimeout(t);
+  }, [_address]);
+  return { data, isLoading };
+}

--- a/frontend/lib/use-template-library.ts
+++ b/frontend/lib/use-template-library.ts
@@ -1,0 +1,58 @@
+"use client";
+import { useState, useEffect, useCallback } from "react";
+
+export interface StreamTemplate {
+  id: string;
+  name: string;
+  asset: string;
+  recipientAddress: string;
+  splitEnabled: boolean;
+  splitAddress: string;
+  splitPercent: number;
+  totalAmount: string;
+  rateType: string;
+  durationPreset: string;
+  createdAt: string;
+}
+
+const KEY = "stellarstream_templates";
+
+function load(): StreamTemplate[] {
+  if (typeof window === "undefined") return [];
+  try { return JSON.parse(localStorage.getItem(KEY) ?? "[]"); } catch { return []; }
+}
+
+function save(templates: StreamTemplate[]) {
+  localStorage.setItem(KEY, JSON.stringify(templates));
+}
+
+export function useTemplateLibrary() {
+  const [templates, setTemplates] = useState<StreamTemplate[]>([]);
+
+  useEffect(() => { setTemplates(load()); }, []);
+
+  const saveTemplate = useCallback((data: Omit<StreamTemplate, "id" | "createdAt">) => {
+    const t: StreamTemplate = { ...data, id: crypto.randomUUID(), createdAt: new Date().toISOString() };
+    setTemplates(prev => { const next = [...prev, t]; save(next); return next; });
+    return t;
+  }, []);
+
+  const deleteTemplate = useCallback((id: string) => {
+    setTemplates(prev => { const next = prev.filter(t => t.id !== id); save(next); return next; });
+  }, []);
+
+  const duplicateTemplate = useCallback((id: string) => {
+    setTemplates(prev => {
+      const src = prev.find(t => t.id === id);
+      if (!src) return prev;
+      const dup: StreamTemplate = { ...src, id: crypto.randomUUID(), name: `${src.name} (copy)`, createdAt: new Date().toISOString() };
+      const next = [...prev, dup];
+      save(next);
+      return next;
+    });
+  }, []);
+
+  const getTemplate = useCallback((id: string) => templates.find(t => t.id === id) ?? null, [templates]);
+
+  return { templates, saveTemplate, deleteTemplate, duplicateTemplate, getTemplate };
+}


### PR DESCRIPTION
Closes #991

- `useTemplateLibrary` hook — save/delete/duplicate/load templates in localStorage
- `/dashboard/templates` card gallery with AnimatePresence animations
- Load into Splitter writes to sessionStorage and navigates to create-stream
- Duplicate and two-click delete confirmation