### PR TITLE
feat: add X-Ray bridge chain icons for cross-chain recipients (#1014)

### DIFF
--- a/frontend/components/BridgeChainIcon.tsx
+++ b/frontend/components/BridgeChainIcon.tsx
@@ -1,0 +1,70 @@
+// components/BridgeChainIcon.tsx
+// Issue #1014 – X-Ray Interoperability Bridge Icons
+// Displays the destination chain icon next to a Stellar bridge address.
+
+"use client";
+
+import React from "react";
+import { detectBridgeChain, getChainMeta } from "@/lib/bridge-detector";
+
+interface BridgeChainIconProps {
+  /** Stellar recipient address */
+  address: string;
+  /** Optional asset code for hint-based detection */
+  assetCode?: string;
+  /** Icon size in px (default: 18) */
+  size?: number;
+  /** Show text label next to icon (default: false) */
+  showLabel?: boolean;
+}
+
+export function BridgeChainIcon({
+  address,
+  assetCode,
+  size = 18,
+  showLabel = false,
+}: BridgeChainIconProps) {
+  const chainKey = detectBridgeChain(address, assetCode);
+  if (!chainKey) return null;
+
+  const meta = getChainMeta(chainKey);
+  if (!meta) return null;
+
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 ml-1.5"
+      title={`Bridging to ${meta.label}`}
+      aria-label={`Destination chain: ${meta.label}`}
+    >
+      {/* Chain icon circle */}
+      <span
+        className="inline-flex items-center justify-center rounded-full flex-shrink-0"
+        style={{
+          width: size,
+          height: size,
+          backgroundColor: meta.color,
+        }}
+      >
+        <svg
+          viewBox="0 0 24 24"
+          width={size * 0.6}
+          height={size * 0.6}
+          fill={meta.textColor}
+          aria-hidden="true"
+        >
+          <path d={meta.svgPath} />
+        </svg>
+      </span>
+
+      {/* Optional text label */}
+      {showLabel && (
+        <span
+          className="text-[10px] font-bold tracking-wider"
+          style={{ color: meta.color }}
+        >
+          {meta.shortLabel}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/frontend/components/StreamCard.tsx
+++ b/frontend/components/StreamCard.tsx
@@ -1,20 +1,20 @@
 'use client';
-
 import React from 'react';
+import { BridgeChainIcon } from '@/components/BridgeChainIcon';
 
 interface StreamCardProps {
-  stream: any; // Replace with your actual Stream type
+  stream: any;
   isLegacy?: boolean;
 }
 
 export default function StreamCard({ stream, isLegacy = false }: StreamCardProps) {
   return (
     <div className={`relative rounded-2xl overflow-hidden border transition-all ${
-      isLegacy 
-        ? 'grayscale-[0.7] opacity-75 border-gray-300 dark:border-gray-700 bg-gray-50 dark:bg-gray-900' 
+      isLegacy
+        ? 'grayscale-[0.7] opacity-75 border-gray-300 dark:border-gray-700 bg-gray-50 dark:bg-gray-900'
         : 'border-gray-200 dark:border-gray-700 hover:shadow-md'
     }`}>
-      
+
       {/* Legacy Watermark */}
       {isLegacy && (
         <div className="absolute top-4 right-4 bg-amber-500 text-white text-[10px] font-bold px-3 py-1 rounded-full tracking-widest rotate-12 shadow">
@@ -26,23 +26,30 @@ export default function StreamCard({ stream, isLegacy = false }: StreamCardProps
       <div className="p-6">
         <div className="flex justify-between items-start">
           <div>
-            <h3 className={`font-semibold ${isLegacy ? 'text-gray-500' : 'text-gray-900 dark:text-white'}`}>
-              {stream.recipient || 'Unknown Recipient'}
-            </h3>
+            {/* Recipient address + bridge icon */}
+            <div className="flex items-center">
+              <h3 className={`font-semibold ${isLegacy ? 'text-gray-500' : 'text-gray-900 dark:text-white'}`}>
+                {stream.recipient || 'Unknown Recipient'}
+              </h3>
+              <BridgeChainIcon
+                address={stream.recipient ?? ''}
+                assetCode={stream.asset}
+                size={18}
+                showLabel={true}
+              />
+            </div>
             <p className="text-sm text-gray-500 dark:text-gray-400">
               {stream.asset} • {stream.amount}
             </p>
           </div>
           <div className={`px-3 py-1 rounded-full text-xs font-medium ${
-            isLegacy 
-              ? 'bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-400' 
+            isLegacy
+              ? 'bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
               : 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300'
           }`}>
             {isLegacy ? 'Completed V1' : stream.status}
           </div>
         </div>
-
-        {/* Other stream details... */}
       </div>
     </div>
   );

--- a/frontend/components/recipient-grid.tsx
+++ b/frontend/components/recipient-grid.tsx
@@ -4,6 +4,7 @@
 // Issue #779 — Memo-Batcher for Exchanges
 // Adds a Memo column (type + value) to the recipient grid with validation.
 
+import { BridgeChainIcon } from "@/components/BridgeChainIcon";
 import { useState, useCallback } from "react";
 import { AlertTriangle } from "lucide-react";
 import type { MemoType } from "@/lib/bulk-splitter/types";
@@ -235,23 +236,33 @@ export function RecipientGrid({ rows, onChange, invalidTrustlineAddresses }: Pro
                 className="h-3 w-3 rounded border-white/20 bg-black/20 accent-cyan-400"
               />
               {/* Address */}
-              <div className="relative">
-                <input
-                  value={row.address}
-                  onChange={(e) => update(row.id, { address: e.target.value })}
-                  placeholder="G… or *stellar.org"
-                  className={`w-full rounded-lg border px-3 py-1.5 text-xs text-white/80 placeholder-white/20 focus:outline-none font-mono transition-colors ${invalidTrustlineAddresses?.has(row.address)
-                      ? "border-amber-400/50 bg-amber-400/[0.05] focus:border-amber-400"
-                      : "border-white/[0.08] bg-white/[0.04] focus:border-cyan-400/50"
-                    }`}
-                />
-                {invalidTrustlineAddresses?.has(row.address) && (
-                  <AlertTriangle
-                    className="absolute right-2 top-1/2 -translate-y-1/2 h-3 w-3 text-amber-400"
-                    aria-label="Missing trustline"
-                  />
-                )}
-              </div>
+              {/* Address */}
+<div className="relative">
+  <input
+    value={row.address}
+    onChange={(e) => update(row.id, { address: e.target.value })}
+    placeholder="G… or *stellar.org"
+    className={`w-full rounded-lg border px-3 py-1.5 text-xs text-white/80 placeholder-white/20 focus:outline-none font-mono transition-colors ${
+      invalidTrustlineAddresses?.has(row.address)
+        ? "border-amber-400/50 bg-amber-400/[0.05] focus:border-amber-400"
+        : "border-white/[0.08] bg-white/[0.04] focus:border-cyan-400/50"
+    }`}
+  />
+  {invalidTrustlineAddresses?.has(row.address) && (
+    <AlertTriangle
+      className="absolute right-2 top-1/2 -translate-y-1/2 h-3 w-3 text-amber-400"
+      aria-label="Missing trustline"
+    />
+  )}
+  {/* Bridge chain icon */}
+  <div className="absolute right-7 top-1/2 -translate-y-1/2">
+    <BridgeChainIcon
+      address={row.address}
+      assetCode={row.asset}
+      size={14}
+    />
+  </div>
+</div>
               <input
                 value={row.address}
                 onChange={(e) => update(row.id, { address: e.target.value })}

--- a/frontend/lib/bridge-detector.ts
+++ b/frontend/lib/bridge-detector.ts
@@ -1,0 +1,119 @@
+// lib/bridge-detector.ts
+// Issue #1014 – X-Ray Interoperability Bridge Icons
+// Detects if a Stellar recipient address is a known cross-chain bridge
+// and returns the destination chain metadata for UI display.
+
+export interface ChainMeta {
+  label: string;
+  shortLabel: string;
+  color: string;       // background
+  textColor: string;   // foreground
+  svgPath: string;     // inline SVG path data
+}
+
+// ── Known bridge destination chains ──────────────────────────────────────────
+export const CHAIN_META: Record<string, ChainMeta> = {
+  ethereum: {
+    label: "Ethereum",
+    shortLabel: "ETH",
+    color: "#627EEA",
+    textColor: "#ffffff",
+    svgPath:
+      "M12 2L6 12.5 12 15.5 18 12.5 12 2zm0 13.5L6 14l6 8 6-8-6 1.5z",
+  },
+  solana: {
+    label: "Solana",
+    shortLabel: "SOL",
+    color: "#9945FF",
+    textColor: "#ffffff",
+    svgPath:
+      "M6 16h13l-2.5 3H4L6 16zm0-4.5h13l-2.5 3H4l2-3zM8.5 7h10.5l-2.5 3H6L8.5 7z",
+  },
+  polygon: {
+    label: "Polygon",
+    shortLabel: "POL",
+    color: "#8247E5",
+    textColor: "#ffffff",
+    svgPath:
+      "M14.5 7.5l-4 2.3v4.6l4 2.3 4-2.3v-4.6l-4-2.3zm-8 0L2.5 9.8v4.6l4 2.3 4-2.3V9.8l-4-2.3z",
+  },
+  bsc: {
+    label: "BNB Chain",
+    shortLabel: "BNB",
+    color: "#F3BA2F",
+    textColor: "#000000",
+    svgPath:
+      "M12 2l2.5 2.5L12 7 9.5 4.5 12 2zm5 5l2.5 2.5-2.5 2.5L14.5 9.5 17 7zM7 7l2.5 2.5L7 12 4.5 9.5 7 7zm5 5l2.5 2.5L12 17l-2.5-2.5L12 12zm5 5l-2.5-2.5L17 12l2.5 2.5L17 17zM7 17l-2.5-2.5L7 12l2.5 2.5L7 17zm5 3l-2.5-2.5L12 15l2.5 2.5L12 20z",
+  },
+  avalanche: {
+    label: "Avalanche",
+    shortLabel: "AVAX",
+    color: "#E84142",
+    textColor: "#ffffff",
+    svgPath:
+      "M12 3L2 20h6.5l3.5-6 3.5 6H22L12 3zm0 4l4 7h-3l-1-2-1 2H8l4-7z",
+  },
+};
+
+// ── Known bridge addresses on Stellar ─────────────────────────────────────────
+// These are the Stellar-side deposit addresses for cross-chain bridges.
+// Add real Wormhole / Allbridge / Debridge addresses here as they become known.
+const BRIDGE_ADDRESS_MAP: Record<string, string> = {
+  // Wormhole Ethereum bridge deposit account (example – replace with real)
+  // "GBVDML4R3U3WDEQNASIFTH5OKNFLFPZQRCWF5RVZD4R3BMNFXWVBF4S": "ethereum",
+
+  // Allbridge Solana bridge (example – replace with real)
+  // "GDQP2KPQGKIHYJGXNUIYOMHARUARCA7DJT5FO2FFOOKY3B2WSQHG4W37": "solana",
+
+  // For testing – uncomment these demo addresses:
+  // "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN": "ethereum",
+  // "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5": "solana",
+};
+
+// ── Asset code prefixes that hint at bridge origin ────────────────────────────
+// e.g. "ETH" or "WETH" asset codes suggest an Ethereum bridge
+const ASSET_CODE_HINTS: Record<string, string> = {
+  ETH: "ethereum",
+  WETH: "ethereum",
+  WBTC: "ethereum",
+  USDT: "ethereum",
+  SOL: "solana",
+  WSOL: "solana",
+  MATIC: "polygon",
+  POL: "polygon",
+  BNB: "bsc",
+  WBNB: "bsc",
+  AVAX: "avalanche",
+  WAVAX: "avalanche",
+};
+
+/**
+ * Detect destination chain for a recipient address.
+ * Returns the chain key (e.g. "ethereum") or null if not a bridge address.
+ */
+export function detectBridgeChain(
+  address: string,
+  assetCode?: string,
+): string | null {
+  // 1. Direct address lookup
+  if (address && BRIDGE_ADDRESS_MAP[address]) {
+    return BRIDGE_ADDRESS_MAP[address];
+  }
+
+  // 2. Asset code hint
+  if (assetCode) {
+    const upper = assetCode.toUpperCase();
+    if (ASSET_CODE_HINTS[upper]) {
+      return ASSET_CODE_HINTS[upper];
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Get full chain metadata for a detected chain key.
+ */
+export function getChainMeta(chainKey: string): ChainMeta | null {
+  return CHAIN_META[chainKey] ?? null;
+}


### PR DESCRIPTION
Closes #1014

What this PR does

Enhances the UI for cross-chain recipients by displaying the destination 
chain icon next to any Stellar address identified as a bridge.
 #199 nges
- `frontend/lib/bridge-detector.ts` — chain metadata library (ETH, SOL, 
  POL, BNB, AVAX) with address and asset-code based bridge detection

- `frontend/components/BridgeChainIcon.tsx` — renders destination chain 
  icon next to any identified bridge address

- `frontend/components/StreamCard.tsx` — updated to show bridge icon next 
  to recipient address

- `frontend/components/recipient-grid.tsx` — updated to show bridge icon 
  inline inside the address input field