### PR TITLE
feat(compliance): add regulatory compliance report generation

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -8,3 +8,6 @@ coverage/
 *.tsbuildinfo
 
 /src/generated/prisma
+
+# Generated regulatory reports (secure local storage — never committed)
+/storage/compliance-reports/

--- a/backend/prisma/migrations/add_compliance_reports.sql
+++ b/backend/prisma/migrations/add_compliance_reports.sql
@@ -1,0 +1,28 @@
+-- Migration: add_compliance_reports (#1359)
+-- Adds ComplianceReport table: an immutable, checksummed record of every
+-- generated regulatory report (AML/KYC, transaction monitoring, suspicious
+-- activity, regulatory filing bundles, audit trails).
+--
+-- The report file itself is written to secure on-disk storage
+-- (backend/storage/compliance-reports, 0600/0700 permissions, outside any
+-- statically served directory). This table stores only the file's location,
+-- a SHA-256 checksum for tamper detection, and generation metadata —
+-- never the file content or raw PII beyond what's needed to locate it.
+
+CREATE TABLE IF NOT EXISTS "ComplianceReport" (
+  id             UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  report_type    TEXT        NOT NULL, -- AML_KYC | TRANSACTION_MONITORING | SUSPICIOUS_ACTIVITY | REGULATORY_FILING | AUDIT_TRAIL
+  format         TEXT        NOT NULL, -- pdf | csv | xlsx
+  period_start   TIMESTAMPTZ NOT NULL,
+  period_end     TIMESTAMPTZ NOT NULL,
+  record_count   INTEGER     NOT NULL DEFAULT 0,
+  file_path      TEXT        NOT NULL,
+  checksum_sha256 TEXT       NOT NULL,
+  generated_by   TEXT        NOT NULL DEFAULT 'system', -- admin identifier, or 'system' for scheduled runs
+  metadata       JSONB,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_compliance_report_type       ON "ComplianceReport" (report_type);
+CREATE INDEX IF NOT EXISTS idx_compliance_report_created    ON "ComplianceReport" (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_compliance_report_period     ON "ComplianceReport" (period_start, period_end);

--- a/backend/src/__tests__/compliance-report.test.ts
+++ b/backend/src/__tests__/compliance-report.test.ts
@@ -1,0 +1,293 @@
+/**
+ * ComplianceReportService tests (#1359).
+ *
+ * DB calls are mocked so no Postgres instance is required. Filesystem I/O is
+ * real (writing under backend/storage/compliance-reports, which is
+ * gitignored and cleaned up after each test) rather than mocked — pdfkit
+ * itself reads its bundled .afm font files via fs.readFileSync, so a blanket
+ * fs mock would break PDF rendering. Exercising real file I/O also gives
+ * genuine coverage of the checksum/tamper-detection logic instead of a
+ * simulated one.
+ *
+ * Tests cover:
+ *   - Report generation for each report type (AML/KYC, transaction monitoring,
+ *     suspicious activity, regulatory filing, audit trail)
+ *   - PDF and CSV rendering produce non-empty, checksummed output
+ *   - Failed metadata writes roll back the on-disk file
+ *   - Report retrieval refuses to serve a file whose checksum no longer matches
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { createHash } from "crypto";
+
+// ── Mock prisma ──────────────────────────────────────────────────────────────
+
+const mockQueryRaw = vi.fn();
+const mockExecuteRaw = vi.fn();
+const mockEventLogFindMany = vi.fn();
+const mockAdminAuditLogFindMany = vi.fn();
+
+vi.mock("../lib/db.js", () => ({
+  prisma: {
+    $queryRaw: (...args: unknown[]) => mockQueryRaw(...args),
+    $executeRaw: (...args: unknown[]) => mockExecuteRaw(...args),
+    eventLog: { findMany: (...args: unknown[]) => mockEventLogFindMany(...args) },
+    adminAuditLog: { findMany: (...args: unknown[]) => mockAdminAuditLogFindMany(...args) },
+  },
+}));
+
+vi.mock("../logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { ComplianceReportService } from "../services/compliance-report.service.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const PERIOD_START = new Date("2026-06-01T00:00:00.000Z");
+const PERIOD_END = new Date("2026-07-01T00:00:00.000Z");
+const REPORTS_DIR = path.join(process.cwd(), "storage", "compliance-reports");
+
+function queryTextOf(strings: TemplateStringsArray): string {
+  return strings.join(" ");
+}
+
+function mockAllComplianceQueries() {
+  mockQueryRaw.mockImplementation((strings: TemplateStringsArray) => {
+    const q = queryTextOf(strings);
+    if (q.includes("ComplianceProfile")) {
+      return Promise.resolve([
+        {
+          stellar_address: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+          kyc_level: 1,
+          sanctioned: false,
+          is_pep: false,
+          updated_at: PERIOD_START,
+        },
+      ]);
+    }
+    if (q.includes("ComplianceLog")) {
+      return Promise.resolve([
+        {
+          sender_address: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+          recipient_address: "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+          amount_stroops: "20000000000",
+          asset_code: "XLM",
+          tx_hash: "abc123",
+          allowed: false,
+          check_name: "AML,TRANSACTION_LIMITS",
+          block_reason: "Structuring pattern detected",
+          created_at: PERIOD_START,
+        },
+      ]);
+    }
+    return Promise.resolve([]);
+  });
+}
+
+describe("ComplianceReportService", () => {
+  let service: ComplianceReportService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAllComplianceQueries();
+    mockExecuteRaw.mockResolvedValue(undefined);
+    mockEventLogFindMany.mockResolvedValue([
+      {
+        eventType: "create",
+        streamId: "stream-1",
+        txHash: "tx-1",
+        sender: "GSENDER",
+        receiver: "GRECEIVER",
+        amount: BigInt("1000000"),
+        entryHash: "deadbeefdeadbeef",
+        createdAt: PERIOD_START,
+      },
+    ]);
+    mockAdminAuditLogFindMany.mockResolvedValue([
+      {
+        timestamp: PERIOD_START,
+        userId: "admin-1",
+        userEmail: "admin@example.com",
+        method: "PATCH",
+        path: "/compliance/config",
+        statusCode: 200,
+        changesSummary: "Updated KYC threshold",
+      },
+    ]);
+    service = new ComplianceReportService();
+  });
+
+  afterEach(() => {
+    fs.rmSync(REPORTS_DIR, { recursive: true, force: true });
+  });
+
+  // ── Generation: one test per report type ────────────────────────────────
+
+  it.each([
+    "AML_KYC",
+    "TRANSACTION_MONITORING",
+    "SUSPICIOUS_ACTIVITY",
+    "REGULATORY_FILING",
+    "AUDIT_TRAIL",
+  ] as const)("generates a PDF report for %s and writes it to secure storage", async (reportType) => {
+    const report = await service.generateReport({
+      reportType,
+      format: "pdf",
+      periodStart: PERIOD_START,
+      periodEnd: PERIOD_END,
+      generatedBy: "admin-test",
+    });
+
+    expect(report.reportType).toBe(reportType);
+    expect(report.format).toBe("pdf");
+    expect(report.checksumSha256).toMatch(/^[a-f0-9]{64}$/);
+
+    const files = fs.readdirSync(REPORTS_DIR);
+    expect(files.length).toBe(1);
+
+    const written = fs.readFileSync(path.join(REPORTS_DIR, files[0]));
+    expect(written.length).toBeGreaterThan(0);
+    expect(createHash("sha256").update(written).digest("hex")).toBe(report.checksumSha256);
+
+    // Secure permissions: owner read/write only
+    const stat = fs.statSync(path.join(REPORTS_DIR, files[0]));
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+
+  it("generates a CSV report with correct checksum", async () => {
+    const report = await service.generateReport({
+      reportType: "TRANSACTION_MONITORING",
+      format: "csv",
+      periodStart: PERIOD_START,
+      periodEnd: PERIOD_END,
+      generatedBy: "admin-test",
+    });
+
+    expect(report.format).toBe("csv");
+    const files = fs.readdirSync(REPORTS_DIR);
+    expect(files[0].endsWith(".csv")).toBe(true);
+
+    const written = fs.readFileSync(path.join(REPORTS_DIR, files[0]), "utf-8");
+    expect(written).toContain("Sender");
+    expect(written).toContain("Recipient");
+  });
+
+  it("persists report metadata via a ComplianceReport insert", async () => {
+    await service.generateReport({
+      reportType: "SUSPICIOUS_ACTIVITY",
+      format: "pdf",
+      periodStart: PERIOD_START,
+      periodEnd: PERIOD_END,
+      generatedBy: "admin-test",
+    });
+
+    expect(mockExecuteRaw).toHaveBeenCalledTimes(1);
+    expect(String(mockExecuteRaw.mock.calls[0][0])).toMatch(/ComplianceReport/i);
+  });
+
+  it("rolls back the on-disk file if metadata persistence fails", async () => {
+    mockExecuteRaw.mockRejectedValue(new Error("DB unavailable"));
+
+    await expect(
+      service.generateReport({
+        reportType: "AML_KYC",
+        format: "pdf",
+        periodStart: PERIOD_START,
+        periodEnd: PERIOD_END,
+        generatedBy: "admin-test",
+      }),
+    ).rejects.toThrow("DB unavailable");
+
+    expect(fs.existsSync(REPORTS_DIR) ? fs.readdirSync(REPORTS_DIR) : []).toHaveLength(0);
+  });
+
+  // ── Listing / metadata ───────────────────────────────────────────────────
+
+  it("listReports queries ComplianceReport", async () => {
+    mockQueryRaw.mockResolvedValue([{ id: "r1", report_type: "AML_KYC" }]);
+    const reports = await service.listReports({ limit: 10 });
+    expect(Array.isArray(reports)).toBe(true);
+    expect(mockQueryRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it("getReportMetadata returns null when no row matches", async () => {
+    mockQueryRaw.mockResolvedValue([]);
+    const meta = await service.getReportMetadata("nonexistent-id");
+    expect(meta).toBeNull();
+  });
+
+  // ── Secure retrieval ─────────────────────────────────────────────────────
+
+  it("getReportFile returns null when metadata is missing", async () => {
+    mockQueryRaw.mockResolvedValue([]);
+    const file = await service.getReportFile("missing-id");
+    expect(file).toBeNull();
+  });
+
+  it("getReportFile returns null when the file is missing from disk", async () => {
+    mockQueryRaw.mockResolvedValue([
+      {
+        id: "r1",
+        report_type: "AML_KYC",
+        format: "pdf",
+        file_path: path.join(os.tmpdir(), "compliance-report-test-does-not-exist.pdf"),
+        checksum_sha256: "abc",
+      },
+    ]);
+
+    const file = await service.getReportFile("r1");
+    expect(file).toBeNull();
+  });
+
+  it("getReportFile throws when the checksum no longer matches (tamper detection)", async () => {
+    const tamperedPath = path.join(os.tmpdir(), `compliance-report-tamper-${Date.now()}.pdf`);
+    fs.writeFileSync(tamperedPath, "tampered content after generation");
+
+    mockQueryRaw.mockResolvedValue([
+      {
+        id: "r1",
+        report_type: "AML_KYC",
+        format: "pdf",
+        file_path: tamperedPath,
+        checksum_sha256: "0".repeat(64), // does not match the file's real content
+      },
+    ]);
+
+    try {
+      await expect(service.getReportFile("r1")).rejects.toThrow(/integrity/i);
+    } finally {
+      fs.rmSync(tamperedPath, { force: true });
+    }
+  });
+
+  it("getReportFile returns the buffer and correct content type when checksum matches", async () => {
+    const filePath = path.join(os.tmpdir(), `compliance-report-valid-${Date.now()}.csv`);
+    const content = "sender_address,recipient_address\nGA...,GB...\n";
+    fs.writeFileSync(filePath, content);
+    const checksum = createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+
+    mockQueryRaw.mockResolvedValue([
+      {
+        id: "r1",
+        report_type: "TRANSACTION_MONITORING",
+        format: "csv",
+        file_path: filePath,
+        checksum_sha256: checksum,
+      },
+    ]);
+
+    try {
+      const file = await service.getReportFile("r1");
+      expect(file).not.toBeNull();
+      expect(file!.contentType).toBe("text/csv");
+      expect(file!.filename).toBe("transaction_monitoring-r1.csv");
+      expect(file!.buffer.toString("utf-8")).toBe(content);
+    } finally {
+      fs.rmSync(filePath, { force: true });
+    }
+  });
+});

--- a/backend/src/api/compliance-reports.routes.ts
+++ b/backend/src/api/compliance-reports.routes.ts
@@ -1,0 +1,189 @@
+/**
+ * Compliance Reports API routes — /api/v1/compliance/reports (#1359)
+ *
+ * POST   /generate      — generate a regulatory report for a period (admin)
+ * GET    /              — list previously generated reports (admin)
+ * GET    /:id           — report metadata (admin)
+ * GET    /:id/download  — stream the stored report file (admin)
+ *
+ * All endpoints are admin-gated: these reports can contain KYC levels,
+ * sanctions/PEP flags, and full transaction detail for real counterparties.
+ */
+
+import { Router, Request, Response } from "express";
+import { z } from "zod";
+import { complianceReportService } from "../services/compliance-report.service.js";
+import validateRequest from "../middleware/validateRequest.js";
+import { requireAdmin } from "../middleware/requireAdmin.js";
+import { logger } from "../logger.js";
+
+const router = Router();
+
+// ── Validation schemas ─────────────────────────────────────────────────────
+
+const reportTypeEnum = z.enum([
+  "AML_KYC",
+  "TRANSACTION_MONITORING",
+  "SUSPICIOUS_ACTIVITY",
+  "REGULATORY_FILING",
+  "AUDIT_TRAIL",
+]);
+
+const GenerateSchema = z.object({
+  body: z.object({
+    reportType: reportTypeEnum,
+    format: z.enum(["pdf", "csv"]).default("pdf"),
+    periodStart: z.string().datetime(),
+    periodEnd: z.string().datetime(),
+  }),
+});
+
+const ListQuerySchema = z.object({
+  query: z.object({
+    reportType: reportTypeEnum.optional(),
+    startDate: z.string().datetime().optional(),
+    endDate: z.string().datetime().optional(),
+    limit: z.coerce.number().int().min(1).max(200).default(50),
+    offset: z.coerce.number().int().min(0).default(0),
+  }),
+});
+
+const IdParamSchema = z.object({
+  params: z.object({
+    id: z.string().uuid(),
+  }),
+});
+
+// ── Routes ─────────────────────────────────────────────────────────────────
+
+/**
+ * POST /api/v1/compliance/reports/generate
+ * Generates a regulatory report for [periodStart, periodEnd] and stores it securely.
+ * Returns metadata only — the file itself is retrieved via the download endpoint.
+ */
+router.post(
+  "/generate",
+  requireAdmin,
+  validateRequest({ body: GenerateSchema.shape.body }),
+  async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { reportType, format, periodStart, periodEnd } =
+        req.body as z.infer<typeof GenerateSchema.shape.body>;
+
+      const start = new Date(periodStart);
+      const end = new Date(periodEnd);
+
+      if (start > end) {
+        res.status(400).json({
+          success: false,
+          error: "periodStart must be before periodEnd",
+          code: "INVALID_PERIOD",
+        });
+        return;
+      }
+
+      const generatedBy =
+        (req.headers["x-admin-key"] as string | undefined)?.slice(0, 8) ?? "admin";
+
+      const report = await complianceReportService.generateReport({
+        reportType,
+        format,
+        periodStart: start,
+        periodEnd: end,
+        generatedBy,
+      });
+
+      res.status(201).json({ success: true, report });
+    } catch (err) {
+      logger.error("[compliance/reports/generate] Error", { err });
+      res.status(500).json({ success: false, error: "Failed to generate report" });
+    }
+  },
+);
+
+/**
+ * GET /api/v1/compliance/reports
+ * List previously generated reports.
+ */
+router.get(
+  "/",
+  requireAdmin,
+  validateRequest({ query: ListQuerySchema.shape.query }),
+  async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { reportType, startDate, endDate, limit, offset } =
+        req.query as unknown as z.infer<typeof ListQuerySchema.shape.query>;
+
+      const reports = await complianceReportService.listReports({
+        reportType,
+        startDate: startDate ? new Date(startDate) : undefined,
+        endDate: endDate ? new Date(endDate) : undefined,
+        limit,
+        offset,
+      });
+
+      res.json({ success: true, count: (reports as unknown[]).length, reports });
+    } catch (err) {
+      logger.error("[compliance/reports] Error", { err });
+      res.status(500).json({ success: false, error: "Failed to list reports" });
+    }
+  },
+);
+
+/**
+ * GET /api/v1/compliance/reports/:id
+ * Report metadata (no file content).
+ */
+router.get(
+  "/:id",
+  requireAdmin,
+  validateRequest({ params: IdParamSchema.shape.params }),
+  async (req: Request, res: Response): Promise<void> => {
+    try {
+      const meta = await complianceReportService.getReportMetadata(req.params.id);
+      if (!meta) {
+        res.status(404).json({ success: false, error: "Report not found", code: "NOT_FOUND" });
+        return;
+      }
+      // file_path is an internal storage detail — never expose it.
+      const { file_path: _filePath, ...safeMeta } = meta;
+      res.json({ success: true, report: safeMeta });
+    } catch (err) {
+      logger.error("[compliance/reports/:id] Error", { err });
+      res.status(500).json({ success: false, error: "Failed to fetch report" });
+    }
+  },
+);
+
+/**
+ * GET /api/v1/compliance/reports/:id/download
+ * Streams the stored report file after verifying its checksum.
+ */
+router.get(
+  "/:id/download",
+  requireAdmin,
+  validateRequest({ params: IdParamSchema.shape.params }),
+  async (req: Request, res: Response): Promise<void> => {
+    try {
+      const file = await complianceReportService.getReportFile(req.params.id);
+      if (!file) {
+        res.status(404).json({ success: false, error: "Report not found", code: "NOT_FOUND" });
+        return;
+      }
+
+      res.setHeader("Content-Type", file.contentType);
+      res.setHeader("Content-Disposition", `attachment; filename="${file.filename}"`);
+      res.setHeader("Content-Length", file.buffer.length);
+      res.send(file.buffer);
+    } catch (err) {
+      logger.error("[compliance/reports/:id/download] Error", { err });
+      res.status(500).json({
+        success: false,
+        error: "Failed to download report — integrity check failed",
+        code: "REPORT_INTEGRITY_FAILED",
+      });
+    }
+  },
+);
+
+export default router;

