### PR TITLE
docs: expand CONTRACT_UPGRADABILITY with checklist, procedure, and ro…

### DIFF
--- a/contracts/Contract-V1/CONTRACT_UPGRADABILITY.md
+++ b/contracts/Contract-V1/CONTRACT_UPGRADABILITY.md
@@ -1,305 +1,378 @@
-# Contract Upgradability Implementation
+# Contract Upgradability
 
 ## Overview
 
-This implementation adds native Soroban contract upgradability to StellarStream, allowing the contract logic to be updated while maintaining the same contract ID and all existing storage state.
+StellarStream uses Soroban's native `update_current_contract_wasm` mechanism to upgrade contract logic while preserving the same contract ID and all on-chain storage state. Only a `SuperAdmin` can invoke an upgrade, and every upgrade is recorded on-chain as an immutable event.
 
-## Features Implemented
+---
 
-### 1. Upgrade Function
+## How It Works
 
-```rust
-pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>)
-```
-
-**Parameters:**
-- `new_wasm_hash`: The hash of the new WASM binary that has been uploaded to the network
-
-**Authorization:**
-- Requires admin authorization via `admin.require_auth()`
-- Only the contract admin can perform upgrades
-
-**Behavior:**
-1. Retrieves the admin address from storage
-2. Requires admin authorization
-3. Updates the contract WASM to the new hash
-4. Emits an upgrade event with the new WASM hash
-
-### 2. Get Admin Function
+### The Upgrade Function
 
 ```rust
-pub fn get_admin(env: Env) -> Address
+pub fn upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>)
 ```
 
-Query function to retrieve the current admin address.
+| Parameter       | Description                                                          |
+| --------------- | -------------------------------------------------------------------- |
+| `admin`         | Caller — must hold the `SuperAdmin` role                             |
+| `new_wasm_hash` | 32-byte hash of the new WASM, returned by `soroban contract install` |
 
-## Upgrade Process
+**What happens internally:**
 
-### Step 1: Upload New WASM
-Before calling `upgrade()`, the new contract WASM must be uploaded to the Stellar network:
+1. `admin.require_auth()` — Stellar enforces the admin's signature
+2. `has_role(&env, &admin, Role::SuperAdmin)` — contract enforces role check
+3. `env.deployer().update_current_contract_wasm(new_wasm_hash)` — atomic WASM swap
+4. `env.events().publish(("upgrade", admin), new_wasm_hash)` — on-chain audit trail
+
+**What is preserved:** contract ID, all storage keys, all streams, all fee settings, all roles.  
+**What changes:** the bytecode executed by future contract calls.
+
+---
+
+## Upgrade Checklist
+
+Complete every item before calling `upgrade()` on mainnet.
+
+### Pre-Upgrade (Preparation)
+
+- [ ] New contract version passes all existing unit tests (`cargo test`)
+- [ ] New contract version passes all existing integration tests
+- [ ] Storage layout is backward-compatible (no renamed or removed `DataKey` variants)
+- [ ] If storage schema changed, a `migrate_*` function is included and tested
+- [ ] Public function signatures are unchanged (or new functions are additive only)
+- [ ] WASM has been optimized (`soroban contract optimize`)
+- [ ] New WASM has been deployed and tested on **testnet** with a live upgrade
+- [ ] WASM hash from testnet install matches the hash you will use on mainnet
+- [ ] Admin key (or multi-sig) is available and ready to sign
+- [ ] Previous WASM hash is recorded for rollback
+- [ ] Upgrade announcement has been communicated to users
+- [ ] Monitoring / alerting is in place on the upgrade event
+
+### Upgrade Execution
+
+- [ ] Confirm current on-chain state is healthy (no stuck streams, no pending migrations)
+- [ ] Record the current WASM hash before upgrading (see rollback section)
+- [ ] Execute upgrade on mainnet (see procedure below)
+- [ ] Confirm the `upgrade` event appears in the ledger
+
+### Post-Upgrade Verification
+
+- [ ] `get_admin()` returns the expected admin address
+- [ ] A representative stream can be queried and shows correct data
+- [ ] A representative stream can be withdrawn from (if applicable to your test)
+- [ ] Fee settings are intact (`get_fee_bps`, `get_treasury`)
+- [ ] No errors in contract invocations over the first 30 minutes
+- [ ] Upgrade event is visible in a block explorer
+
+---
+
+## Example Upgrade Procedure
+
+The following end-to-end example upgrades Contract-V1 on Stellar testnet.
+
+### Step 1 — Build and Optimize
 
 ```bash
-soroban contract install \
-  --wasm target/wasm32-unknown-unknown/release/stellarstream_contracts.wasm \
-  --network testnet
-```
+# From the repo root
+cargo build \
+  --target wasm32-unknown-unknown \
+  --release \
+  --manifest-path contracts/Contract-V1/Cargo.toml
 
