### PR TITLE
Implement WebSocket heartbeat mechanism and load testing scripts

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -20,6 +20,8 @@
     "db:generate": "prisma generate",
     "db:studio": "prisma studio",
     "test:jest": "jest --config jest.config.cjs --runInBand",
+    "test:ws-load": "tsx src/test-websocket-load.ts",
+    "test:ws-load:1000": "COUNT=1000 tsx src/test-websocket-load.ts",
     "test:e2e": "jest --config jest.config.cjs --testPathPattern=e2e --runInBand",
     "migrate:v1-to-v2": "tsx src/scripts/migrate-v1-to-v2.ts",
     "migrate:v1-to-v2:dry": "tsx src/scripts/migrate-v1-to-v2.ts --dry-run",

--- a/backend/src/services/websocket.service.ts
+++ b/backend/src/services/websocket.service.ts
@@ -28,10 +28,14 @@ export interface BalanceUpdatePayload {
 export class WebSocketService {
   private io: SocketIOServer;
   private userRooms: Map<string, Set<string>> = new Map();
+  private socketUserMap: Map<string, string> = new Map();
+  private lastPong: Map<string, number> = new Map();
+  private heartbeatIntervalHandle: NodeJS.Timeout | null = null;
 
   constructor(io: SocketIOServer) {
     this.io = io;
     this.setupEventHandlers();
+    this.startHeartbeat();
   }
 
   private setupEventHandlers(): void {
@@ -40,6 +44,10 @@ export class WebSocketService {
 
       socket.on('join-stream-room', (userAddress: string) => {
         this.joinUserRoom(socket, userAddress);
+      });
+
+      socket.on('client-pong', () => {
+        this.lastPong.set(socket.id, Date.now());
       });
 
       socket.on('join-split-feed', () => {
@@ -60,6 +68,8 @@ export class WebSocketService {
   private joinUserRoom(socket: Socket, userAddress: string): void {
     const roomName = `stream-${userAddress}`;
     socket.join(roomName);
+    this.socketUserMap.set(socket.id, userAddress);
+    this.lastPong.set(socket.id, Date.now());
     
     if (!this.userRooms.has(userAddress)) {
       this.userRooms.set(userAddress, new Set());
@@ -81,6 +91,8 @@ export class WebSocketService {
         this.userRooms.delete(userAddress);
       }
     }
+    this.socketUserMap.delete(socket.id);
+    this.lastPong.delete(socket.id);
     
     console.log(`📱 Socket ${socket.id} left room for user: ${userAddress}`);
     socket.emit('left-room', { userAddress, roomName });
@@ -96,6 +108,50 @@ export class WebSocketService {
         break;
       }
     }
+    this.socketUserMap.delete(socket.id);
+    this.lastPong.delete(socket.id);
+  }
+
+  startHeartbeat(intervalMs = 15000, staleMs = 45000): void {
+    if (this.heartbeatIntervalHandle) return;
+    this.heartbeatIntervalHandle = setInterval(() => {
+      const now = Date.now();
+      for (const [id, socket] of this.io.sockets.sockets) {
+        try {
+          socket.emit('server-ping', { ts: now });
+        } catch (err) {
+          console.warn('Failed to send heartbeat to', id, err);
+        }
+      }
+
+      // Disconnect stale sockets that didn't respond
+      for (const [socketId, last] of this.lastPong.entries()) {
+        if (now - last > staleMs) {
+          const s = this.io.sockets.sockets.get(socketId);
+          if (s) {
+            console.log(`⏱️  Disconnecting stale socket ${socketId}`);
+            s.disconnect(true);
+          }
+          this.lastPong.delete(socketId);
+          const userAddr = this.socketUserMap.get(socketId);
+          if (userAddr) {
+            const set = this.userRooms.get(userAddr);
+            if (set) {
+              set.delete(socketId);
+              if (set.size === 0) this.userRooms.delete(userAddr);
+            }
+            this.socketUserMap.delete(socketId);
+          }
+        }
+      }
+    }, intervalMs);
+  }
+
+  stopHeartbeat(): void {
+    if (this.heartbeatIntervalHandle) {
+      clearInterval(this.heartbeatIntervalHandle);
+      this.heartbeatIntervalHandle = null;
+    }
   }
 
   emitNewStream(userAddress: string, payload: StreamEventPayload): void {
@@ -108,6 +164,12 @@ export class WebSocketService {
     const roomName = `stream-${userAddress}`;
     this.io.to(roomName).emit('balance-update', payload);
     console.log(`💰 Emitted BALANCE_UPDATE to room ${roomName}:`, payload);
+  }
+
+  emitTransactionStatus(userAddress: string, payload: { txId: string; status: string; timestamp: string; details?: any }): void {
+    const roomName = `stream-${userAddress}`;
+    this.io.to(roomName).emit('transaction-status', payload);
+    console.log(`🔁 Emitted TRANSACTION_STATUS to ${roomName}:`, payload);
   }
 
   getConnectedUsers(): string[] {

--- a/backend/src/test-websocket-load.ts
+++ b/backend/src/test-websocket-load.ts
@@ -1,0 +1,58 @@
+import { io, Socket } from 'socket.io-client';
+
+const SERVER_URL = process.env.SERVER_URL || 'http://localhost:3000';
+const DEFAULT_COUNT = 100;
+const argCount = parseInt(process.argv[2] || process.env.COUNT || `${DEFAULT_COUNT}`, 10);
+const CONNECT_INTERVAL_MS = 5; // stagger connections to avoid bursts
+
+console.log(`Starting load test: connecting ${argCount} clients to ${SERVER_URL}`);
+
+const sockets: Socket[] = [];
+let connected = 0;
+let disconnected = 0;
+
+function makeAddress(i: number) {
+  return `GDTESTUSER${String(i).padStart(12, '0')}ABCDEFGHIJKLMNO`;
+}
+
+async function startClients(count: number) {
+  for (let i = 0; i < count; i++) {
+    await new Promise((r) => setTimeout(r, CONNECT_INTERVAL_MS));
+    const socket = io(SERVER_URL, { transports: ['websocket'], reconnection: false });
+
+    socket.on('connect', () => {
+      connected += 1;
+      const addr = makeAddress(i);
+      socket.emit('join-stream-room', addr);
+    });
+
+    socket.on('disconnect', () => {
+      disconnected += 1;
+    });
+
+    socket.on('server-ping', () => {
+      socket.emit('client-pong');
+    });
+
+    sockets.push(socket);
+  }
+}
+
+startClients(argCount).then(() => {
+  console.log('All clients initiated');
+  const statsInterval = setInterval(() => {
+    console.log(`Clients created: ${sockets.length} | connected: ${connected} | disconnected: ${disconnected}`);
+    const mem = process.memoryUsage();
+    console.log(`Memory (MB): rss=${(mem.rss/1024/1024).toFixed(2)} heapUsed=${(mem.heapUsed/1024/1024).toFixed(2)} external=${(mem.external/1024/1024).toFixed(2)}`);
+  }, 2000);
+
+  // Stop after 60s
+  setTimeout(() => {
+    console.log('Stopping load test, disconnecting clients...');
+    for (const s of sockets) {
+      try { s.disconnect(); } catch (e) {}
+    }
+    clearInterval(statsInterval);
+    process.exit(0);
+  }, 60000);
+});

--- a/backend/src/test-websocket.ts
+++ b/backend/src/test-websocket.ts
@@ -26,6 +26,12 @@ socket.on('balance-update', (payload) => {
   console.log('💰 Received BALANCE_UPDATE event:', payload);
 });
 
+// Respond to server heartbeat
+socket.on('server-ping', (data) => {
+  console.log('🏓 Received server-ping, sending client-pong');
+  socket.emit('client-pong');
+});
+
 socket.on('disconnect', () => {
   console.log('❌ Disconnected from WebSocket server');
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,14 @@
         "@radix-ui/react-select": "^2.0.0",
         "autoprefixer": "^10.4.16",
         "clsx": "^2.0.0",
+        "dotenv": "^16.4.5",
         "lucide-react": "^0.294.0",
         "next": "14.0.0",
         "postcss": "^8.4.31",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "tailwindcss": "^3.3.0"
+        "tailwindcss": "^3.3.0",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.0.0",
@@ -4424,6 +4426,18 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -10999,6 +11013,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }


### PR DESCRIPTION
Closes #1203 

# PR: WebSocket (Socket.io) Real-time Stream Updates

Summary
-------
This PR introduces a Socket.io-based WebSocket service to deliver real-time stream events, balance updates, and transaction status notifications. It replaces inefficient API polling for these live updates and adds a heartbeat (ping/pong) mechanism and connection bookkeeping for graceful handling of connections/disconnections.

Files changed / added
---------------------
- `backend/src/services/websocket.service.ts` — enhanced with heartbeat, socket bookkeeping, and `transaction-status` emits.
- `backend/src/test-websocket.ts` — test client updated to respond to server heartbeat (client-pong).
- `backend/src/test-websocket-load.ts` — new load-test client to spawn many connections and report memory/connection stats.
- `backend/package.json` — added npm scripts: `test:ws-load` and `test:ws-load:1000`.

Acceptance Criteria Mapping
--------------------------
- Create WebSocket server with Socket.io: implemented in `websocket.service.ts` and wired from `index.ts`.
- Implement stream update subscriptions: clients can `join-stream-room` per user address; service emits `new-stream`.
- Add balance update notifications: `balance-update` emitted per-user room.
- Add transaction status updates: `transaction-status` emit added.
- Implement heartbeat/ping-pong: server emits `server-ping`; clients should respond with `client-pong`. Heartbeat disconnects stale sockets.
- Handle connection/disconnection gracefully: socket bookkeeping (`userRooms`, `socketUserMap`) maintained on join/leave/disconnect.
- Test with 100 concurrent connections: included `test-websocket-load.ts` to connect N clients (default 100).
- Memory usage < 100MB for 1000 connections: load-test script provided; actual measurement depends on environment — see "Running load tests" below.