--- a/backend/src/api/index.ts
+++ b/backend/src/api/index.ts
@@ -21,6 +21,7 @@ import assetMappingRouter from "./asset-mapping.routes.js";
 import dustAuditRouter from "./dust-audit.routes.js";
 import recipientRouter from "./recipient.routes.js";
 import complianceRouter from "./compliance.routes.js";
+import complianceReportsRouter from "./compliance-reports.routes.js";
 import auditLogRoutes from "./audit-log.routes.js";
 import clawbackRoutes from "./clawback.routes.js";
 
@@ -44,6 +45,7 @@ router.use("/asset-mapping", assetMappingRouter);
 router.use("/dust-audit", dustAuditRouter);
 router.use("/recipient", recipientRouter);
 router.use("/compliance", complianceRouter);
+router.use("/compliance/reports", complianceReportsRouter);
 router.use("/v2/streams/:streamId/clawback", clawbackRoutes);
 
 // ── Admin Audit Log Routes (#COMPLIANCE - requires admin access) ────────────────

--- a/backend/src/schedulers.ts
+++ b/backend/src/schedulers.ts
@@ -9,6 +9,7 @@ import { MultisigNotifierService } from "./services/multisig-notifier.service.js
 import { archiveOldDisbursements } from "./services/disbursement-archive.service.js";
 import { LedgerConsistencyChecker } from "./services/ledger-consistency.service.js";
 import { V3VolumeAggregatorService } from "./services/v3-volume-aggregator.service.js";
