### PR TITLE
Add V1 deprecation warnings and migration guide

### DIFF
--- a/DEPRECATION_TIMELINE.md
+++ b/DEPRECATION_TIMELINE.md
@@ -1,0 +1,45 @@
+# StellarStream API V1 Deprecation Timeline
+
+This page is the source of truth for the StellarStream API v1 deprecation window.
+It covers the `/api/v1` routes in the main backend and the standalone
+`backend/legacy_v1` stream API.
+
+## Timeline
+
+| Date | Milestone | Impact |
+|------|-----------|--------|
+| 2026-06-29 | Deprecation announced and runtime warnings enabled | V1 is marked deprecated in docs and Swagger metadata. V1 responses include `Deprecation`, `Sunset`, `Link`, `Warning`, and `X-StellarStream-API-Deprecation` headers. |
+| 2026-08-01 | New V1 integrations frozen | New API consumers should be onboarded to V3 or an approved bridge endpoint only. |
+| 2026-09-01 | Final migration window | Support focuses on migration blockers and endpoint parity gaps. |
+| 2026-10-01 | V1 sunset | V1 endpoints may be disabled or moved behind compatibility support. |
+| 2026-11-01 or later | V1 removal | Remaining V1 code paths may be removed after consumer migration review. |
+
+## Runtime warning headers
+
+Every V1 API response should include:
+
+```http
+Deprecation: @1782691200
+Sunset: Thu, 01 Oct 2026 00:00:00 GMT
+Link: <https://github.com/StellarStream-HQ/StellarStream/blob/main/DEPRECATION_TIMELINE.md>; rel="deprecation"; type="text/markdown", <https://github.com/StellarStream-HQ/StellarStream/blob/main/docs/V1_MIGRATION_GUIDE.md>; rel="successor-version"; type="text/markdown"
+Warning: 299 - "StellarStream API v1 is deprecated and will sunset on 2026-10-01. Migrate to v3 endpoints where available; use documented bridge paths where V3 parity is not yet available. See docs/V1_MIGRATION_GUIDE.md."
+X-StellarStream-API-Deprecation: StellarStream API v1 is deprecated and will sunset on 2026-10-01. Migrate to v3 endpoints where available; use documented bridge paths where V3 parity is not yet available. See docs/V1_MIGRATION_GUIDE.md.
+```
+
+The headers are advisory and non-breaking. They do not change status codes,
+response body shape, authentication, or rate limits.
+The `Deprecation` value is a structured field date for the announcement date.
+
+## Migration resources
+
+- Top endpoint migration guide: [`docs/V1_MIGRATION_GUIDE.md`](./docs/V1_MIGRATION_GUIDE.md)
+- Consumer notification copy: [`docs/V1_DEPRECATION_EMAIL.md`](./docs/V1_DEPRECATION_EMAIL.md)
+- API reference: [`docs/API_DOCUMENTATION.md`](./docs/API_DOCUMENTATION.md)
+
+## Compatibility policy
+
+- Critical security fixes may still be applied to V1 during the migration
+  window.
+- New API features should target V3.
+- If a V1 endpoint has no exact V3 equivalent, keep the consumer on the
+  documented bridge path until V3 parity exists.

--- a/backend/legacy_v1/api-server.ts
+++ b/backend/legacy_v1/api-server.ts
@@ -1,9 +1,13 @@
 import express, { type Request, type Response } from "express";
 import { config } from "../config";
+import { v1DeprecationWarning } from "../src/middleware/deprecationWarning";
 import streamsRouter from "./streams";
 
 const app = express();
 app.use(express.json());
