### PR TITLE
fix: implemented json-to-csv

### DIFF
--- a/frontend/app/dashboard/split-report/page.tsx
+++ b/frontend/app/dashboard/split-report/page.tsx
@@ -7,6 +7,7 @@ import { Suspense, useEffect, useRef, useState } from "react";
 import { ExternalLink, CheckCircle2, Copy, Download, Share2 } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { generateProofOfPaymentPDF } from "@/lib/proof-of-payment-pdf";
+import { downloadSettlementCsv, type SettlementCsvRecipient } from "@/lib/settlement-csv";
 
 const STELLAR_EXPERT_BASE =
   process.env.NEXT_PUBLIC_STELLAR_NETWORK === "mainnet"
@@ -17,6 +18,51 @@ interface OperationRow {
   index: number;
   operationId: string;
   url: string;
+}
+
+function parseRecipientParam(rawRecipients: string | null): SettlementCsvRecipient[] | undefined {
+  if (!rawRecipients) return undefined;
+
+  const candidates = [rawRecipients];
+  try {
+    candidates.push(decodeURIComponent(rawRecipients));
+  } catch {
+    // Keep raw candidate only when decoding fails.
+  }
+
+  try {
+    for (const candidate of candidates) {
+      const parsed = JSON.parse(candidate);
+      if (!Array.isArray(parsed)) continue;
+
+      return parsed
+        .map((item) => {
+          if (!item || typeof item !== "object") return null;
+          const row = item as Record<string, unknown>;
+
+          return {
+            address: typeof row.address === "string" ? row.address : undefined,
+            payee:
+              typeof row.payee === "string"
+                ? row.payee
+                : typeof row.name === "string"
+                  ? row.name
+                  : undefined,
+            amount:
+              typeof row.amount === "number" || typeof row.amount === "string"
+                ? row.amount
+                : undefined,
+            memo: typeof row.memo === "string" ? row.memo : undefined,
+            operationId: typeof row.operationId === "string" ? row.operationId : undefined,
+          };
+        })
+        .filter((entry): entry is SettlementCsvRecipient => entry !== null);
+    }
+
+    return undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function buildRows(txHash: string, opCount: number): OperationRow[] {
@@ -114,6 +160,10 @@ function ReportContent() {
   const sender = params.get("sender") ?? "GABC…7XYZ";
   const asset = params.get("asset") ?? "USDC";
   const amount = params.get("amount") ?? "0";
+  const streamId = params.get("streamId") ?? txHash.slice(0, 12);
+  const memo = params.get("memo") ?? undefined;
+  const timestamp = params.get("timestamp") ?? new Date().toISOString();
+  const recipients = parseRecipientParam(params.get("recipients"));
   const rows = buildRows(txHash, opCount);
 
   const [shareLabel, setShareLabel] = useState("Share Link");
@@ -131,13 +181,27 @@ function ReportContent() {
 
   async function handleDownloadPDF() {
     await generateProofOfPaymentPDF({
-      streamId: txHash.slice(0, 12),
+      streamId,
       sender,
       receiver: `${opCount} recipients`,
       asset,
       amount: `${amount} ${asset}`,
       timestamp: new Date().toISOString(),
       txHash,
+    });
+  }
+
+  function handleDownloadSettlementCsv() {
+    downloadSettlementCsv({
+      txHash,
+      sender,
+      asset,
+      totalAmount: amount,
+      timestamp,
+      streamId,
+      memo,
+      fallbackRecipientCount: opCount,
+      recipients,
     });
   }
 
@@ -179,6 +243,13 @@ function ReportContent() {
           >
             <Download size={13} />
             Download PDF
+          </button>
+          <button
+            onClick={handleDownloadSettlementCsv}
+            className="flex items-center gap-1.5 rounded-xl border border-emerald-400/20 bg-emerald-400/[0.08] px-3 py-2 text-xs text-emerald-200 hover:text-emerald-100 transition-colors"
+          >
+            <Download size={13} />
+            Settlement CSV
           </button>
           <button
             onClick={handleShare}

--- a/frontend/lib/settlement-csv.test.ts
+++ b/frontend/lib/settlement-csv.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { buildSettlementCsv } from "@/lib/settlement-csv";
+
+describe("settlement-csv", () => {
+  it("builds accounting-compatible CSV rows for provided recipients", () => {
+    const csv = buildSettlementCsv({
+      txHash: "abc123def456",
+      sender: "GD5SENDER",
+      asset: "USDC",
+      totalAmount: "175.5",
+      timestamp: "2026-04-25T10:00:00.000Z",
+      streamId: "stream-42",
+      memo: "Payroll April",
+      recipients: [
+        {
+          address: "GRECIPIENT1",
+          payee: "Alice",
+          amount: 100,
+          operationId: "abc-op0",
+        },
+        {
+          address: "GRECIPIENT2",
+          payee: "Bob",
+          amount: "75.5",
+          operationId: "abc-op1",
+        },
+      ],
+    });
+
+    const lines = csv.trim().split("\n");
+    expect(lines[0]).toBe(
+      "Date,Amount,Payee,Description,Reference,Currency,Debit,Credit,Tx_Hash,Operation_ID,Stream_ID,Sender_Address,Recipient_Address,Asset,Memo,Status",
+    );
+    expect(lines[1]).toContain("2026-04-25,-100,Alice");
+    expect(lines[1]).toContain(
+      ",StellarStream split settlement (USDC),SETTLEMENT-abc123def456,USDC,100,0,abc123def456,abc-op0,stream-42,GD5SENDER,GRECIPIENT1,USDC,Payroll April,Settled",
+    );
+    expect(lines[2]).toContain("2026-04-25,-75.5,Bob");
+  });
+
+  it("creates fallback rows when recipients are not provided", () => {
+    const csv = buildSettlementCsv({
+      txHash: "def456abc123",
+      sender: "GSENDERXYZ",
+      asset: "XLM",
+      totalAmount: "30",
+      fallbackRecipientCount: 3,
+    });
+
+    const lines = csv.trim().split("\n");
+    expect(lines).toHaveLength(4);
+    expect(lines[1]).toContain(",-10,Recipient 1,");
+    expect(lines[2]).toContain(",-10,Recipient 2,");
+    expect(lines[3]).toContain(",-10,Recipient 3,");
+  });
+});

--- a/frontend/lib/settlement-csv.ts
+++ b/frontend/lib/settlement-csv.ts
@@ -1,0 +1,155 @@
+export interface SettlementCsvRecipient {
+  address?: string;
+  payee?: string;
+  amount?: number | string;
+  memo?: string;
+  operationId?: string;
+}
+
+export interface SettlementCsvInput {
+  txHash: string;
+  sender: string;
+  asset: string;
+  totalAmount: number | string;
+  timestamp?: string;
+  streamId?: string;
+  memo?: string;
+  currency?: string;
+  fallbackRecipientCount?: number;
+  recipients?: SettlementCsvRecipient[];
+}
+
+const SETTLEMENT_HEADERS = [
+  "Date",
+  "Amount",
+  "Payee",
+  "Description",
+  "Reference",
+  "Currency",
+  "Debit",
+  "Credit",
+  "Tx_Hash",
+  "Operation_ID",
+  "Stream_ID",
+  "Sender_Address",
+  "Recipient_Address",
+  "Asset",
+  "Memo",
+  "Status",
+] as const;
+
+function escapeCsvValue(value: string | number | undefined): string {
+  if (value === undefined || value === null) {
+    return "";
+  }
+
+  const stringValue = String(value);
+  if (
+    stringValue.includes(",") ||
+    stringValue.includes('"') ||
+    stringValue.includes("\n")
+  ) {
+    return `"${stringValue.replace(/"/g, '""')}"`;
+  }
+  return stringValue;
+}
+
+function parseAmount(value: number | string): number {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : 0;
+  }
+
+  const normalized = value.replace(/,/g, "").trim();
+  const parsed = Number.parseFloat(normalized);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function formatAmount(value: number): string {
+  const normalized = Object.is(value, -0) ? 0 : value;
+  return normalized
+    .toFixed(7)
+    .replace(/\.0+$/, "")
+    .replace(/(\.\d*?)0+$/, "$1");
+}
+
+function toDateValue(timestamp: string): string {
+  const parsed = new Date(timestamp);
+  if (Number.isNaN(parsed.getTime())) {
+    return new Date().toISOString().slice(0, 10);
+  }
+  return parsed.toISOString().slice(0, 10);
+}
+
+function expandRecipients(input: SettlementCsvInput): SettlementCsvRecipient[] {
+  const provided = input.recipients?.filter(Boolean) ?? [];
+  if (provided.length > 0) {
+    return provided;
+  }
+
+  const fallbackCount = Math.max(1, input.fallbackRecipientCount ?? 1);
+  const totalAmount = parseAmount(input.totalAmount);
+  const perRecipient =
+    fallbackCount > 0 ? totalAmount / fallbackCount : totalAmount;
+
+  return Array.from({ length: fallbackCount }, (_, index) => ({
+    payee: `Recipient ${index + 1}`,
+    amount: perRecipient,
+    operationId: `${input.txHash.slice(0, 16)}-op${index}`,
+  }));
+}
+
+export function buildSettlementCsv(input: SettlementCsvInput): string {
+  const rows: string[] = [SETTLEMENT_HEADERS.join(",")];
+  const date = toDateValue(input.timestamp ?? new Date().toISOString());
+  const recipients = expandRecipients(input);
+  const reference = `SETTLEMENT-${input.txHash.slice(0, 12)}`;
+  const description = `StellarStream split settlement (${input.asset})`;
+  const currency = input.currency ?? input.asset;
+
+  recipients.forEach((recipient, index) => {
+    const absoluteAmount = Math.abs(parseAmount(recipient.amount ?? 0));
+    const amount = -absoluteAmount;
+    const operationId =
+      recipient.operationId ?? `${input.txHash.slice(0, 16)}-op${index}`;
+
+    const values = [
+      date,
+      formatAmount(amount),
+      escapeCsvValue(recipient.payee ?? `Recipient ${index + 1}`),
+      escapeCsvValue(description),
+      reference,
+      escapeCsvValue(currency),
+      formatAmount(absoluteAmount),
+      "0",
+      input.txHash,
+      escapeCsvValue(operationId),
+      escapeCsvValue(input.streamId),
+      escapeCsvValue(input.sender),
+      escapeCsvValue(recipient.address),
+      escapeCsvValue(input.asset),
+      escapeCsvValue(recipient.memo ?? input.memo),
+      "Settled",
+    ];
+
+    rows.push(values.join(","));
+  });
+
+  return `${rows.join("\n")}\n`;
+}
+
+export function downloadSettlementCsv(input: SettlementCsvInput): void {
+  const csv = buildSettlementCsv(input);
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+
+  const filenameDate = new Date().toISOString().slice(0, 10);
+  const link = document.createElement("a");
+  link.href = url;
+  link.setAttribute("download", `settlement_${filenameDate}.csv`);
+  link.style.display = "none";
+
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
closes #1036

This pull request adds the ability to generate and download an accounting-compatible CSV settlement report from the split payment dashboard. It introduces a new CSV generation utility, integrates it with the UI, and includes tests to ensure correct CSV output for various scenarios.