+import { complianceReportService } from "./services/compliance-report.service.js";
 import { logger } from "./logger.js";
 
 const priceService = new PriceService();
@@ -135,6 +136,7 @@ export function initializeSchedulers() {
   scheduleDisbursementArchive();
   scheduleLedgerConsistencyCheck();
   scheduleV3VolumeAggregation();
+  scheduleComplianceReportGeneration();
 }
 
 /**
@@ -229,4 +231,43 @@ export function scheduleV3VolumeAggregation() {
   });
 
   logger.info("V3 volume aggregator scheduler started (daily at 00:05 UTC)");
+}
+
+/**
+ * Compliance Reports (#1359): automatically generate the previous calendar
+ * month's regulatory filing bundle and audit trail report.
+ * Runs on the 1st of every month at 04:00 UTC — after disbursement archival
+ * (03:00) so the period's data is settled.
+ */
+export function scheduleComplianceReportGeneration() {
+  cron.schedule("0 4 1 * *", async () => {
+    try {
+      logger.info("[ComplianceReport] Starting monthly automated report generation");
+
+      const periodEnd = new Date();
+      periodEnd.setUTCDate(1);
+      periodEnd.setUTCHours(0, 0, 0, 0);
+      const periodStart = new Date(periodEnd);
+      periodStart.setUTCMonth(periodStart.getUTCMonth() - 1);
+
+      for (const reportType of ["REGULATORY_FILING", "AUDIT_TRAIL"] as const) {
+        await complianceReportService.generateReport({
+          reportType,
+          format: "pdf",
+          periodStart,
+          periodEnd,
+          generatedBy: "system-scheduler",
+        });
+      }
+
+      logger.info("[ComplianceReport] Monthly automated report generation completed", {
+        periodStart: periodStart.toISOString(),
+        periodEnd: periodEnd.toISOString(),
+      });
+    } catch (error) {
+      logger.error("[ComplianceReport] Monthly automated report generation failed", error);
+    }
+  });
+
+  logger.info("Compliance report scheduler started (monthly on 1st at 04:00 UTC)");
 }

