### PR TITLE
perf(backend): add strategic database indexes (#1148)

### DIFF
--- a/backend/prisma/migrations/add_strategic_indexes.sql
+++ b/backend/prisma/migrations/add_strategic_indexes.sql
@@ -1,0 +1,50 @@
+-- #1148 — Strategic Database Indexes
+--
+-- Adds composite indexes for the hottest read paths that were previously
+-- doing sequential scans, plus a batch_id column on Disbursement to support
+-- the batch processing engine (#1202).
+--
+-- NOTE ON CONCURRENTLY:
+--   CREATE/DROP INDEX CONCURRENTLY must run OUTSIDE a transaction block so the
+--   index is built without taking a write lock on a populated table. Apply this
+--   file with psql (autocommit), e.g.:
+--       psql "$DATABASE_URL" -f prisma/migrations/add_strategic_indexes.sql
+--   If you apply it through a transaction-wrapping runner, remove the
+--   CONCURRENTLY keywords first.
+
+-- ── streams: (sender, status, createdAt DESC) ────────────────────────────────
+-- Powers the owner dashboard: a user's most recent streams filtered by status.
+-- ("sender" is the stream owner; the schema has no separate userId column.)
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Stream_sender_status_createdAt_idx"
+    ON "Stream" ("sender", "status", "createdAt" DESC);
+
+-- ── events: (contract_id, ledger_sequence DESC) ──────────────────────────────
+-- Newest-first event scans per contract. Replaces the existing ascending
+-- composite so the index order matches the dominant ORDER BY ... DESC queries.
+DROP INDEX CONCURRENTLY IF EXISTS "ContractEvent_contract_id_ledger_sequence_idx";
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "ContractEvent_contract_id_ledger_sequence_idx"
+    ON "ContractEvent" ("contract_id", "ledger_sequence" DESC);
+
+-- ── audit_logs: (streamId, createdAt DESC) ───────────────────────────────────
+-- Stream audit trail, newest entries first. (EventLog is the audit-log table.)
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "EventLog_streamId_createdAt_idx"
+    ON "EventLog" ("streamId", "createdAt" DESC);
+
+-- ── disbursements: (batch_id, status) ────────────────────────────────────────
+-- The Disbursement table had no batch concept; add a nullable batch_id that the
+-- batch processing engine (#1202) populates, then index it with status for
+-- per-batch progress/status lookups. Nullable + no default => instant DDL.
+ALTER TABLE "Disbursement" ADD COLUMN IF NOT EXISTS "batch_id" TEXT;
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Disbursement_batch_id_status_idx"
+    ON "Disbursement" ("batch_id", "status");
+
+-- ── (contractId, ledger) UNIQUE — intentionally NOT added ─────────────────────
+-- The issue asks for UNIQUE (contractId, ledger) on events, but a single
+-- contract routinely emits MANY events in the same ledger, so this constraint
+-- would reject valid events and break ingestion. Event idempotency is already
+-- guaranteed by the existing constraints:
+--     UNIQUE ("tx_hash", "event_index")   -- ContractEvent_tx_hash_event_index_key
+--     UNIQUE ("event_id")                 -- ContractEvent_event_id_key
+-- If a one-row-per-ledger uniqueness is genuinely required, it belongs on a
+-- ledger-keyed table (e.g. LedgerHash.sequence, which is already a PK), not on
+-- the events table. Add it explicitly here only after confirming the intent.

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -47,6 +47,8 @@ model Stream {
   @@index([yieldEnabled, status])
   @@index([isDust])
   @@index([affiliateId])
+  // #1148 — owner dashboard: latest streams for a user filtered by status
+  @@index([sender, status, createdAt(sort: Desc)])
 }
 
 model ContractEvent {
@@ -64,7 +66,8 @@ model ContractEvent {
   createdAt      DateTime @default(now()) @map("created_at")
 
   @@unique([txHash, eventIndex])
-  @@index([contractId, ledgerSequence])
+  // #1148 — newest-first event scans per contract (ledger DESC)
+  @@index([contractId, ledgerSequence(sort: Desc)])
   @@index([eventType])
   @@index([txHash])
 }
@@ -140,6 +143,8 @@ model EventLog {
   @@index([eventType])
   @@index([createdAt])
   @@index([ledger])
+  // #1148 — audit trail for a stream, newest entries first
+  @@index([streamId, createdAt(sort: Desc)])
 }
 
 // Monthly snapshots of stream states
@@ -478,12 +483,15 @@ model Disbursement {
   createdAt      DateTime     @default(now())
   completedAt    DateTime?
   ledger         Int
+  batchId        String?      @map("batch_id") // #1148 — groups disbursements processed in one batch (#1202)
 
   @@index([streamId])
   @@index([sender])
   @@index([receiver])
   @@index([status])
   @@index([createdAt])
+  // #1148 — batch progress/status lookups for the batch processing engine
+  @@index([batchId, status])
 }
 
 enum DisbursementStatus {

--- a/backend/scripts/verify-strategic-indexes.sql
+++ b/backend/scripts/verify-strategic-indexes.sql
@@ -1,0 +1,59 @@
+-- #1148 — Verification harness for the strategic indexes.
+--
+-- Runs EXPLAIN ANALYZE on the four query shapes the indexes target so you can
+-- confirm the planner switched from a Seq Scan to an Index Scan and measure the
+-- improvement (target: >= 50% lower execution time on a populated database).
+--
+-- Usage:
+--   1. Capture a baseline BEFORE applying the migration:
+--        psql "$DATABASE_URL" -f backend/scripts/verify-strategic-indexes.sql > before.txt
+--   2. Apply the migration:
+--        psql "$DATABASE_URL" -f backend/prisma/migrations/add_strategic_indexes.sql
+--   3. Re-run and compare:
+--        psql "$DATABASE_URL" -f backend/scripts/verify-strategic-indexes.sql > after.txt
+--        diff before.txt after.txt
+--
+-- Look for: "Seq Scan" (before) -> "Index Scan"/"Index Only Scan" (after) and a
+-- lower "Execution Time".
+
+\timing on
+
+-- Replace the literals below with values that exist in your dataset.
+\set sample_sender    '''GSAMPLESENDERADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'''
+\set sample_contract  '''CSAMPLECONTRACTIDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'''
+\set sample_stream    '''stream-sample-id'''
+\set sample_batch     '''batch-sample-id'''
+
+-- ── streams: latest ACTIVE streams for an owner ──────────────────────────────
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT *
+FROM "Stream"
+WHERE "sender" = :sample_sender
+  AND "status" = 'ACTIVE'
+ORDER BY "createdAt" DESC
+LIMIT 50;
+
+-- ── events: newest events for a contract ─────────────────────────────────────
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT *
+FROM "ContractEvent"
+WHERE "contract_id" = :sample_contract
+ORDER BY "ledger_sequence" DESC
+LIMIT 100;
+
+-- ── audit_logs: newest audit entries for a stream ────────────────────────────
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT *
+FROM "EventLog"
+WHERE "streamId" = :sample_stream
+ORDER BY "createdAt" DESC
+LIMIT 100;
+
+-- ── disbursements: items in a batch by status ────────────────────────────────
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT *
+FROM "Disbursement"
+WHERE "batch_id" = :sample_batch
+  AND "status" = 'PENDING';
+
+\timing off


### PR DESCRIPTION
# Pull Request: Strategic Database Indexes

## 📋 Issue Reference
Closes #1148

## 🎯 Summary
Adds composite indexes for the hottest read paths that were previously doing sequential scans. Index targets from the issue were mapped to the **actual** schema columns (the issue used idealized names), and one requested constraint was intentionally omitted because it would break event ingestion (details below).

## 🚀 Changes

### Schema — `backend/prisma/schema.prisma`
- `Stream`: `@@index([sender, status, createdAt(sort: Desc)])`
- `ContractEvent`: `@@index([contractId, ledgerSequence(sort: Desc)])` (replaces ascending composite)
- `EventLog`: `@@index([streamId, createdAt(sort: Desc)])`
- `Disbursement`: new `batchId String? @map("batch_id")` + `@@index([batchId, status])`

### Migration — `backend/prisma/migrations/add_strategic_indexes.sql`
- Uses `CREATE INDEX CONCURRENTLY IF NOT EXISTS` so indexes build without locking populated tables (apply via `psql` / autocommit).
- Adds the nullable `batch_id` column (instant, metadata-only DDL).

### Verification — `backend/scripts/verify-strategic-indexes.sql`
- `EXPLAIN (ANALYZE, BUFFERS)` for each of the four query shapes.
- Workflow: capture baseline → apply migration → re-run → diff, confirming `Seq Scan` → `Index Scan` and a lower execution time.