-This returns a WASM hash (32 bytes).
-
-### Step 2: Call Upgrade Function
-With the admin's authorization, call the upgrade function:
-
-```rust
-client.upgrade(&new_wasm_hash);
-```
-
-### Step 3: Verify Upgrade
-The contract emits an `upgrade` event containing:
-- Topic: `("upgrade", admin_address)`
-- Data: `new_wasm_hash`
-
-## Security Considerations
-
-### Authorization
-- **Strict Admin-Only Access**: Only the admin can upgrade the contract
-- **require_auth() Enforcement**: Admin must provide valid authorization
-- **No Bypass**: There is no way to upgrade without admin authorization
-
-### State Preservation
-- **Contract ID Unchanged**: The contract address remains the same
-- **Storage Intact**: All existing data (streams, fees, settings) is preserved
-- **Seamless Transition**: Users don't need to migrate or update anything
-
-### Transparency
-- **Upgrade Events**: Every upgrade emits an event for auditability
-- **On-Chain Record**: All upgrades are permanently recorded on the blockchain
-- **Admin Visibility**: The admin address is publicly queryable
-
-## Use Cases
-
-### 1. Bug Fixes
-Fix critical bugs without requiring users to migrate their streams:
-```rust
-// Upload patched WASM
-let patched_hash = upload_wasm("v1.0.1-patched.wasm");
-
-// Upgrade contract
-client.upgrade(&patched_hash);
-
-// All existing streams continue working with the fix
-```
-
-### 2. Feature Additions
-Add new functionality while preserving existing features:
-```rust
-// Upload enhanced WASM with new features
-let enhanced_hash = upload_wasm("v2.0.0-with-new-features.wasm");
-
-// Upgrade contract
-client.upgrade(&enhanced_hash);
-
-// Old streams work as before, new features available
-```
-
-### 3. Performance Optimizations
-Improve contract efficiency without disrupting users:
-```rust
-// Upload optimized WASM
-let optimized_hash = upload_wasm("v1.1.0-optimized.wasm");
-
-// Upgrade contract
-client.upgrade(&optimized_hash);
-
-// Same functionality, better performance
-```
-
-## Testing
-
-### Unit Tests
-The implementation includes comprehensive tests:
-
-- ✅ `test_upgrade_by_admin`: Admin can upgrade
-- ✅ `test_upgrade_without_initialization`: Fails without admin
-- ✅ `test_upgrade_maintains_state`: Storage is preserved
-- ✅ `test_get_admin`: Admin query works
-- ✅ `test_get_admin_not_initialized`: Fails without initialization
-- ✅ `test_upgrade_with_paused_contract`: Upgrade works even when paused
-- ✅ `test_upgrade_preserves_fee_settings`: Fee settings survive upgrade
-- ✅ `test_admin_authorization_required`: Authorization is enforced
-
-### Integration Testing Note
-Full upgrade testing requires:
-1. Actual WASM upload to network
-2. Real contract deployment
-3. Upgrade with valid WASM hash
-
-Unit tests verify the authorization and event logic. Integration tests on testnet/mainnet verify the actual WASM update.
-
-## Events
-
-### Upgrade Event
-```rust
-env.events().publish(
-    (symbol_short!("upgrade"), admin),
-    new_wasm_hash,
-);
-```
-
-**Structure:**
-- **Topics**: `["upgrade", admin_address]`
-- **Data**: `new_wasm_hash` (BytesN<32>)
-
-**Purpose:**
-- Provides transparency for all upgrades
-- Allows monitoring and auditing
-- Records the new WASM hash on-chain
-
-## Best Practices
-
-### 1. Test Thoroughly
-- Test new WASM extensively on testnet
-- Verify all existing functionality works
-- Check that storage migration (if any) is correct
-
-### 2. Communicate Upgrades
-- Announce upgrades to users in advance
-- Document what's changing
-- Provide upgrade timeline
-
-### 3. Emergency Procedures
-- Have rollback plan ready
-- Keep previous WASM hash available
-- Monitor contract after upgrade
-
-### 4. Gradual Rollout
-- Consider upgrading on testnet first
-- Monitor for issues
-- Then upgrade mainnet
-
-### 5. Admin Key Security
-- Use multi-sig for admin if possible
-- Secure admin private key
-- Consider timelock for upgrades
-
-## Comparison with Other Approaches
-
-### Traditional Approach (No Upgradability)
-- ❌ Bugs require new deployment
-- ❌ Users must migrate manually
-- ❌ Loses contract address
-- ❌ Complex migration process
-
-### Proxy Pattern
-- ⚠️ More complex architecture
-- ⚠️ Additional gas costs
-- ⚠️ Potential security risks
-- ✅ Flexible upgrade logic
-
-### Native Soroban Upgradability (This Implementation)
-- ✅ Simple and clean
-- ✅ Preserves contract ID
-- ✅ No migration needed
-- ✅ Built-in security
-- ✅ Minimal gas overhead
-
-## Limitations
-
-### 1. Storage Schema Changes
-If the new WASM changes data structures, you may need migration logic:
-```rust
-pub fn migrate_v1_to_v2(env: Env) {
-    // Migration logic here
-}
-```
-
-### 2. Breaking Changes
-Avoid breaking changes to public API:
-- Don't remove public functions
-- Don't change function signatures
-- Add new functions instead
-
-### 3. Admin Dependency
-- Contract upgradability depends on admin key security
-- Lost admin key = no more upgrades
-- Consider multi-sig or DAO governance
-
-## Acceptance Criteria
-
-✅ **Contract Logic Updatable**: WASM can be updated via `upgrade()` function
-✅ **Same Contract ID**: Contract address remains unchanged after upgrade
-✅ **Storage State Maintained**: All data persists through upgrades
-✅ **Admin Authorization**: Only admin can upgrade, strictly enforced
-✅ **Unauthorized Users Blocked**: Non-admin calls fail
-✅ **Event Emission**: Upgrade events provide transparency
-
-## API Reference
-
-### upgrade
-```rust
-pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>)
-```
-Updates the contract WASM to a new version.
-
-**Requirements:**
-- Admin authorization required
-- WASM must be pre-uploaded to network
-
-**Emits:** `upgrade` event
-
-### get_admin
-```rust
-pub fn get_admin(env: Env) -> Address
-```
-Returns the current admin address.
-
-**Requirements:** None (public query)
-
-## Example Usage
-
-### CLI Example
-```bash
-# 1. Build new contract version
-cargo build --target wasm32-unknown-unknown --release
-
-# 2. Optimize WASM
 soroban contract optimize \
-  --wasm target/wasm32-unknown-unknown/release/stellarstream_contracts.wasm
+  --wasm target/wasm32-unknown-unknown/release/stellar_stream.wasm \
+  --wasm-out target/wasm32-unknown-unknown/release/stellar_stream.optimized.wasm
+```
 