--- a/backend/src/services/compliance-report.service.ts
+++ b/backend/src/services/compliance-report.service.ts
@@ -1,0 +1,692 @@
+/**
+ * ComplianceReportService — regulatory compliance report generation (#1359)
+ *
+ * Generates the report types regulators and internal compliance teams need:
+ *   - AML_KYC               — compliance-profile state (KYC level, sanctions, PEP) + AML/KYC check history
+ *   - TRANSACTION_MONITORING — every compliance-screened payment in a period, flagged limit breaches included
+ *   - SUSPICIOUS_ACTIVITY    — blocked payments formatted as SAR-style entries with a narrative
+ *   - REGULATORY_FILING      — a filing-ready bundle summarizing all of the above for a period
+ *   - AUDIT_TRAIL            — the hash-chained protocol event log + admin operation log for a period
+ *
+ * Every generated report is written to secure on-disk storage (0600, outside
+ * any statically-served directory), checksummed with SHA-256, and logged to
+ * "ComplianceReport" for accountability — satisfying "automated generation"
+ * and "secure storage" independent of who or what triggered the run.
+ */
+
+import PDFDocument from "pdfkit";
+import { Parser } from "json2csv";
+import * as crypto from "crypto";
+import * as fs from "fs";
+import * as path from "path";
+import { prisma } from "../lib/db.js";
+import { logger } from "../logger.js";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type ComplianceReportType =
+  | "AML_KYC"
+  | "TRANSACTION_MONITORING"
+  | "SUSPICIOUS_ACTIVITY"
+  | "REGULATORY_FILING"
+  | "AUDIT_TRAIL";
+
+export type ComplianceReportFormat = "pdf" | "csv";
+
+export interface GenerateReportOptions {
+  reportType: ComplianceReportType;
+  format: ComplianceReportFormat;
+  periodStart: Date;
+  periodEnd: Date;
+  generatedBy: string;
+}
+
+export interface ComplianceReportRecord {
+  id: string;
+  reportType: string;
+  format: string;
+  periodStart: string;
+  periodEnd: string;
+  recordCount: number;
+  checksumSha256: string;
+  generatedBy: string;
+  createdAt: string;
+}
+
+export interface ComplianceReportListFilters {
+  reportType?: ComplianceReportType;
+  startDate?: Date;
+  endDate?: Date;
+  limit?: number;
+  offset?: number;
+}
+
+export interface StoredReportFile {
+  buffer: Buffer;
+  filename: string;
+  contentType: string;
+}
+
+interface ReportSection {
+  heading: string;
+  columns: string[];
+  rows: string[][];
+}
+
+interface ReportPayload {
+  title: string;
+  summary: Array<[string, string]>;
+  sections: ReportSection[];
+  /** Section used for CSV export (CSV supports a single flat table). */
+  csvSection: ReportSection;
+}
+
+const REPORT_TYPES: ComplianceReportType[] = [
+  "AML_KYC",
+  "TRANSACTION_MONITORING",
+  "SUSPICIOUS_ACTIVITY",
+  "REGULATORY_FILING",
+  "AUDIT_TRAIL",
+];
+
+// ─── Secure storage ─────────────────────────────────────────────────────────
+
+const REPORTS_DIR = path.join(process.cwd(), "storage", "compliance-reports");
+
+function ensureReportsDir(): void {
+  fs.mkdirSync(REPORTS_DIR, { recursive: true, mode: 0o700 });
+}
+
+function sha256(buffer: Buffer): string {
+  return crypto.createHash("sha256").update(buffer).digest("hex");
+}
+
+// ─── Brand tokens (matches invoice-pdf.service.ts / split-audit-export.service.ts) ──
+
+const BRAND_CYAN = "#00f5ff";
+const DARK_BG = "#080814";
+const TEXT_PRIMARY = "#e0e0ff";
+const TEXT_MUTED = "#7878a0";
+const ROW_ALT = "#0f0f28";
+
+// ─── PDF rendering ──────────────────────────────────────────────────────────
+
+function renderPDF(payload: ReportPayload): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const doc = new PDFDocument({ size: "A4", margin: 50 });
+    const chunks: Buffer[] = [];
+
+    doc.on("data", (chunk: Buffer) => chunks.push(chunk));
+    doc.on("end", () => resolve(Buffer.concat(chunks)));
+    doc.on("error", reject);
+
+    const W = doc.page.width;
+    const M = 50;
+
+    const drawHeader = () => {
+      doc.rect(0, 0, W, doc.page.height).fill(DARK_BG);
+      doc.rect(0, 0, W, 4).fill(BRAND_CYAN);
+      doc
+        .font("Helvetica-Bold")
+        .fontSize(20)
+        .fillColor(BRAND_CYAN)
+        .text("StellarStream", M, 24);
+      doc
+        .font("Helvetica-Bold")
+        .fontSize(13)
+        .fillColor(TEXT_PRIMARY)
+        .text(payload.title.toUpperCase(), W - M - 260, 28, { width: 260, align: "right" });
+      doc.moveTo(M, 72).lineTo(W - M, 72).strokeColor(BRAND_CYAN).lineWidth(0.5).stroke();
+    };
+
+    const drawFooter = () => {
+      const footerY = doc.page.height - 30;
+      doc.rect(0, footerY - 4, W, 4).fill(BRAND_CYAN);
+      doc
+        .font("Helvetica")
+        .fontSize(7)
+        .fillColor(TEXT_MUTED)
+        .text(
+          `Generated ${new Date().toISOString()} · StellarStream Compliance · Confidential`,
+          M,
+          footerY + 6,
+          { width: W - M * 2, align: "center" },
+        );
+    };
+
+    drawHeader();
+    let y = 86;
+
+    // ── Summary block ────────────────────────────────────────────────────────
+    for (const [label, value] of payload.summary) {
+      doc.font("Helvetica-Bold").fontSize(8).fillColor(TEXT_MUTED).text(label, M, y);
+      doc.font("Helvetica").fontSize(9).fillColor(TEXT_PRIMARY).text(value, M + 160, y, { width: W - M * 2 - 160 });
+      y += 16;
+    }
+    y += 10;
+
+    for (const section of payload.sections) {
+      if (y > doc.page.height - 140) {
+        drawFooter();
+        doc.addPage();
+        drawHeader();
+        y = 86;
+      }
+
+      doc.font("Helvetica-Bold").fontSize(11).fillColor(BRAND_CYAN).text(section.heading, M, y);
+      y += 18;
+
+      if (section.rows.length === 0) {
+        doc.font("Helvetica").fontSize(9).fillColor(TEXT_MUTED).text("No records in this period.", M, y);
+        y += 20;
+        continue;
+      }
+
+      const colWidth = (W - M * 2) / section.columns.length;
+
+      doc.rect(M, y, W - M * 2, 16).fill("#0a0a22");
+      section.columns.forEach((col, i) => {
+        doc
+          .font("Helvetica-Bold")
+          .fontSize(7.5)
+          .fillColor(TEXT_MUTED)
+          .text(col.toUpperCase(), M + i * colWidth + 4, y + 4, { width: colWidth - 6 });
+      });
+      y += 16;
+
+      for (let r = 0; r < section.rows.length; r++) {
+        if (y > doc.page.height - 60) {
+          drawFooter();
+          doc.addPage();
+          drawHeader();
+          y = 86;
+        }
+
+        const rowH = 16;
+        if (r % 2 === 1) doc.rect(M, y, W - M * 2, rowH).fill(ROW_ALT);
+
+        section.rows[r].forEach((cell, i) => {
+          doc
+            .font("Helvetica")
+            .fontSize(7)
+            .fillColor(TEXT_PRIMARY)
+            .text(cell, M + i * colWidth + 4, y + 4, { width: colWidth - 6, ellipsis: true });
+        });
+        y += rowH;
+      }
+      y += 14;
+    }
+
+    drawFooter();
+    doc.end();
+  });
+}
+
+// ─── CSV rendering ──────────────────────────────────────────────────────────
+
+function renderCSV(section: ReportSection): string {
+  if (section.rows.length === 0) {
+    return section.columns.join(",") + "\n";
+  }
+  const rows = section.rows.map((row) =>
+    Object.fromEntries(section.columns.map((col, i) => [col, row[i] ?? ""])),
+  );
+  const parser = new Parser({ fields: section.columns });
+  return parser.parse(rows);
+}
+
+// ─── Data access ────────────────────────────────────────────────────────────
+
+interface ComplianceProfileRow {
+  stellar_address: string;
+  kyc_level: number;
+  sanctioned: boolean;
+  is_pep: boolean;
+  updated_at: Date;
+}
+
+interface ComplianceLogRow {
+  sender_address: string;
+  recipient_address: string;
+  amount_stroops: string;
+  asset_code: string;
+  tx_hash: string | null;
+  allowed: boolean;
+  check_name: string;
+  block_reason: string | null;
+  created_at: Date;
+}
+
+async function fetchComplianceProfiles(
+  periodStart: Date,
+  periodEnd: Date,
+): Promise<ComplianceProfileRow[]> {
+  try {
+    return await prisma.$queryRaw<ComplianceProfileRow[]>`
+      SELECT stellar_address, kyc_level, sanctioned, is_pep, updated_at
+      FROM "ComplianceProfile"
+      WHERE updated_at >= ${periodStart} AND updated_at <= ${periodEnd}
+      ORDER BY updated_at DESC
+    `;
+  } catch (err) {
+    logger.error("[ComplianceReport] Failed to fetch ComplianceProfile rows", { err });
+    return [];
+  }
+}
+
+async function fetchComplianceLogs(
+  periodStart: Date,
+  periodEnd: Date,
+  options: { blockedOnly?: boolean; checkNameLike?: string } = {},
+): Promise<ComplianceLogRow[]> {
+  try {
+    if (options.blockedOnly) {
+      return await prisma.$queryRaw<ComplianceLogRow[]>`
+        SELECT sender_address, recipient_address, amount_stroops::text AS amount_stroops,
+               asset_code, tx_hash, allowed, check_name, block_reason, created_at
+        FROM "ComplianceLog"
+        WHERE allowed = false
+          AND created_at >= ${periodStart} AND created_at <= ${periodEnd}
+        ORDER BY created_at DESC
+      `;
+    }
+    if (options.checkNameLike) {
+      return await prisma.$queryRaw<ComplianceLogRow[]>`
+        SELECT sender_address, recipient_address, amount_stroops::text AS amount_stroops,
+               asset_code, tx_hash, allowed, check_name, block_reason, created_at
+        FROM "ComplianceLog"
+        WHERE created_at >= ${periodStart} AND created_at <= ${periodEnd}
+          AND check_name LIKE ${options.checkNameLike}
+        ORDER BY created_at DESC
+      `;
+    }
+    return await prisma.$queryRaw<ComplianceLogRow[]>`
+      SELECT sender_address, recipient_address, amount_stroops::text AS amount_stroops,
+             asset_code, tx_hash, allowed, check_name, block_reason, created_at
+      FROM "ComplianceLog"
+      WHERE created_at >= ${periodStart} AND created_at <= ${periodEnd}
+      ORDER BY created_at DESC
+    `;
+  } catch (err) {
+    logger.error("[ComplianceReport] Failed to fetch ComplianceLog rows", { err });
+    return [];
+  }
+}
+
+async function fetchEventLogRows(periodStart: Date, periodEnd: Date) {
+  try {
+    return await prisma.eventLog.findMany({
+      where: { createdAt: { gte: periodStart, lte: periodEnd } },
+      orderBy: { createdAt: "desc" },
+      take: 5000,
+    });
+  } catch (err) {
+    logger.error("[ComplianceReport] Failed to fetch EventLog rows", { err });
+    return [];
+  }
+}
+
+async function fetchAdminAuditRows(periodStart: Date, periodEnd: Date) {
+  try {
+    return await prisma.adminAuditLog.findMany({
+      where: { timestamp: { gte: periodStart, lte: periodEnd } },
+      orderBy: { timestamp: "desc" },
+      take: 5000,
+      select: {
+        timestamp: true,
+        userId: true,
+        userEmail: true,
+        method: true,
+        path: true,
+        statusCode: true,
+        changesSummary: true,
+      },
+    });
+  } catch (err) {
+    logger.error("[ComplianceReport] Failed to fetch AdminAuditLog rows", { err });
+    return [];
+  }
+}
+
+// ─── Payload builders (one per report type) ────────────────────────────────
+
+function profileSection(rows: ComplianceProfileRow[]): ReportSection {
+  return {
+    heading: "Compliance Profiles Updated in Period",
+    columns: ["Address", "KYC Level", "Sanctioned", "PEP", "Updated At"],
+    rows: rows.map((r) => [
+      r.stellar_address,
+      String(r.kyc_level),
+      r.sanctioned ? "YES" : "NO",
+      r.is_pep ? "YES" : "NO",
+      new Date(r.updated_at).toISOString(),
+    ]),
+  };
+}
+
+function complianceLogSection(heading: string, rows: ComplianceLogRow[]): ReportSection {
+  return {
+    heading,
+    columns: ["Sender", "Recipient", "Amount (stroops)", "Asset", "Allowed", "Checks", "Reason", "Timestamp"],
+    rows: rows.map((r) => [
+      r.sender_address,
+      r.recipient_address,
+      r.amount_stroops,
+      r.asset_code,
+      r.allowed ? "YES" : "NO",
+      r.check_name,
+      r.block_reason ?? "",
+      new Date(r.created_at).toISOString(),
+    ]),
+  };
+}
+
+async function buildAmlKycPayload(periodStart: Date, periodEnd: Date): Promise<ReportPayload> {
+  const [profiles, amlKycLogs] = await Promise.all([
+    fetchComplianceProfiles(periodStart, periodEnd),
+    fetchComplianceLogs(periodStart, periodEnd, { checkNameLike: "%AML%" }),
+  ]);
+
+  const profiles_ = profileSection(profiles);
+  const logs_ = complianceLogSection("AML / KYC Check History", amlKycLogs);
+
+  return {
+    title: "AML / KYC Compliance Report",
+    summary: [
+      ["Period", `${periodStart.toISOString()} — ${periodEnd.toISOString()}`],
+      ["Profiles Updated", String(profiles.length)],
+      ["Sanctioned Addresses", String(profiles.filter((p) => p.sanctioned).length)],
+      ["PEP-Flagged Addresses", String(profiles.filter((p) => p.is_pep).length)],
+      ["AML/KYC Checks Logged", String(amlKycLogs.length)],
+    ],
+    sections: [profiles_, logs_],
+    csvSection: profiles_,
+  };
+}
+
+async function buildTransactionMonitoringPayload(
+  periodStart: Date,
+  periodEnd: Date,
+): Promise<ReportPayload> {
+  const logs = await fetchComplianceLogs(periodStart, periodEnd);
+  const flagged = logs.filter((r) => !r.allowed);
+  const section = complianceLogSection("Screened Transactions", logs);
+
+  return {
+    title: "Transaction Monitoring Report",
+    summary: [
+      ["Period", `${periodStart.toISOString()} — ${periodEnd.toISOString()}`],
+      ["Transactions Screened", String(logs.length)],
+      ["Flagged / Blocked", String(flagged.length)],
+      ["Flag Rate", logs.length > 0 ? `${((flagged.length / logs.length) * 100).toFixed(2)}%` : "0%"],
+    ],
+    sections: [section],
+    csvSection: section,
+  };
+}
+
+async function buildSuspiciousActivityPayload(
+  periodStart: Date,
+  periodEnd: Date,
+): Promise<ReportPayload> {
+  const blocked = await fetchComplianceLogs(periodStart, periodEnd, { blockedOnly: true });
+  const section: ReportSection = {
+    heading: "Suspicious Activity Entries",
+    columns: ["Sender", "Recipient", "Amount (stroops)", "Asset", "TX Hash", "Triggered Checks", "Narrative", "Detected At"],
+    rows: blocked.map((r) => [
+      r.sender_address,
+      r.recipient_address,
+      r.amount_stroops,
+      r.asset_code,
+      r.tx_hash ?? "N/A",
+      r.check_name,
+      r.block_reason ?? "Blocked by automated compliance checks",
+      new Date(r.created_at).toISOString(),
+    ]),
+  };
+
+  return {
+    title: "Suspicious Activity Report (SAR)",
+    summary: [
+      ["Period", `${periodStart.toISOString()} — ${periodEnd.toISOString()}`],
+      ["Suspicious Transactions Identified", String(blocked.length)],
+      ["Filing Basis", "Automated compliance rule engine (sanctions, AML, KYC, PEP, limits)"],
+    ],
+    sections: [section],
+    csvSection: section,
+  };
+}
+
+async function buildAuditTrailPayload(periodStart: Date, periodEnd: Date): Promise<ReportPayload> {
+  const [events, adminOps] = await Promise.all([
+    fetchEventLogRows(periodStart, periodEnd),
+    fetchAdminAuditRows(periodStart, periodEnd),
+  ]);
+
+  const eventSection: ReportSection = {
+    heading: "Protocol Event Log (Hash-Chained)",
+    columns: ["Event Type", "Stream ID", "TX Hash", "Sender", "Receiver", "Amount", "Entry Hash", "Created At"],
+    rows: events.map((e) => [
+      e.eventType,
+      e.streamId,
+      e.txHash,
+      e.sender ?? "",
+      e.receiver ?? "",
+      e.amount?.toString() ?? "",
+      (e.entryHash ?? "").slice(0, 16),
+      e.createdAt.toISOString(),
+    ]),
+  };
+
+  const adminSection: ReportSection = {
+    heading: "Administrative Operations Log",
+    columns: ["Timestamp", "User", "Method", "Path", "Status", "Summary"],
+    rows: adminOps.map((a) => [
+      a.timestamp.toISOString(),
+      a.userEmail ?? a.userId ?? "unknown",
+      a.method,
+      a.path,
+      String(a.statusCode),
+      a.changesSummary ?? "",
+    ]),
+  };
+
+  return {
+    title: "Audit Trail Report",
+    summary: [
+      ["Period", `${periodStart.toISOString()} — ${periodEnd.toISOString()}`],
+      ["Protocol Events", String(events.length)],
+      ["Admin Operations", String(adminOps.length)],
+    ],
+    sections: [eventSection, adminSection],
+    csvSection: eventSection,
+  };
+}
+
+async function buildRegulatoryFilingPayload(
+  periodStart: Date,
+  periodEnd: Date,
+): Promise<ReportPayload> {
+  const [amlKyc, txMonitoring, sar] = await Promise.all([
+    buildAmlKycPayload(periodStart, periodEnd),
+    buildTransactionMonitoringPayload(periodStart, periodEnd),
+    buildSuspiciousActivityPayload(periodStart, periodEnd),
+  ]);
+
+  const summarySection: ReportSection = {
+    heading: "Filing Summary",
+    columns: ["Category", "Metric", "Value"],
+    rows: [
+      ["AML/KYC", "Profiles Updated", amlKyc.summary[1][1]],
+      ["AML/KYC", "Sanctioned Addresses", amlKyc.summary[2][1]],
+      ["AML/KYC", "PEP-Flagged Addresses", amlKyc.summary[3][1]],
+      ["Transaction Monitoring", "Transactions Screened", txMonitoring.summary[1][1]],
+      ["Transaction Monitoring", "Flagged / Blocked", txMonitoring.summary[2][1]],
+      ["Suspicious Activity", "SAR Entries Filed", sar.summary[1][1]],
+    ],
+  };
+
+  return {
+    title: "Regulatory Filing Bundle",
+    summary: [
+      ["Period", `${periodStart.toISOString()} — ${periodEnd.toISOString()}`],
+      ["Sections Included", "AML/KYC, Transaction Monitoring, Suspicious Activity"],
+    ],
+    sections: [summarySection, ...amlKyc.sections, ...txMonitoring.sections, ...sar.sections],
+    csvSection: summarySection,
+  };
+}
+
+async function buildPayload(
+  reportType: ComplianceReportType,
+  periodStart: Date,
+  periodEnd: Date,
+): Promise<ReportPayload> {
+  switch (reportType) {
+    case "AML_KYC":
+      return buildAmlKycPayload(periodStart, periodEnd);
+    case "TRANSACTION_MONITORING":
+      return buildTransactionMonitoringPayload(periodStart, periodEnd);
+    case "SUSPICIOUS_ACTIVITY":
+      return buildSuspiciousActivityPayload(periodStart, periodEnd);
+    case "AUDIT_TRAIL":
+      return buildAuditTrailPayload(periodStart, periodEnd);
+    case "REGULATORY_FILING":
+      return buildRegulatoryFilingPayload(periodStart, periodEnd);
+  }
+}
+
+function recordCountOf(payload: ReportPayload): number {
+  return payload.sections.reduce((sum, s) => sum + s.rows.length, 0);
+}
+
+// ─── ComplianceReportService ────────────────────────────────────────────────
+
+export class ComplianceReportService {
+  /**
+   * Generate a report, persist it to secure storage, and log its metadata.
+   * Never returns the raw file — callers must fetch it via getReportFile()
+   * so every access to report content goes through the same audit path.
+   */
+  async generateReport(options: GenerateReportOptions): Promise<ComplianceReportRecord> {
+    const { reportType, format, periodStart, periodEnd, generatedBy } = options;
+
+    const payload = await buildPayload(reportType, periodStart, periodEnd);
+    const recordCount = recordCountOf(payload);
+
+    const buffer =
+      format === "pdf"
+        ? await renderPDF(payload)
+        : Buffer.from(renderCSV(payload.csvSection), "utf-8");
+
+    ensureReportsDir();
+    const id = crypto.randomUUID();
+    const ext = format === "pdf" ? "pdf" : "csv";
+    const filename = `${reportType.toLowerCase()}-${id}.${ext}`;
+    const filePath = path.join(REPORTS_DIR, filename);
+    fs.writeFileSync(filePath, buffer, { mode: 0o600 });
+
+    const checksum = sha256(buffer);
+
+    try {
+      await prisma.$executeRaw`
+        INSERT INTO "ComplianceReport" (
+          id, report_type, format, period_start, period_end,
+          record_count, file_path, checksum_sha256, generated_by, metadata, created_at
+        ) VALUES (
+          ${id}::uuid, ${reportType}, ${format}, ${periodStart}, ${periodEnd},
+          ${recordCount}, ${filePath}, ${checksum}, ${generatedBy},
+          ${JSON.stringify({ title: payload.title })}::jsonb, NOW()
+        )
+      `;
+    } catch (err) {
+      // Roll back the file so we never have an orphaned, unlogged report on disk.
+      fs.rmSync(filePath, { force: true });
+      logger.error("[ComplianceReport] Failed to persist report metadata", { err, reportType });
+      throw err;
+    }
+
+    logger.info("[ComplianceReport] Report generated", {
+      id,
+      reportType,
+      format,
+      recordCount,
+      generatedBy,
+    });
+
+    return {
+      id,
+      reportType,
+      format,
+      periodStart: periodStart.toISOString(),
+      periodEnd: periodEnd.toISOString(),
+      recordCount,
+      checksumSha256: checksum,
+      generatedBy,
+      createdAt: new Date().toISOString(),
+    };
+  }
+
+  async listReports(filters: ComplianceReportListFilters = {}): Promise<unknown[]> {
+    const { reportType, startDate, endDate, limit = 50, offset = 0 } = filters;
+
+    return prisma.$queryRaw`
+      SELECT id, report_type, format, period_start, period_end,
+             record_count, checksum_sha256, generated_by, created_at
+      FROM "ComplianceReport"
+      WHERE (${reportType ?? null}::text IS NULL OR report_type = ${reportType ?? null})
+        AND (${startDate ?? null}::timestamptz IS NULL OR created_at >= ${startDate ?? null})
+        AND (${endDate ?? null}::timestamptz IS NULL OR created_at <= ${endDate ?? null})
+      ORDER BY created_at DESC
+      LIMIT ${limit} OFFSET ${offset}
+    `;
+  }
+
+  async getReportMetadata(id: string): Promise<Record<string, unknown> | null> {
+    const rows = await prisma.$queryRaw<Record<string, unknown>[]>`
+      SELECT id, report_type, format, period_start, period_end,
+             record_count, file_path, checksum_sha256, generated_by, created_at
+      FROM "ComplianceReport"
+      WHERE id = ${id}::uuid
+      LIMIT 1
+    `;
+    return rows[0] ?? null;
+  }
+
+  /**
+   * Read a previously generated report's file, re-verifying its checksum
+   * against the value logged at generation time. Refuses to serve a file
+   * whose contents no longer match — the storage-integrity guarantee that
+   * makes this "secure storage" rather than just a filesystem write.
+   */
+  async getReportFile(id: string): Promise<StoredReportFile | null> {
+    const meta = await this.getReportMetadata(id);
+    if (!meta) return null;
+
+    const filePath = meta.file_path as string;
+    if (!fs.existsSync(filePath)) {
+      logger.error("[ComplianceReport] Report file missing from storage", { id, filePath });
+      return null;
+    }
+
+    const buffer = fs.readFileSync(filePath);
+    const checksum = sha256(buffer);
+    if (checksum !== meta.checksum_sha256) {
+      logger.error("[ComplianceReport] Checksum mismatch — refusing to serve report", { id });
+      throw new Error("Report integrity check failed");
+    }
+
+    const reportType = String(meta.report_type).toLowerCase();
+    const format = meta.format as string;
+    const contentType = format === "pdf" ? "application/pdf" : "text/csv";
+
+    return {
+      buffer,
+      filename: `${reportType}-${id}.${format}`,
+      contentType,
+    };
+  }
+}
+
+export const complianceReportService = new ComplianceReportService();
+export const SUPPORTED_REPORT_TYPES = REPORT_TYPES;


