### PR TITLE
Add missing Stellar address validation

### DIFF
--- a/__tests__/validation.test.ts
+++ b/__tests__/validation.test.ts
@@ -8,12 +8,27 @@ import {
 } from '../lib/validation'
 import { ASSET_CONFIGS } from '../lib/utils'
 
+const VALID_G_ADDRESS = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF'
+const VALID_M_ADDRESS = 'MAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACTA4'
+
 describe('Validation Utilities', () => {
   describe('validateStellarAddress', () => {
-    it('should validate a correct Stellar address', () => {
-      const result = validateStellarAddress('GABCDEFGHIJKLMNOPQRSTUVWXYZ123456789')
+    it('should validate a checksum-valid G Stellar address', () => {
+      const result = validateStellarAddress(VALID_G_ADDRESS)
       expect(result.isValid).toBe(true)
       expect(result.errorMessage).toBeUndefined()
+    })
+
+    it('should validate a checksum-valid M Stellar address', () => {
+      const result = validateStellarAddress(VALID_M_ADDRESS)
+      expect(result.isValid).toBe(true)
+      expect(result.errorMessage).toBeUndefined()
+    })
+
+    it('should reject a truncated M Stellar address', () => {
+      const result = validateStellarAddress(VALID_M_ADDRESS.slice(0, 56))
+      expect(result.isValid).toBe(false)
+      expect(result.errorMessage).toBe('Invalid Stellar address format')
     })
 
     it('should reject empty address', () => {
@@ -28,8 +43,26 @@ describe('Validation Utilities', () => {
       expect(result.errorMessage).toBe('Invalid Stellar address format')
     })
 
+    it('should reject address with unsupported prefix', () => {
+      const result = validateStellarAddress(`C${VALID_G_ADDRESS.slice(1)}`)
+      expect(result.isValid).toBe(false)
+      expect(result.errorMessage).toBe('Invalid Stellar address format')
+    })
+
     it('should reject address that is too short', () => {
       const result = validateStellarAddress('GABC')
+      expect(result.isValid).toBe(false)
+      expect(result.errorMessage).toBe('Invalid Stellar address format')
+    })
+
+    it('should reject address with invalid base32 characters', () => {
+      const result = validateStellarAddress(`G${'0'.repeat(55)}`)
+      expect(result.isValid).toBe(false)
+      expect(result.errorMessage).toBe('Invalid Stellar address format')
+    })
+
+    it('should reject address with invalid checksum', () => {
+      const result = validateStellarAddress(`${VALID_G_ADDRESS.slice(0, -1)}G`)
       expect(result.isValid).toBe(false)
       expect(result.errorMessage).toBe('Invalid Stellar address format')
     })
@@ -128,7 +161,18 @@ describe('Validation Utilities', () => {
   describe('validateRecipient', () => {
     it('should validate a complete valid recipient', () => {
       const recipient = {
-        address: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ123456789',
+        address: VALID_G_ADDRESS,
+        amount: 10.50,
+        asset: 'USDC',
+        memo: 'Payment'
+      }
+      const result = validateRecipient(recipient)
+      expect(result.isValid).toBe(true)
+    })
+
+    it('should validate a complete recipient with a muxed Stellar address', () => {
+      const recipient = {
+        address: VALID_M_ADDRESS,
         amount: 10.50,
         asset: 'USDC',
         memo: 'Payment'
@@ -151,7 +195,7 @@ describe('Validation Utilities', () => {
 
     it('should reject recipient with invalid amount', () => {
       const recipient = {
-        address: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ123456789',
+        address: VALID_G_ADDRESS,
         amount: -5,
         asset: 'USDC',
         memo: 'Payment'

--- a/backend/docs/postman/StellarStream-V3-Disbursement-Engine.postman_collection.json
+++ b/backend/docs/postman/StellarStream-V3-Disbursement-Engine.postman_collection.json
@@ -68,7 +68,7 @@
               "raw": "[\n  { \"address\": \"GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN\", \"amount\": \"100.50\" },\n  { \"address\": \"INVALID_ADDRESS\", \"amount\": \"50.00\" },\n  { \"address\": \"GBVVJJWT3JTHKBZISFYIGR7QRKNSENTRY3BNKFNZOMKVLBXGKBCXBXBB\", \"amount\": \"99999999.12345678\" }\n]",
               "options": { "raw": { "language": "json" } }
             },
-            "description": "Demonstrates partial validation. Invalid rows are collected in the `errors` array; valid rows are still returned in `valid`. The third row has 8 decimal places (exceeds the 7-decimal stroop limit) and will also appear in `errors`.\n\n**Expected 200 response:**\n```json\n{\n  \"success\": true,\n  \"data\": {\n    \"valid\": [\n      { \"address\": \"GAAZI4...\", \"amountStroops\": \"1005000000\" }\n    ],\n    \"errors\": [\n      { \"row\": 2, \"address\": \"INVALID_ADDRESS\", \"reason\": \"Invalid G-address checksum\" },\n      { \"row\": 3, \"address\": \"GBVVJJ...\", \"reason\": \"Amount exceeds 7 decimal places\" }\n    ],\n    \"totalRows\": 3\n  }\n}\n```"
+            "description": "Demonstrates partial validation. Invalid rows are collected in the `errors` array; valid rows are still returned in `valid`. The third row has 8 decimal places (exceeds the 7-decimal stroop limit) and will also appear in `errors`.\n\n**Expected 200 response:**\n```json\n{\n  \"success\": true,\n  \"data\": {\n    \"valid\": [\n      { \"address\": \"GAAZI4...\", \"amountStroops\": \"1005000000\" }\n    ],\n    \"errors\": [\n      { \"row\": 2, \"address\": \"INVALID_ADDRESS\", \"reason\": \"Invalid Stellar address checksum\" },\n      { \"row\": 3, \"address\": \"GBVVJJ...\", \"reason\": \"Amount exceeds 7 decimal places\" }\n    ],\n    \"totalRows\": 3\n  }\n}\n```"
           },
           "response": [
             {
@@ -76,7 +76,7 @@
               "status": "OK",
               "code": 200,
               "header": [{ "key": "Content-Type", "value": "application/json" }],
-              "body": "{\n  \"success\": true,\n  \"data\": {\n    \"valid\": [\n      { \"address\": \"GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN\", \"amountStroops\": \"1005000000\" }\n    ],\n    \"errors\": [\n      { \"row\": 2, \"address\": \"INVALID_ADDRESS\", \"reason\": \"Invalid G-address checksum\" },\n      { \"row\": 3, \"address\": \"GBVVJJWT3JTHKBZISFYIGR7QRKNSENTRY3BNKFNZOMKVLBXGKBCXBXBB\", \"reason\": \"Amount exceeds 7 decimal places\" }\n    ],\n    \"totalRows\": 3\n  }\n}"
+              "body": "{\n  \"success\": true,\n  \"data\": {\n    \"valid\": [\n      { \"address\": \"GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN\", \"amountStroops\": \"1005000000\" }\n    ],\n    \"errors\": [\n      { \"row\": 2, \"address\": \"INVALID_ADDRESS\", \"reason\": \"Invalid Stellar address checksum\" },\n      { \"row\": 3, \"address\": \"GBVVJJWT3JTHKBZISFYIGR7QRKNSENTRY3BNKFNZOMKVLBXGKBCXBXBB\", \"reason\": \"Amount exceeds 7 decimal places\" }\n    ],\n    \"totalRows\": 3\n  }\n}"
             }
           ]
         },

--- a/backend/src/api/v3/swagger.ts
+++ b/backend/src/api/v3/swagger.ts
@@ -40,7 +40,7 @@ const options: swaggerJsdoc.Options = {
         CleanRecipient: {
           type: "object",
           properties: {
-            address: { type: "string", example: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN", description: "Validated Stellar G-address" },
+            address: { type: "string", example: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN", description: "Validated Stellar recipient address" },
             amountStroops: { type: "string", example: "10050000", description: "Amount in 7-decimal stroops" },
           },
           required: ["address", "amountStroops"],
@@ -50,7 +50,7 @@ const options: swaggerJsdoc.Options = {
           properties: {
             row: { type: "integer", example: 3 },
             address: { type: "string", example: "INVALID_ADDR" },
-            reason: { type: "string", example: "Invalid G-address checksum" },
+            reason: { type: "string", example: "Invalid Stellar address checksum" },
           },
         },
         ProcessFileResult: {
@@ -490,7 +490,7 @@ const options: swaggerJsdoc.Options = {
           responses: {
             "200": {
               description: "Processed. Check `errors` array for invalid rows.",
-              content: { "application/json": { example: { success: true, data: { valid: [{ address: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN", amountStroops: "10050000" }], errors: [{ row: 2, address: "INVALID_ADDR", reason: "Invalid G-address checksum" }], totalRows: 2 } } } },
+              content: { "application/json": { example: { success: true, data: { valid: [{ address: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN", amountStroops: "10050000" }], errors: [{ row: 2, address: "INVALID_ADDR", reason: "Invalid Stellar address checksum" }], totalRows: 2 } } } },
             },
             "400": { description: "Malformed CSV/JSON", content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } } },
             "401": { description: "Unauthorized", content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } } },

--- a/backend/src/lib/stellar-address.ts
+++ b/backend/src/lib/stellar-address.ts
@@ -1,0 +1,106 @@
+const STELLAR_ACCOUNT_ADDRESS_LENGTH = 56;
+const STELLAR_MUXED_ADDRESS_LENGTH = 69;
+const STELLAR_ACCOUNT_ID_VERSION_BYTE = 6 << 3;
+const STELLAR_MUXED_ACCOUNT_VERSION_BYTE = 12 << 3;
+const STELLAR_ACCOUNT_DECODED_LENGTH = 35;
+const STELLAR_MUXED_DECODED_LENGTH = 43;
+
+function base32Value(char: string): number {
+  const code = char.charCodeAt(0);
+
+  if (code >= 65 && code <= 90) {
+    return code - 65;
+  }
+
+  if (code >= 50 && code <= 55) {
+    return code - 24;
+  }
+
+  return -1;
+}
+
+function decodeStellarAddress(address: string, decodedLength: number): Uint8Array | null {
+  const decoded = new Uint8Array(decodedLength);
+  let bitBuffer = 0;
+  let bitCount = 0;
+  let decodedIndex = 0;
+
+  for (let i = 0; i < address.length; i++) {
+    const value = base32Value(address[i]);
+    if (value < 0) {
+      return null;
+    }
+
+    bitBuffer = (bitBuffer << 5) | value;
+    bitCount += 5;
+
+    if (bitCount >= 8) {
+      bitCount -= 8;
+      if (decodedIndex >= decoded.length) {
+        return null;
+      }
+
+      decoded[decodedIndex] = (bitBuffer >> bitCount) & 0xff;
+      decodedIndex += 1;
+      bitBuffer &= (1 << bitCount) - 1;
+    }
+  }
+
+  if (decodedIndex !== decodedLength || bitBuffer !== 0) {
+    return null;
+  }
+
+  return decoded;
+}
+
+function crc16XModem(bytes: Uint8Array): number {
+  let crc = 0;
+
+  for (let i = 0; i < bytes.length; i++) {
+    crc ^= bytes[i] << 8;
+
+    for (let bit = 0; bit < 8; bit++) {
+      if ((crc & 0x8000) !== 0) {
+        crc = ((crc << 1) ^ 0x1021) & 0xffff;
+      } else {
+        crc = (crc << 1) & 0xffff;
+      }
+    }
+  }
+
+  return crc;
+}
+
+function hasValidStellarChecksum(decoded: Uint8Array): boolean {
+  const payload = decoded.slice(0, decoded.length - 2);
+  const expectedChecksum = decoded[decoded.length - 2] | (decoded[decoded.length - 1] << 8);
+
+  return crc16XModem(payload) === expectedChecksum;
+}
+
+export function isValidStellarRecipientAddress(address: string): boolean {
+  const trimmedAddress = address.trim();
+  const version = trimmedAddress[0];
+  const expectedLength = version === "G"
+    ? STELLAR_ACCOUNT_ADDRESS_LENGTH
+    : version === "M"
+      ? STELLAR_MUXED_ADDRESS_LENGTH
+      : null;
+  const expectedDecodedLength = version === "G"
+    ? STELLAR_ACCOUNT_DECODED_LENGTH
+    : version === "M"
+      ? STELLAR_MUXED_DECODED_LENGTH
+      : null;
+  const expectedVersionByte = version === "G"
+    ? STELLAR_ACCOUNT_ID_VERSION_BYTE
+    : version === "M"
+      ? STELLAR_MUXED_ACCOUNT_VERSION_BYTE
+      : null;
+
+  if (!expectedLength || !expectedDecodedLength || !expectedVersionByte || trimmedAddress.length !== expectedLength) {
+    return false;
+  }
+
+  const decoded = decodeStellarAddress(trimmedAddress, expectedDecodedLength);
+  return decoded !== null && decoded[0] === expectedVersionByte && hasValidStellarChecksum(decoded);
+}

--- a/backend/src/services/disbursement-file.service.test.ts
+++ b/backend/src/services/disbursement-file.service.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { processRows } from "./disbursement-file.service.js";
+
+const VALID_G_ADDRESS = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+const VALID_M_ADDRESS = "MAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACTA4";
+
+describe("processRows recipient address validation", () => {
+  it("accepts checksum-valid G and M recipient addresses", () => {
+    const result = processRows([
+      { address: VALID_G_ADDRESS, amount: "1" },
+      { address: VALID_M_ADDRESS, amount: "2.5" },
+    ]);
+
+    expect(result.errors).toEqual([]);
+    expect(result.valid).toEqual([
+      { address: VALID_G_ADDRESS, amountStroops: "10000000" },
+      { address: VALID_M_ADDRESS, amountStroops: "25000000" },
+    ]);
+  });
+
+  it("rejects unsupported prefixes and invalid checksums", () => {
+    const invalidChecksum = `${VALID_G_ADDRESS.slice(0, -1)}G`;
+    const result = processRows([
+      { address: `C${VALID_G_ADDRESS.slice(1)}`, amount: "1" },
+      { address: invalidChecksum, amount: "2" },
+    ]);
+
+    expect(result.valid).toEqual([]);
+    expect(result.errors).toEqual([
+      { row: 1, address: `C${VALID_G_ADDRESS.slice(1)}`, reason: "Invalid Stellar address checksum" },
+      { row: 2, address: invalidChecksum, reason: "Invalid Stellar address checksum" },
+    ]);
+  });
+});

--- a/backend/src/services/disbursement-file.service.ts
+++ b/backend/src/services/disbursement-file.service.ts
@@ -1,7 +1,7 @@
-import { StrKey } from "@stellar/stellar-sdk";
 import { parse } from "csv-parse";
 import { Readable } from "stream";
 import { ValidationError } from "../lib/app-error.js";
+import { isValidStellarRecipientAddress } from "../lib/stellar-address.js";
 
 export interface RawRecipientRow {
   address: string;
@@ -72,8 +72,8 @@ export function processRows(rows: RawRecipientRow[]): ProcessFileResult {
     const amountRaw = (row.amount ?? "").trim();
     const rowNum = i + 1;
 
-    if (!StrKey.isValidEd25519PublicKey(address)) {
-      errors.push({ row: rowNum, address, reason: "Invalid G-address checksum" });
+    if (!isValidStellarRecipientAddress(address)) {
+      errors.push({ row: rowNum, address, reason: "Invalid Stellar address checksum" });
       continue;
     }
 

--- a/frontend/components/conflict-resolver.tsx
+++ b/frontend/components/conflict-resolver.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { StrKey } from "@stellar/stellar-sdk";
+import { isValidStellarRecipientAddress } from "@/lib/stellar-address";
 import { CheckCircle2, AlertTriangle, X } from "lucide-react";
 import type { ParseError } from "@/lib/bulk-parser";
 import type { RecipientRow } from "@/components/recipient-grid";
@@ -59,7 +59,7 @@ export function ConflictResolver({ errors, onResolve, onDiscardAll }: Props) {
       const { address, amount, memoType, memo } = row.rawData;
       const reasons: string[] = [];
 
-      if (!StrKey.isValidEd25519PublicKey(address)) {
+      if (!isValidStellarRecipientAddress(address)) {
         reasons.push("Invalid address");
       }
       const num = parseFloat(amount);

--- a/frontend/lib/bulk-parser.test.ts
+++ b/frontend/lib/bulk-parser.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { parseCSV, parseJSON } from "./bulk-parser";
+
+const VALID_G_ADDRESS = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+const VALID_M_ADDRESS = "MAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACTA4";
+
+describe("bulk recipient address validation", () => {
+  it("accepts checksum-valid G and M recipient addresses from CSV", () => {
+    const result = parseCSV(`address,amount\n${VALID_G_ADDRESS},10\n${VALID_M_ADDRESS},20`);
+
+    expect(result.errors).toEqual([]);
+    expect(result.valid.map((row) => row.address)).toEqual([VALID_G_ADDRESS, VALID_M_ADDRESS]);
+  });
+
+  it("rejects unsupported prefixes and invalid checksums from JSON", () => {
+    const invalidChecksum = `${VALID_G_ADDRESS.slice(0, -1)}G`;
+    const result = parseJSON(
+      JSON.stringify([
+        { address: `C${VALID_G_ADDRESS.slice(1)}`, amount: "10" },
+        { address: invalidChecksum, amount: "20" },
+      ]),
+    );
+
+    expect(result.valid).toEqual([]);
+    expect(result.errors).toHaveLength(2);
+    expect(result.errors[0].reason).toContain("Invalid Stellar address");
+    expect(result.errors[1].reason).toContain("Invalid Stellar address");
+  });
+});

--- a/frontend/lib/bulk-parser.ts
+++ b/frontend/lib/bulk-parser.ts
@@ -1,5 +1,5 @@
 import Papa from "papaparse";
-import { StrKey } from "@stellar/stellar-sdk";
+import { isValidStellarRecipientAddress } from "@/lib/stellar-address";
 import type { MemoType } from "@/lib/bulk-splitter/types";
 import type { RecipientRow } from "@/components/recipient-grid";
 
@@ -43,7 +43,7 @@ function validateRow(
   const { address, amount } = rawData;
   const reasons: string[] = [];
   
-  if (!StrKey.isValidEd25519PublicKey(address)) {
+  if (!isValidStellarRecipientAddress(address)) {
     reasons.push(`Invalid Stellar address "${address}"`);
   }
   const num = parseFloat(amount);

--- a/frontend/lib/stellar-address.ts
+++ b/frontend/lib/stellar-address.ts
@@ -1,0 +1,106 @@
+const STELLAR_ACCOUNT_ADDRESS_LENGTH = 56;
+const STELLAR_MUXED_ADDRESS_LENGTH = 69;
+const STELLAR_ACCOUNT_ID_VERSION_BYTE = 6 << 3;
+const STELLAR_MUXED_ACCOUNT_VERSION_BYTE = 12 << 3;
+const STELLAR_ACCOUNT_DECODED_LENGTH = 35;
+const STELLAR_MUXED_DECODED_LENGTH = 43;
+
+function base32Value(char: string): number {
+  const code = char.charCodeAt(0);
+
+  if (code >= 65 && code <= 90) {
+    return code - 65;
+  }
+
+  if (code >= 50 && code <= 55) {
+    return code - 24;
+  }
+
+  return -1;
+}
+
+function decodeStellarAddress(address: string, decodedLength: number): Uint8Array | null {
+  const decoded = new Uint8Array(decodedLength);
+  let bitBuffer = 0;
+  let bitCount = 0;
+  let decodedIndex = 0;
+
+  for (let i = 0; i < address.length; i++) {
+    const value = base32Value(address[i]);
+    if (value < 0) {
+      return null;
+    }
+
+    bitBuffer = (bitBuffer << 5) | value;
+    bitCount += 5;
+
+    if (bitCount >= 8) {
+      bitCount -= 8;
+      if (decodedIndex >= decoded.length) {
+        return null;
+      }
+
+      decoded[decodedIndex] = (bitBuffer >> bitCount) & 0xff;
+      decodedIndex += 1;
+      bitBuffer &= (1 << bitCount) - 1;
+    }
+  }
+
+  if (decodedIndex !== decodedLength || bitBuffer !== 0) {
+    return null;
+  }
+
+  return decoded;
+}
+
+function crc16XModem(bytes: Uint8Array): number {
+  let crc = 0;
+
+  for (let i = 0; i < bytes.length; i++) {
+    crc ^= bytes[i] << 8;
+
+    for (let bit = 0; bit < 8; bit++) {
+      if ((crc & 0x8000) !== 0) {
+        crc = ((crc << 1) ^ 0x1021) & 0xffff;
+      } else {
+        crc = (crc << 1) & 0xffff;
+      }
+    }
+  }
+
+  return crc;
+}
+
+function hasValidStellarChecksum(decoded: Uint8Array): boolean {
+  const payload = decoded.slice(0, decoded.length - 2);
+  const expectedChecksum = decoded[decoded.length - 2] | (decoded[decoded.length - 1] << 8);
+
+  return crc16XModem(payload) === expectedChecksum;
+}
+
+export function isValidStellarRecipientAddress(address: string): boolean {
+  const trimmedAddress = address.trim();
+  const version = trimmedAddress[0];
+  const expectedLength = version === "G"
+    ? STELLAR_ACCOUNT_ADDRESS_LENGTH
+    : version === "M"
+      ? STELLAR_MUXED_ADDRESS_LENGTH
+      : null;
+  const expectedDecodedLength = version === "G"
+    ? STELLAR_ACCOUNT_DECODED_LENGTH
+    : version === "M"
+      ? STELLAR_MUXED_DECODED_LENGTH
+      : null;
+  const expectedVersionByte = version === "G"
+    ? STELLAR_ACCOUNT_ID_VERSION_BYTE
+    : version === "M"
+      ? STELLAR_MUXED_ACCOUNT_VERSION_BYTE
+      : null;
+
+  if (!expectedLength || !expectedDecodedLength || !expectedVersionByte || trimmedAddress.length !== expectedLength) {
+    return false;
+  }
+
+  const decoded = decodeStellarAddress(trimmedAddress, expectedDecodedLength);
+  return decoded !== null && decoded[0] === expectedVersionByte && hasValidStellarChecksum(decoded);
+}

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -1,5 +1,85 @@
 import { ValidationResult, AssetConfig, ASSET_CONFIGS } from './utils'
 
+const STELLAR_ACCOUNT_ADDRESS_LENGTH = 56
+const STELLAR_MUXED_ADDRESS_LENGTH = 69
+const STELLAR_ACCOUNT_ID_VERSION_BYTE = 6 << 3
+const STELLAR_MUXED_ACCOUNT_VERSION_BYTE = 12 << 3
+const STELLAR_ACCOUNT_DECODED_LENGTH = 35
+const STELLAR_MUXED_DECODED_LENGTH = 43
+
+function base32Value(char: string): number {
+  const code = char.charCodeAt(0)
+
+  if (code >= 65 && code <= 90) {
+    return code - 65
+  }
+
+  if (code >= 50 && code <= 55) {
+    return code - 24
+  }
+
+  return -1
+}
+
+function decodeStellarAddress(address: string, decodedLength: number): Uint8Array | null {
+  const decoded = new Uint8Array(decodedLength)
+  let bitBuffer = 0
+  let bitCount = 0
+  let decodedIndex = 0
+
+  for (let i = 0; i < address.length; i++) {
+    const value = base32Value(address[i])
+    if (value < 0) {
+      return null
+    }
+
+    bitBuffer = (bitBuffer << 5) | value
+    bitCount += 5
+
+    if (bitCount >= 8) {
+      bitCount -= 8
+      if (decodedIndex >= decoded.length) {
+        return null
+      }
+
+      decoded[decodedIndex] = (bitBuffer >> bitCount) & 0xff
+      decodedIndex += 1
+      bitBuffer &= (1 << bitCount) - 1
+    }
+  }
+
+  if (decodedIndex !== decodedLength || bitBuffer !== 0) {
+    return null
+  }
+
+  return decoded
+}
+
+function crc16XModem(bytes: Uint8Array): number {
+  let crc = 0
+
+  for (let i = 0; i < bytes.length; i++) {
+    crc ^= bytes[i] << 8
+
+    for (let bit = 0; bit < 8; bit++) {
+      if ((crc & 0x8000) !== 0) {
+        crc = ((crc << 1) ^ 0x1021) & 0xffff
+      } else {
+        crc = (crc << 1) & 0xffff
+      }
+    }
+  }
+
+  return crc
+}
+
+function hasValidStellarChecksum(decoded: Uint8Array): boolean {
+  const payload = decoded.slice(0, decoded.length - 2)
+  const expectedChecksum = decoded[decoded.length - 2] | (decoded[decoded.length - 1] << 8)
+
+  return crc16XModem(payload) === expectedChecksum
+}
+
 /**
  * Validates a Stellar address format
  * @param address - The Stellar address to validate
@@ -13,9 +93,47 @@ export function validateStellarAddress(address: string): ValidationResult {
     }
   }
 
-  // Basic Stellar address validation (starts with 'G' and is 56 characters)
-  const stellarAddressRegex = /^G[A-Z0-9]{55}$/
-  if (!stellarAddressRegex.test(address.trim())) {
+  const trimmedAddress = address.trim()
+  const version = trimmedAddress[0]
+  const expectedLength = version === 'G'
+    ? STELLAR_ACCOUNT_ADDRESS_LENGTH
+    : version === 'M'
+      ? STELLAR_MUXED_ADDRESS_LENGTH
+      : null
+  const expectedDecodedLength = version === 'G'
+    ? STELLAR_ACCOUNT_DECODED_LENGTH
+    : version === 'M'
+      ? STELLAR_MUXED_DECODED_LENGTH
+      : null
+  const expectedVersionByte = version === 'G'
+    ? STELLAR_ACCOUNT_ID_VERSION_BYTE
+    : version === 'M'
+      ? STELLAR_MUXED_ACCOUNT_VERSION_BYTE
+      : null
+
+  if (!expectedLength || !expectedDecodedLength || !expectedVersionByte || trimmedAddress.length !== expectedLength) {
+    return {
+      isValid: false,
+      errorMessage: 'Invalid Stellar address format'
+    }
+  }
+
+  const decoded = decodeStellarAddress(trimmedAddress, expectedDecodedLength)
+  if (!decoded) {
+    return {
+      isValid: false,
+      errorMessage: 'Invalid Stellar address format'
+    }
+  }
+
+  if (decoded[0] !== expectedVersionByte) {
+    return {
+      isValid: false,
+      errorMessage: 'Invalid Stellar address format'
+    }
+  }
+
+  if (!hasValidStellarChecksum(decoded)) {
     return {
       isValid: false,
       errorMessage: 'Invalid Stellar address format'


### PR DESCRIPTION
Closes #1160

## Summary
- Replaces loose recipient address checks with StrKey-style Stellar address validation at the user-input and file-ingestion boundaries.
- Validates G account addresses and M muxed addresses with version bytes, base32 decoding, and CRC16-XModem checksums.
- Rejects unsupported prefixes, invalid lengths, invalid base32 characters, and checksum mismatches.
- Applies the validation to the shared recipient helper, frontend bulk parsing, frontend conflict resolution, and backend disbursement file processing.
- Adds focused tests for the helper plus frontend and backend ingestion paths.

## Verification
- `npm test -- --runInBand --runTestsByPath __tests__/validation.test.ts -t "validateStellarAddress|validateRecipient"`: 1 test suite passed; 13 tests passed, 20 skipped
- `cd frontend && npx vitest run lib/bulk-parser.test.ts`: 1 test file passed, 2 tests passed
- `cd backend && npx vitest run src/services/disbursement-file.service.test.ts`: 1 test file passed, 2 tests passed

## Notes
- Stellar G account addresses are 56 characters; muxed M addresses are 69 characters. This PR follows Stellar StrKey format while still enforcing the requested G/M boundary.
- `contracts/splitter-v3` receives Soroban `Address` values, not raw user-entered strings. Raw prefix, length, base32, and checksum validation therefore belongs before the address is converted into contract input; this PR hardens those ingestion paths without changing contract transfer semantics.
- The root Jest command is scoped to the changed address validator; this PR does not change existing amount validation behavior in the same test file.