-# 3. Upload new WASM
+### Step 2 — Record the Current WASM Hash (for Rollback)
+
+```bash
+# Save the current WASM hash before you overwrite it
+CURRENT_HASH=$(soroban contract info \
+  --id $CONTRACT_ID \
+  --network testnet \
+  | jq -r '.wasm_hash')
+
+echo "Current WASM hash (keep for rollback): $CURRENT_HASH"
+```
+
+### Step 3 — Install the New WASM
+
+```bash
 NEW_HASH=$(soroban contract install \
-  --wasm target/wasm32-unknown-unknown/release/stellarstream_contracts.optimized.wasm \
+  --wasm target/wasm32-unknown-unknown/release/stellar_stream.optimized.wasm \
+  --source $ADMIN_SECRET \
   --network testnet)
 
-# 4. Upgrade contract
+echo "New WASM hash: $NEW_HASH"
+```
+
+### Step 4 — Call upgrade()
+
+```bash
+soroban contract invoke \
+  --id $CONTRACT_ID \
+  --source $ADMIN_SECRET \
+  --network testnet \
+  -- \
+  upgrade \
+  --admin $ADMIN_ADDRESS \
+  --new_wasm_hash $NEW_HASH
+```
+
+### Step 5 — Verify the Upgrade
+
+```bash
+# Check admin is still set correctly
 soroban contract invoke \
   --id $CONTRACT_ID \
   --network testnet \
   -- \
+  get_admin
+
+# Confirm the upgrade event in recent ledger events
+soroban events \
+  --id $CONTRACT_ID \
+  --network testnet \
+  --start-ledger $(soroban network get-sequence --network testnet)
+```
+
+Expected event structure:
+
+```json
+{
+  "type": "contract",
+  "topics": ["upgrade", "<admin_address>"],
+  "value": "<new_wasm_hash>"
+}
+```
+
+---
+
+## Rollback Procedure
+
+A rollback is a second upgrade — you call `upgrade()` again with the **previous** WASM hash. This is why recording `CURRENT_HASH` before every upgrade (Step 2 above) is mandatory.
+
+### rollback.sh
+
+```bash
+#!/usr/bin/env bash
+# rollback.sh — Re-deploy a previous WASM hash for StellarStream Contract-V1.
+#
+# Usage:
+#   export CONTRACT_ID=<contract_address>
+#   export ADMIN_SECRET=<admin_secret_key>
+#   export ADMIN_ADDRESS=<admin_stellar_address>
+#   export ROLLBACK_HASH=<previous_wasm_hash>
+#   export NETWORK=testnet   # or mainnet
+#   bash rollback.sh
+
+set -euo pipefail
+
+: "${CONTRACT_ID:?CONTRACT_ID is required}"
+: "${ADMIN_SECRET:?ADMIN_SECRET is required}"
+: "${ADMIN_ADDRESS:?ADMIN_ADDRESS is required}"
+: "${ROLLBACK_HASH:?ROLLBACK_HASH is required}"
+: "${NETWORK:=testnet}"
+
+echo "=== StellarStream Contract Rollback ==="
+echo "Contract ID : $CONTRACT_ID"
+echo "Network     : $NETWORK"
+echo "Target hash : $ROLLBACK_HASH"
+echo ""
+echo "WARNING: This will revert contract logic to the previous WASM."
+echo "Storage state (streams, fees, roles) will NOT be affected."
+echo ""
+read -r -p "Confirm rollback? [yes/no]: " CONFIRM
+if [[ "$CONFIRM" != "yes" ]]; then
+  echo "Rollback cancelled."
+  exit 0
+fi
+
+echo ""
+echo "Step 1/3 — Recording current WASM hash..."
+CURRENT_HASH=$(soroban contract info \
+  --id "$CONTRACT_ID" \
+  --network "$NETWORK" \
+  | jq -r '.wasm_hash')
+echo "  Current hash: $CURRENT_HASH"
+echo "  Target hash : $ROLLBACK_HASH"
+
+echo ""
+echo "Step 2/3 — Invoking upgrade() with rollback hash..."
+soroban contract invoke \
+  --id "$CONTRACT_ID" \
+  --source "$ADMIN_SECRET" \
+  --network "$NETWORK" \
+  -- \
   upgrade \
-  --new_wasm_hash $NEW_HASH
+  --admin "$ADMIN_ADDRESS" \
+  --new_wasm_hash "$ROLLBACK_HASH"
+
+echo ""
+echo "Step 3/3 — Verifying rollback..."
+ADMIN_AFTER=$(soroban contract invoke \
+  --id "$CONTRACT_ID" \
+  --network "$NETWORK" \
+  -- \
+  get_admin)
+echo "  Admin after rollback: $ADMIN_AFTER"
+
+echo ""
+echo "=== Rollback complete ==="
+echo "Contract is now running WASM hash: $ROLLBACK_HASH"
+echo "Previous hash was               : $CURRENT_HASH"
+echo ""
+echo "Next steps:"
+echo "  1. Verify streams are still readable."
+echo "  2. Notify users of the rollback."
+echo "  3. Investigate the root cause before re-upgrading."
 ```
 