### PR DESCRIPTION
## 📋 Issue Reference
Closes #1359

## 🎯 Summary
Adds automated generation of regulatory compliance reports — AML/KYC, transaction monitoring, suspicious activity (SAR), regulatory filing bundles, and audit trails — built on top of the existing compliance-screening data (`ComplianceLog`, `ComplianceProfile`) and protocol/admin audit logs (`EventLog`, `AdminAuditLog`).

## ✅ Requirements Met
- [x] **AML/KYC reports** — compliance-profile state (KYC level, sanctions, PEP flags) plus AML/KYC check history for a period
- [x] **Transaction monitoring** — every compliance-screened payment in a period, with flag/block rate
- [x] **Suspicious activity reports** — blocked payments formatted as SAR-style entries with a narrative
- [x] **Regulatory filings** — a single filing-ready bundle summarizing all of the above
- [x] **Audit trails** — the hash-chained protocol event log + admin operations log for a period
- [x] **Reports meet regulatory standards** — consistent structure, period-scoped, narrative + tabular detail, SHA-256 checksummed for integrity
- [x] **Automated generation** — monthly scheduler (1st of month, 04:00 UTC) auto-generates the regulatory filing + audit trail for the prior period; also generatable on demand
- [x] **Secure storage** — files are written to a non-web-served directory with `0700`/`0600` permissions, admin-auth-gated access, and checksum re-verification on every download (refuses to serve a tampered file)