+
+// ── V1 deprecation notice ─────────────────────────────────────────────────────
+app.use("/api", v1DeprecationWarning);
 
 // ── Health check ──────────────────────────────────────────────────────────────
 app.get("/health", (_req: Request, res: Response) => {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -42,6 +42,7 @@ import { createSplitWorker } from "./workers/splitWorker.js";
 import { enqueueSplit, getSplitJobStatus } from "./lib/splitQueue.js";
 import { requestId as requestIdMiddleware } from "./middleware/requestId.js";
 import { errorHandler } from "./middleware/errorHandler.js";
+import { v1DeprecationWarning } from "./middleware/deprecationWarning.js";
 
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
@@ -98,6 +99,13 @@ app.use(
     credentials: true,
     methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
     allowedHeaders: ["Content-Type", "Authorization", "X-Api-Key"],
+    exposedHeaders: [
+      "Deprecation",
+      "Sunset",
+      "Link",
+      "Warning",
+      "X-StellarStream-API-Deprecation",
+    ],
   }),
 );
 
@@ -117,6 +125,9 @@ app.use(requestIdMiddleware);
 app.get("/", (_req: Request, res: Response) => {
   res.redirect("/api/v1/docs");
 });
+
+// ── V1 deprecation notice ────────────────────────────────────────────────────
+app.use("/api/v1", v1DeprecationWarning);
 
 // ── Swagger UI ────────────────────────────────────────────────────────────────
 app.use("/api/v1/docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec));

--- a/backend/src/middleware/deprecationWarning.test.ts
+++ b/backend/src/middleware/deprecationWarning.test.ts
@@ -1,0 +1,64 @@
+import type { Request, Response } from "express";
+import express from "express";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+import {
+  V1_DEPRECATION_DATE,
+  V1_MIGRATION_GUIDE_URL,
+  V1_SUNSET_DATE,
+  v1DeprecationWarning,
+} from "./deprecationWarning.js";
+
+describe("v1DeprecationWarning", () => {
+  it("sets advisory V1 deprecation headers and continues the request", () => {
+    const headers = new Map<string, string | number | readonly string[]>();
+    const res = {
+      setHeader: vi.fn((name: string, value: string | number | readonly string[]) => {
+        headers.set(name, value);
+        return res as Response;
+      }),
+    } as Partial<Response> as Response;
+    const next = vi.fn();
+
+    v1DeprecationWarning({} as Request, res, next);
+
+    expect(headers.get("Deprecation")).toBe(V1_DEPRECATION_DATE);
+    expect(headers.get("Sunset")).toBe(V1_SUNSET_DATE);
+    expect(String(headers.get("Link"))).toContain(V1_MIGRATION_GUIDE_URL);
+    expect(String(headers.get("Warning"))).toContain("StellarStream API v1 is deprecated");
+    expect(String(headers.get("X-StellarStream-API-Deprecation"))).toContain(
+      "documented bridge paths",
+    );
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies headers when mounted on the main V1 prefix", async () => {
+    const app = express();
+    app.use("/api/v1", v1DeprecationWarning);
+    app.get("/api/v1/health", (_req, res) => {
+      res.json({ status: "ok" });
+    });
+
+    const res = await request(app).get("/api/v1/health").expect(200);
+
+    expect(res.headers.deprecation).toBe(V1_DEPRECATION_DATE);
+    expect(res.headers.sunset).toBe(V1_SUNSET_DATE);
+    expect(res.headers.link).toContain(V1_MIGRATION_GUIDE_URL);
+    expect(res.body).toEqual({ status: "ok" });
+  });
+
+  it("applies headers when mounted on the legacy API prefix", async () => {
+    const app = express();
+    app.use("/api", v1DeprecationWarning);
+    app.get("/api/streams", (_req, res) => {
+      res.json({ streams: [] });
+    });
+
+    const res = await request(app).get("/api/streams").expect(200);
+
+    expect(res.headers.deprecation).toBe(V1_DEPRECATION_DATE);
+    expect(res.headers.sunset).toBe(V1_SUNSET_DATE);
+    expect(res.headers.link).toContain(V1_MIGRATION_GUIDE_URL);
+    expect(res.body).toEqual({ streams: [] });
+  });
+});

--- a/backend/src/middleware/deprecationWarning.ts
+++ b/backend/src/middleware/deprecationWarning.ts
@@ -1,0 +1,32 @@
+import type { NextFunction, Request, Response } from "express";
+
+export const V1_SUNSET_DATE = "Thu, 01 Oct 2026 00:00:00 GMT";
+export const V1_DEPRECATION_DATE = "@1782691200";
+export const V1_MIGRATION_GUIDE_URL =
+  "https://github.com/StellarStream-HQ/StellarStream/blob/main/docs/V1_MIGRATION_GUIDE.md";
+export const V1_DEPRECATION_TIMELINE_URL =
+  "https://github.com/StellarStream-HQ/StellarStream/blob/main/DEPRECATION_TIMELINE.md";
+
+const V1_DEPRECATION_MESSAGE =
+  "StellarStream API v1 is deprecated and will sunset on 2026-10-01. " +
+  "Migrate to v3 endpoints where available; use documented bridge paths where V3 parity is not yet available. " +
+  "See docs/V1_MIGRATION_GUIDE.md.";
+
+export function v1DeprecationWarning(
+  _req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  res.setHeader("Deprecation", V1_DEPRECATION_DATE);
+  res.setHeader("Sunset", V1_SUNSET_DATE);
+  res.setHeader(
+    "Link",
+    [
+      `<${V1_DEPRECATION_TIMELINE_URL}>; rel="deprecation"; type="text/markdown"`,
+      `<${V1_MIGRATION_GUIDE_URL}>; rel="successor-version"; type="text/markdown"`,
+    ].join(", "),
+  );
+  res.setHeader("Warning", `299 - "${V1_DEPRECATION_MESSAGE}"`);
+  res.setHeader("X-StellarStream-API-Deprecation", V1_DEPRECATION_MESSAGE);
+  next();
+}

--- a/backend/src/swagger.ts
+++ b/backend/src/swagger.ts
@@ -8,13 +8,14 @@ const options: swaggerJsdoc.Options = {
       version: "1.0.0",
       description:
         "REST API for the StellarStream Stellar payment streaming indexer. " +
-        "Provides endpoints to query streams, audit logs, statistics, authentication, and webhook management.",
+        "Provides endpoints to query streams, audit logs, statistics, authentication, and webhook management. " +
+        "API v1 is deprecated; see DEPRECATION_TIMELINE.md and docs/V1_MIGRATION_GUIDE.md.",
       contact: { name: "StellarStream", url: "https://github.com/StellarStream-HQ/StellarStream" },
       license: { name: "MIT" },
     },
     servers: [
-      { url: "/api/v1", description: "V1 API (current)" },
-      { url: "http://localhost:3000/api/v1", description: "Local development" },
+      { url: "/api/v1", description: "V1 API (deprecated)" },
+      { url: "http://localhost:3000/api/v1", description: "Local development (deprecated v1)" },
     ],
     tags: [
       { name: "Streams", description: "Stellar payment stream queries and fee estimation" },

--- a/docs/V1_DEPRECATION_EMAIL.md
+++ b/docs/V1_DEPRECATION_EMAIL.md
@@ -1,0 +1,83 @@
+# StellarStream V1 Deprecation Email Content
+
+Use this copy for API consumers who have called `/api/v1` in the last 90 days.
+Replace bracketed placeholders before sending.
+
+## Announcement
+
+Subject: StellarStream API v1 deprecation notice - migrate before 2026-10-01
+
+Hi [Name],
+
+We are deprecating StellarStream API v1 and moving active integrations to the
+supported V3 API surface. Your integration has recently used `/api/v1`, so we
+want to give you the migration window early.
+
+Important dates:
+
+- 2026-06-29: V1 responses begin returning deprecation headers.
+- 2026-08-01: New V1 integrations are frozen.
+- 2026-10-01: V1 reaches sunset and may be disabled.
+
+What changes now:
+
+- Existing V1 requests continue to work during the migration window.
+- V1 responses include `Deprecation`, `Sunset`, `Link`, `Warning`, and
+  `X-StellarStream-API-Deprecation` headers.
+- New integrations should use V3 endpoints or a documented bridge path.
+
+Migration resources:
+
+- Timeline: [DEPRECATION_TIMELINE.md]
+- Top endpoint guide: [docs/V1_MIGRATION_GUIDE.md]
+- API reference: [docs/API_DOCUMENTATION.md]
+
+Please reply with the V1 endpoints you still depend on if the guide does not
+cover your use case.
+
+Thanks,
+The StellarStream team
+
+## 30-day reminder
+
+Subject: Reminder: StellarStream API v1 sunsets on 2026-10-01
+
+Hi [Name],
+
+This is a reminder that StellarStream API v1 sunsets on 2026-10-01. We still
+see recent traffic from your integration to `[observed_v1_endpoint]`.
+
+Recommended next step:
+
+1. Move read-only calls to the documented V3 or bridge endpoint.
+2. Confirm response parsing against the V3 `success` and `data` envelope.
+3. Keep V1 fallback only until production traffic is verified.
+
+Migration guide: [docs/V1_MIGRATION_GUIDE.md]
+
+Please contact us by [support_deadline] if you have a blocker that requires V3
+endpoint parity.
+
+Thanks,
+The StellarStream team
+
+## Final reminder
+
+Subject: Action required: StellarStream API v1 sunset is 7 days away
+
+Hi [Name],
+
+StellarStream API v1 reaches sunset on 2026-10-01. Your integration still
+appears to call `[observed_v1_endpoint]`.
+
+After the sunset date, V1 endpoints may be disabled or moved behind
+compatibility support. To avoid interruption, migrate the remaining calls using
+the V1 migration guide:
+
+[docs/V1_MIGRATION_GUIDE.md]
+
+If you believe this traffic is no longer active, please verify that old jobs,
+webhooks, retry queues, and background workers no longer reference `/api/v1`.
+
+Thanks,
+The StellarStream team

--- a/docs/V1_MIGRATION_GUIDE.md
+++ b/docs/V1_MIGRATION_GUIDE.md
@@ -1,0 +1,125 @@
+# StellarStream V1 Migration Guide
+
+This guide covers the top V1 migration paths for consumers moving off
+`/api/v1` before the 2026-10-01 sunset date.
+
+## Quick checklist
+
+1. Capture current V1 calls and response fields used by your integration.
+2. Add logging for the `Deprecation` and `Sunset` response headers.
+3. Move read-only traffic first, then writes and webhook registration.
+4. Keep V1 fallback until V3 parity is verified in production.
+5. Remove V1 keys, URLs, and client wrappers after the final cutover.
+
+## Top 5 endpoint migrations
+
+### 1. Stream history by address
+
+| V1 | Replacement | Notes |
+|----|-------------|-------|
+| `GET /api/v1/streams/:address` | `GET /api/v3/history/:address` | V3 returns paginated results under `data.results`. |
+
+Query mapping:
+
+| V1 query | V3 query | Action |
+|----------|----------|--------|
+| `tokens=CODE:ISSUER` | `asset=CODE:ISSUER` | Rename the query parameter. |
+| `direction=inbound|outbound` | none | Filter client-side by comparing `sender` and `receiver` to the address. |
+| `status=active|paused|completed` | none | Filter client-side until a V3 status filter is added. |
+
+If you need the old `{ v1, v2 }` split during rollout, use
+`GET /api/v2/streams/:address` as a temporary bridge.
+
+### 2. Stream export
+
+| V1 | Replacement | Notes |
+|----|-------------|-------|
+| `GET /api/v1/streams/export/:address` | `GET /api/v3/history/:address` plus `GET /api/v3/export/:tx_hash?format=pdf|xlsx` | V3 exports transaction-level split audit reports, not address-wide CSVs. |
+
+Migration steps:
+
+1. Fetch the address history with `GET /api/v3/history/:address`.
+2. For each transaction that needs an audit artifact, call
+   `GET /api/v3/export/:tx_hash?format=pdf` or
+   `GET /api/v3/export/:tx_hash?format=xlsx`.
+3. If you require one address-wide CSV, keep the V1 export path until the V3
+   export endpoint has address-level parity.
+
+### 3. Stream fee estimation
+
+| V1 | Replacement | Notes |
+|----|-------------|-------|
+| `POST /api/v1/streams/estimate-fee` | `POST /api/v3/validate-split` and `POST /api/v3/transactions/monitor` | V3 separates preflight validation from submitted transaction monitoring. |
+
+Use `POST /api/v3/validate-split` before creating bulk disbursement or split
+transactions. After a transaction is built, use `POST /api/v3/transactions/monitor`
+to track fee-bump monitoring status.
+
+If your integration needs a pre-submit XDR simulation response, use the
+available V2 fee-estimate bridge in the gateway while a V3 fee endpoint is added.
+
+### 4. Protocol stats
+
+| V1 | Replacement | Notes |
+|----|-------------|-------|
+| `GET /api/v1/stats` | `GET /api/v3/analytics/leaderboard` or `GET /api/v2/stats/protocol` | Use V3 for leaderboard-style analytics and the V2 bridge for protocol totals. |
+
+Field mapping for the V2 bridge:
+
+| V1 field | Bridge field |
+|----------|--------------|
+| `globalTvl` | `totalVolume` |
+| `activeStreams` | `activeStreamsCount` |
+| `totalStreams` | no exact bridge field |
+
+### 5. Webhook registration
+
+| V1 | Replacement | Notes |
+|----|-------------|-------|
+| `POST /api/v1/webhooks/register` | `POST /api/v3/webhooks/register` | Direct V3 replacement. |
+
+V1 request:
+
+```json
+{
+  "url": "https://example.com/hooks",
+  "eventType": "stream.created",
+  "description": "Payment notifications"
+}
+```
+
+V3 response shape nests the generated webhook values under `data`:
+
+```json
+{
+  "success": true,
+  "data": {
+    "webhookId": "wh_abc123",
+    "secretKey": "<redacted-webhook-secret>",
+    "eventType": "stream.created"
+  },
+  "message": "Webhook registered successfully. Store the secretKey securely."
+}
+```
+
+## Other V1 routes
+
+| V1 route | Migration path |
+|----------|----------------|
+| `GET /api/v1/auth/nonce` | `GET /api/v3/auth/nonce` |
+| `GET /api/v1/auth/me` | Keep V1 wallet-auth flow until the V3 authenticated identity endpoint is available. |
+| `GET /api/v1/search` | Use `GET /api/v3/history/:address` when the address is known; otherwise keep V1 search until V3 search parity exists. |
+| `GET /api/v1/streams/verify/:streamId` | Use V3 proof/audit artifacts where possible; keep V1 for direct stream verification until V3 parity exists. |
+| `GET /api/v1/audit-log*` | Use V3 history, export, and proof-of-payment artifacts depending on the audit use case. |
+
+## Cutover validation
+
+Before disabling V1 in a client:
+
+- Confirm every V1 call has a V3 or documented bridge replacement.
+- Compare production responses for a representative address, transaction, and
+  webhook registration.
+- Verify downstream parsers handle V3 envelope changes such as `success` and
+  `data`.
+- Keep alerting on any remaining V1 `Deprecation` headers until they drop to
+  zero.


### PR DESCRIPTION
Closes #1188

## Summary
- Adds shared V1 deprecation warning middleware that sets date-valued `Deprecation`, `Sunset`, `Link`, `Warning`, and `X-StellarStream-API-Deprecation` headers.
- Mounts the warning on the main `/api/v1` routes and legacy `/api` stream surface without changing response bodies or status codes.
- Marks V1 as deprecated in Swagger metadata.
- Adds a deprecation timeline, migration guide, and consumer email templates for the V1 to V3/bridge transition.

## Verification
- Focused TypeScript check for `backend/src/middleware/deprecationWarning.ts` and `backend/src/middleware/deprecationWarning.test.ts`: passes.
- `cd backend && npm test -- src/middleware/deprecationWarning.test.ts`: 1 test file passed, 3 tests passed.

## Notes
- Repo-wide backend typecheck is currently blocked by existing TypeScript errors outside this change, so this PR is scoped to #1188 and verifies the changed middleware plus focused regression tests directly.