-### SDK Example
+### When to Roll Back
+
+Roll back immediately if any of the following appear within 30 minutes of an upgrade:
+
+- Invocations panic unexpectedly on previously working call paths
+- Storage reads return wrong types (indicative of a schema mismatch)
+- `get_admin()` fails or returns the wrong address
+- Withdraw or stream-creation calls fail for all users
+
+---
+
+## Storage Compatibility Rules
+
+Soroban persists storage by key — renaming or removing a `DataKey` variant causes existing entries to become orphaned (they won't be read by the new code). Follow these rules across every upgrade:
+
+| Change                                     | Safe?  | Notes                       |
+| ------------------------------------------ | ------ | --------------------------- |
+| Add a new `DataKey` variant                | ✅ Yes | Existing entries unaffected |
+| Add a new field to a struct (with default) | ✅ Yes | Requires migration function |
+| Remove a `DataKey` variant                 | ❌ No  | Orphaned storage; data loss |
+| Rename a `DataKey` variant                 | ❌ No  | Same as removing            |
+| Change a field type in a struct            | ❌ No  | Deserialization will fail   |
+| Add a new public function                  | ✅ Yes | Fully additive              |
+| Remove or rename a public function         | ❌ No  | Breaks existing callers     |
+
+### Writing a Migration Function
+
+If the new WASM introduces an additive storage schema change, include a one-time migration function:
+
 ```rust
-use soroban_sdk::{BytesN, Env};
-
-// Get new WASM hash (from upload)
-let new_wasm_hash = BytesN::from_array(&env, &[/* 32 bytes */]);
-
-// Upgrade contract (requires admin auth)
-client.upgrade(&new_wasm_hash);
+/// Call once after upgrading to vX.Y.Z.
+/// Reads all Stream entries and writes the new `field_name` default.
+pub fn migrate_vX_Y_Z(env: Env, admin: Address) {
+    admin.require_auth();
+    // Only SuperAdmin may run migrations
+    if !Self::has_role(&env, &admin, Role::SuperAdmin) {
+        panic_with_error!(&env, Error::Unauthorized);
+    }
+    // Example: set a new optional field to None for every existing stream
+    // This is a no-op if the field already exists (safe to call multiple times)
+    // ... migration logic here ...
+}
 ```
 
-## Files Modified/Created
+Call `migrate_vX_Y_Z()` in a single transaction **immediately after** `upgrade()` completes.
 
-- `contracts/src/lib.rs`: Added `upgrade()` and `get_admin()` functions
-- `contracts/src/upgrade_test.rs`: Comprehensive test suite
-- `contracts/CONTRACT_UPGRADABILITY.md`: This documentation
+---
 
-## Next Steps
+## Security Considerations
 
-1. Deploy to testnet
-2. Test upgrade process end-to-end
-3. Document upgrade procedures for operators
-4. Consider multi-sig admin for production
-5. Set up monitoring for upgrade events
+### Admin Key Security
+
+- The upgrade function is gated on the `SuperAdmin` role; losing the admin key means no future upgrades are possible
+- For production, configure a multi-signature admin account to require M-of-N approvals before an upgrade can proceed
+- Consider a time-lock governance contract that enforces a mandatory delay between an upgrade proposal and its execution, giving users time to review and exit
+
+### Transparency
+
+- Every upgrade emits an `("upgrade", admin_address)` event with the new WASM hash
+- These events are permanently on-chain and can be monitored by anyone
+- Block explorers will show the full upgrade history
+
+### Authorization Flow
+
+```
+caller --[require_auth()]--> Stellar runtime validates signature
+                         --> has_role(SuperAdmin) check in contract
+                         --> update_current_contract_wasm(hash)
+                         --> events().publish("upgrade", ...)
+```
+
+Both layers (runtime auth + role check) must pass. There is no admin bypass.
+
+---
+
+## Testing
+
+### Unit Tests (in `upgrade_test.rs`)
+
+| Test                                         | Covers                                           |
+| -------------------------------------------- | ------------------------------------------------ |
+| `test_get_admin`                             | Admin retrieval works after init                 |
+| `test_get_admin_not_initialized`             | Panics correctly before init                     |
+| `test_upgrade_without_initialization`        | Non-admin blocked                                |
+| `test_admin_can_be_retrieved_after_fee_init` | Admin survives fee init                          |
+| `test_admin_persists_through_pause`          | Admin survives pause/unpause                     |
+| `test_upgrade_by_admin`                      | _(integration only — requires real WASM upload)_ |
+| `test_upgrade_maintains_state`               | _(integration only — requires real WASM upload)_ |
+
+Unit tests verify authorization logic and event emission. Full WASM swap testing requires a live Stellar node; use the testnet procedure above.
+
+### V1→V2 Migration Tests (in `v1_to_v2_integration_test.rs`)
+
+The Contract-V2 suite includes a mock V1 contract and end-to-end tests verifying that V1 streams can be read and migrated to V2 without data loss. Run with:
+
+```bash
+cargo test --manifest-path contracts/Contract-V2/Cargo.toml
+```
+
+---
+
+## API Reference
+
+### `upgrade(env, admin, new_wasm_hash)`
+
+```rust
+pub fn upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>)
+```
+
+Replaces the contract WASM atomically. All storage is preserved.
+
+**Requires:** `admin.require_auth()` + `SuperAdmin` role  
+**Emits:** `("upgrade", admin) → new_wasm_hash`
+
+### `get_admin(env)`
+
+```rust
+pub fn get_admin(env: Env) -> Address
+```
+
+Returns the current admin address from instance storage.
+
+**Requires:** nothing (public read)
+
+---
+
+## Quick Reference
+
+```bash
+# Build
+cargo build --target wasm32-unknown-unknown --release
+
+# Optimize
+soroban contract optimize --wasm <path>.wasm
+
+# Install (returns hash)
+soroban contract install --wasm <path>.optimized.wasm --source $ADMIN_SECRET --network testnet
+
+# Upgrade
+soroban contract invoke --id $CONTRACT_ID --source $ADMIN_SECRET --network testnet \
+  -- upgrade --admin $ADMIN_ADDRESS --new_wasm_hash $NEW_HASH
+
+# Rollback
+export ROLLBACK_HASH=<previous_hash> && bash rollback.sh
+```


### PR DESCRIPTION
## What does this PR do?
Expands `contracts/Contract-V1/CONTRACT_UPGRADABILITY.md` with the missing documentation required by the issue: a full upgrade checklist, an end-to-end upgrade procedure, and a rollback script.

## Why?
Closes #1191 — the existing file documented the `upgrade()` function well but was missing the operational content needed by teams deploying and maintaining the contract in production.

## Changes
- **Upgrade checklist**: pre-upgrade (build, testnet validation, WASM hash recording), execution, and post-upgrade verification steps with checkboxes
- **End-to-end upgrade procedure**: real `soroban` CLI commands covering build → optimize → record current hash → install new WASM → invoke `upgrade()` → verify event
- **`rollback.sh` script**: complete bash script with confirmation prompt, current vs target hash display, post-rollback admin verification, and next-steps guidance. Rollback is implemented as a second `upgrade()` call with the previous WASM hash — which is why recording the hash before every upgrade is now a checklist requirement
- **Storage compatibility rules table**: documents which `DataKey`/struct changes are safe vs breaking across upgrades, with a migration function template for additive schema changes
- **Security section**: covers admin key risks, multi-sig recommendations, time-lock governance, and a diagram of the dual-layer auth flow (`require_auth` + `SuperAdmin` role check)
- **References to existing tests**: cross-references `upgrade_test.rs` and `v1_to_v2_integration_test.rs` with a table of what each test covers

## Checklist
- [x] Linked issue: Closes #1191
- [x] Documentation only — no code changes