## 🚀 Features Implemented

### Core Functionality
- **`ComplianceReportService`** (`backend/src/services/compliance-report.service.ts`) — builds each report type from existing compliance/audit data, renders PDF (pdfkit, matches existing branded report style) or CSV (json2csv), writes to secure storage, computes a SHA-256 checksum, and logs generation metadata
- **`ComplianceReport` table** (new migration, raw-SQL — matches the existing `ComplianceLog`/`ComplianceProfile` convention) — an accountability record of every report ever generated: type, format, period, checksum, who/what generated it
- **Admin-gated REST API** (`backend/src/api/compliance-reports.routes.ts`), mounted at `/api/v1/compliance/reports`:
  - `POST /generate` — generate a report for a period (returns metadata only, never the raw file)
  - `GET /` — list previously generated reports
  - `GET /:id` — report metadata
  - `GET /:id/download` — stream the file after re-verifying its checksum
- **Monthly scheduler** (`backend/src/schedulers.ts`) — automated regulatory-filing + audit-trail generation, wired into `initializeSchedulers()`

### Security / Integrity
- Reports are stored outside any statically-served directory, with restrictive filesystem permissions (`0700` dir / `0600` file)
- Every generated report is checksummed at write time; the download endpoint refuses to serve a file whose current content no longer matches the logged checksum (tamper detection)
- `file_path` is never exposed in API responses — only report IDs, downloaded through the audited endpoint
- All endpoints require admin auth (`requireAdmin`), since these reports carry KYC levels, sanctions/PEP flags, and full counterparty transaction detail

## 🧪 Testing
- `backend/src/__tests__/compliance-report.test.ts` — 14 tests, DB calls mocked, filesystem I/O real (against the gitignored `storage/compliance-reports` scratch dir) so the checksum/tamper-detection logic is exercised end-to-end rather than simulated
- Covers: PDF generation for all 5 report types, CSV rendering, secure file permissions, metadata persistence, rollback of the on-disk file when the DB write fails, listing/metadata lookup, and the three `getReportFile` integrity paths (missing metadata, missing file, checksum mismatch, valid match)
- All 14 pass under `npm test` (vitest)

## 📁 Files Changed
- `backend/src/services/compliance-report.service.ts` (new)
- `backend/src/api/compliance-reports.routes.ts` (new)
- `backend/src/__tests__/compliance-report.test.ts` (new)
- `backend/prisma/migrations/add_compliance_reports.sql` (new)
- `backend/src/api/index.ts` — mount the new router
- `backend/src/schedulers.ts` — register the monthly scheduler
- `backend/.gitignore` — exclude the local report storage directory

## 🔧 Technical Notes
- Followed existing conventions closely: `ComplianceLog`/`ComplianceProfile` are raw-SQL tables (not in `schema.prisma`), so the new `ComplianceReport` table follows the same pattern for consistency with `compliance.service.ts`
- PDF styling reuses the brand tokens/layout approach from `split-audit-export.service.ts` / `invoice-pdf.service.ts`
- Scope is backend-only; no frontend UI is included in this PR

## ✔️ Verified Locally
- `npm run type-check` — no new errors introduced (pre-existing unrelated errors elsewhere in the codebase are untouched)
- `npx eslint` on all new/changed files — clean
- `npm test` — new test file passes 14/14

## 📝 Checklist
- [x] Code follows project style guidelines
- [x] Self-review of the code completed
- [x] Changes are fully tested
- [x] TypeScript types are properly defined
- [x] No breaking changes introduced
- [x] Admin-only access enforced on all new endpoints

**Labels**: [Feature] [Compliance] [Reporting]