### PR TITLE
feat(templates): add payment memo template library

### DIFF
--- a/frontend/app/dashboard/templates/page.tsx
+++ b/frontend/app/dashboard/templates/page.tsx
@@ -1,10 +1,13 @@
 "use client";
 import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { LayoutTemplate, Plus, Copy, Trash2, ArrowRight, X, CheckCircle2, Loader2 } from "lucide-react";
+import { LayoutTemplate, FileText, Plus, Copy, Trash2, ArrowRight, X, CheckCircle2, Loader2 } from "lucide-react";
 import { useTemplateLibrary, type StreamTemplate } from "@/lib/use-template-library";
 import { useWallet } from "@/lib/wallet-context";
 import { useRouter } from "next/navigation";
+import { MemoTemplateLibrary } from "@/components/MemoTemplateLibrary";
+
+type TemplateTab = "stream" | "memo";
 
 const ASSETS = ["USDC","USDT","DAI","ETH","WBTC"];
 const DURATIONS = ["1 Hour","1 Day","1 Week","1 Month","3 Months","1 Year"];
@@ -63,6 +66,7 @@ export default function TemplatesPage() {
   const { address: walletAddress } = useWallet();
   const { templates, loading, saveTemplate, deleteTemplate, duplicateTemplate } = useTemplateLibrary(walletAddress ?? undefined);
   const router = useRouter();
+  const [activeTab, setActiveTab] = useState<TemplateTab>("stream");
   const [showForm, setShowForm] = useState(false);
   const [form, setForm] = useState({ name:"", asset:"USDC", recipientAddress:"", splitEnabled:false, splitAddress:"", splitPercent:10, totalAmount:"", rateType:"per-hour" as typeof RATE_TYPES[number], durationPreset:"1 Month" });
 
@@ -87,15 +91,45 @@ export default function TemplatesPage() {
           </div>
           <div>
             <h1 className="font-heading text-2xl font-bold text-white">Template Library</h1>
-            <p className="font-body mt-1 text-sm text-white/50">Save and reuse split configurations for payroll or vendor payments.</p>
+            <p className="font-body mt-1 text-sm text-white/50">
+              {activeTab === "stream"
+                ? "Save and reuse split configurations for payroll or vendor payments."
+                : "Reusable payment memo text with variable placeholders."}
+            </p>
           </div>
         </div>
-        <button onClick={() => setShowForm((v) => !v)}
-          className="flex items-center gap-2 rounded-xl border border-[#8a00ff]/30 bg-[#8a00ff]/10 px-4 py-2.5 text-sm font-semibold text-[#c084fc] transition hover:bg-[#8a00ff]/20">
-          {showForm ? <><X className="h-4 w-4" /> Cancel</> : <><Plus className="h-4 w-4" /> Add Template</>}
-        </button>
+        {activeTab === "stream" && (
+          <button onClick={() => setShowForm((v) => !v)}
+            className="flex items-center gap-2 rounded-xl border border-[#8a00ff]/30 bg-[#8a00ff]/10 px-4 py-2.5 text-sm font-semibold text-[#c084fc] transition hover:bg-[#8a00ff]/20">
+            {showForm ? <><X className="h-4 w-4" /> Cancel</> : <><Plus className="h-4 w-4" /> Add Template</>}
+          </button>
+        )}
       </div>
 
+      {/* Tab switcher */}
+      <div className="flex gap-1.5 border-b border-white/10 pb-px">
+        {([
+          ["stream", "Stream Templates", LayoutTemplate],
+          ["memo", "Memo Templates", FileText],
+        ] as const).map(([tab, label, Icon]) => (
+          <button
+            key={tab}
+            onClick={() => setActiveTab(tab)}
+            className={`flex items-center gap-1.5 border-b-2 px-4 py-2.5 text-sm font-semibold transition ${
+              activeTab === tab
+                ? "border-[#8a00ff] text-white"
+                : "border-transparent text-white/40 hover:text-white/70"
+            }`}
+          >
+            <Icon className="h-4 w-4" /> {label}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === "memo" ? (
+        <MemoTemplateLibrary />
+      ) : (
+      <>
       {/* Inline add form */}
       <AnimatePresence>
         {showForm && (
@@ -168,6 +202,8 @@ export default function TemplatesPage() {
           </AnimatePresence>
         </div>
       ) : null}
+      </>
+      )}
     </div>
   );
 }

--- a/frontend/components/MemoTemplateLibrary.tsx
+++ b/frontend/components/MemoTemplateLibrary.tsx
@@ -1,0 +1,468 @@
+"use client";
+// frontend/components/MemoTemplateLibrary.tsx
+// Issue #1366 — Payment Memo Templates
+//
+// Browse/create/edit/delete memo templates, fill in variables, and
+// copy the substituted memo text. Import/export for portability.
+
+import { useMemo, useRef, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import {
+  FileText,
+  Plus,
+  Copy,
+  Trash2,
+  Pencil,
+  X,
+  CheckCircle2,
+  Download,
+  Upload,
+} from "lucide-react";
+import { useMemoTemplates, type CreateMemoTemplateInput } from "@/lib/use-memo-templates";
+import {
+  MEMO_TEMPLATE_CATEGORIES,
+  MEMO_VARIABLES,
+  extractVariables,
+  substituteVariables,
+  type MemoTemplate,
+  type MemoTemplateCategory,
+} from "@/lib/memo-templates";
+
+const EMPTY_FORM: CreateMemoTemplateInput = {
+  name: "",
+  category: "General",
+  body: "",
+};
+
+function VariableChips({ body }: { body: string }) {
+  const vars = extractVariables(body);
+  if (vars.length === 0) return null;
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {vars.map((v) => (
+        <span
+          key={v}
+          className="rounded-full border border-[#00f5ff]/20 bg-[#00f5ff]/10 px-2 py-0.5 font-ticker text-[10px] text-[#00f5ff]"
+        >
+          {`{{${v}}}`}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function UsePanel({
+  template,
+  onClose,
+  onUse,
+}: {
+  template: MemoTemplate;
+  onClose: () => void;
+  onUse: (id: string) => void;
+}) {
+  const variables = useMemo(() => extractVariables(template.body), [template.body]);
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [copied, setCopied] = useState(false);
+
+  const preview = substituteVariables(template.body, values);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(preview);
+      onUse(template.id);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard API unavailable (e.g. insecure context) — no-op.
+    }
+  };
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, height: 0 }}
+      animate={{ opacity: 1, height: "auto" }}
+      exit={{ opacity: 0, height: 0 }}
+      className="mt-3 overflow-hidden rounded-xl border border-white/10 bg-white/[0.03] p-3"
+    >
+      {variables.length > 0 && (
+        <div className="mb-3 grid gap-2 sm:grid-cols-2">
+          {variables.map((key) => {
+            const meta = MEMO_VARIABLES.find((v) => v.key === key);
+            return (
+              <div key={key}>
+                <p className="font-body text-[10px] uppercase tracking-wider text-white/30 mb-1">
+                  {meta?.label ?? key}
+                </p>
+                <input
+                  type="text"
+                  value={values[key] ?? ""}
+                  onChange={(e) => setValues((p) => ({ ...p, [key]: e.target.value }))}
+                  placeholder={meta?.example ?? key}
+                  className="w-full rounded-lg border border-white/10 bg-white/5 px-2.5 py-1.5 font-body text-xs text-white placeholder-white/25 outline-none focus:border-cyan-400/50"
+                />
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <p className="font-body text-[10px] uppercase tracking-wider text-white/30 mb-1">Preview</p>
+      <p className="rounded-lg border border-white/10 bg-black/20 px-3 py-2 font-ticker text-xs text-white/80 break-words">
+        {preview || <span className="text-white/30">Empty template</span>}
+      </p>
+
+      <div className="mt-3 flex gap-2">
+        <button
+          onClick={handleCopy}
+          className="flex items-center gap-1.5 rounded-lg bg-cyan-400 px-3 py-1.5 text-[11px] font-bold text-black transition hover:bg-cyan-300"
+        >
+          <Copy className="h-3 w-3" /> {copied ? "Copied ✓" : "Copy Memo"}
+        </button>
+        <button
+          onClick={onClose}
+          className="rounded-lg border border-white/10 px-3 py-1.5 text-[11px] text-white/50 transition hover:bg-white/5"
+        >
+          Close
+        </button>
+      </div>
+    </motion.div>
+  );
+}
+
+function MemoTemplateCard({
+  template,
+  onDuplicate,
+  onDelete,
+  onEdit,
+  onUse,
+}: {
+  template: MemoTemplate;
+  onDuplicate: () => void;
+  onDelete: () => void;
+  onEdit: () => void;
+  onUse: (id: string) => void;
+}) {
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [using, setUsing] = useState(false);
+
+  return (
+    <motion.div
+      layout
+      initial={{ opacity: 0, scale: 0.96 }}
+      animate={{ opacity: 1, scale: 1 }}
+      exit={{ opacity: 0, scale: 0.94 }}
+      className="glass-card p-5 flex flex-col gap-3"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <p className="font-heading text-base font-semibold text-white">{template.name}</p>
+          <p className="font-body text-xs text-white/40 mt-0.5">
+            {template.category} · Used {template.usageCount}×
+          </p>
+        </div>
+        {template.isDefault && (
+          <span className="rounded-full border border-white/10 bg-white/5 px-2.5 py-0.5 font-ticker text-[10px] text-white/40">
+            Built-in
+          </span>
+        )}
+      </div>
+
+      <p className="rounded-lg border border-white/8 bg-white/[0.03] px-3 py-2 font-ticker text-xs text-white/60 break-words">
+        {template.body}
+      </p>
+
+      <VariableChips body={template.body} />
+
+      <div className="flex gap-2 mt-auto">
+        <button
+          onClick={() => setUsing((v) => !v)}
+          className="flex flex-1 items-center justify-center gap-1.5 rounded-xl border border-[#00f5ff]/25 bg-[#00f5ff]/10 py-2 text-xs font-semibold text-[#00f5ff] transition hover:bg-[#00f5ff]/20"
+        >
+          <FileText className="h-3.5 w-3.5" /> Use
+        </button>
+        {!template.isDefault && (
+          <button
+            onClick={onEdit}
+            className="flex items-center justify-center gap-1.5 rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-xs text-white/50 transition hover:text-white hover:bg-white/10"
+          >
+            <Pencil className="h-3.5 w-3.5" />
+          </button>
+        )}
+        <button
+          onClick={onDuplicate}
+          className="flex items-center justify-center gap-1.5 rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-xs text-white/50 transition hover:text-white hover:bg-white/10"
+        >
+          <Copy className="h-3.5 w-3.5" />
+        </button>
+        {!template.isDefault && (
+          <button
+            onClick={() => {
+              if (confirmDelete) {
+                onDelete();
+              } else {
+                setConfirmDelete(true);
+                setTimeout(() => setConfirmDelete(false), 3000);
+              }
+            }}
+            className={`flex items-center justify-center gap-1.5 rounded-xl border px-3 py-2 text-xs transition ${
+              confirmDelete
+                ? "border-red-500/40 bg-red-500/15 text-red-400"
+                : "border-white/10 bg-white/5 text-white/50 hover:text-red-400 hover:border-red-500/30"
+            }`}
+          >
+            {confirmDelete ? (
+              <>
+                <Trash2 className="h-3.5 w-3.5" /> Confirm
+              </>
+            ) : (
+              <Trash2 className="h-3.5 w-3.5" />
+            )}
+          </button>
+        )}
+      </div>
+
+      <AnimatePresence>
+        {using && (
+          <UsePanel template={template} onClose={() => setUsing(false)} onUse={onUse} />
+        )}
+      </AnimatePresence>
+    </motion.div>
+  );
+}
+
+export function MemoTemplateLibrary() {
+  const {
+    templates,
+    createTemplate,
+    updateTemplate,
+    deleteTemplate,
+    duplicateTemplate,
+    recordUsage,
+    exportTemplates,
+    importTemplates,
+  } = useMemoTemplates();
+
+  const [activeCategory, setActiveCategory] = useState<MemoTemplateCategory | "All">("All");
+  const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [form, setForm] = useState<CreateMemoTemplateInput>(EMPTY_FORM);
+  const [importMessage, setImportMessage] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const visible = useMemo(
+    () => (activeCategory === "All" ? templates : templates.filter((t) => t.category === activeCategory)),
+    [templates, activeCategory],
+  );
+
+  const startCreate = () => {
+    setEditingId(null);
+    setForm(EMPTY_FORM);
+    setShowForm(true);
+  };
+
+  const startEdit = (t: MemoTemplate) => {
+    setEditingId(t.id);
+    setForm({ name: t.name, category: t.category, body: t.body });
+    setShowForm(true);
+  };
+
+  const handleSave = () => {
+    if (!form.name.trim() || !form.body.trim()) return;
+    if (editingId) {
+      updateTemplate(editingId, form);
+    } else {
+      createTemplate(form);
+    }
+    setShowForm(false);
+    setForm(EMPTY_FORM);
+    setEditingId(null);
+  };
+
+  const handleExport = () => {
+    const blob = new Blob([exportTemplates()], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "memo-templates.json";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleImportFile = async (file: File) => {
+    const text = await file.text();
+    const result = importTemplates(text);
+    if (result.error) {
+      setImportMessage(result.error);
+    } else {
+      setImportMessage(`Imported ${result.imported} template${result.imported === 1 ? "" : "s"}.`);
+    }
+    setTimeout(() => setImportMessage(null), 4000);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap gap-1.5">
+          <button
+            onClick={() => setActiveCategory("All")}
+            className={`rounded-lg border px-2.5 py-1 text-xs font-semibold transition ${
+              activeCategory === "All"
+                ? "border-[#00f5ff]/40 bg-[#00f5ff]/10 text-[#00f5ff]"
+                : "border-white/10 bg-white/5 text-white/40 hover:text-white"
+            }`}
+          >
+            All
+          </button>
+          {MEMO_TEMPLATE_CATEGORIES.map((c) => (
+            <button
+              key={c}
+              onClick={() => setActiveCategory(c)}
+              className={`rounded-lg border px-2.5 py-1 text-xs font-semibold transition ${
+                activeCategory === c
+                  ? "border-[#00f5ff]/40 bg-[#00f5ff]/10 text-[#00f5ff]"
+                  : "border-white/10 bg-white/5 text-white/40 hover:text-white"
+              }`}
+            >
+              {c}
+            </button>
+          ))}
+        </div>
+
+        <div className="flex gap-2">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="application/json"
+            className="hidden"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) handleImportFile(file);
+              e.target.value = "";
+            }}
+          />
+          <button
+            onClick={() => fileInputRef.current?.click()}
+            className="flex items-center gap-1.5 rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-xs text-white/60 transition hover:bg-white/10"
+          >
+            <Upload className="h-3.5 w-3.5" /> Import
+          </button>
+          <button
+            onClick={handleExport}
+            className="flex items-center gap-1.5 rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-xs text-white/60 transition hover:bg-white/10"
+          >
+            <Download className="h-3.5 w-3.5" /> Export
+          </button>
+          <button
+            onClick={() => (showForm ? setShowForm(false) : startCreate())}
+            className="flex items-center gap-2 rounded-xl border border-[#8a00ff]/30 bg-[#8a00ff]/10 px-4 py-2 text-xs font-semibold text-[#c084fc] transition hover:bg-[#8a00ff]/20"
+          >
+            {showForm ? (
+              <>
+                <X className="h-3.5 w-3.5" /> Cancel
+              </>
+            ) : (
+              <>
+                <Plus className="h-3.5 w-3.5" /> New Template
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+
+      {importMessage && (
+        <p className="font-body text-xs text-white/50">{importMessage}</p>
+      )}
+
+      <AnimatePresence>
+        {showForm && (
+          <motion.div
+            initial={{ opacity: 0, y: -8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -8 }}
+            className="glass-card p-5 space-y-4"
+          >
+            <p className="font-body text-xs font-medium uppercase tracking-widest text-white/30">
+              {editingId ? "Edit Template" : "New Template"}
+            </p>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div>
+                <p className="font-body text-[10px] uppercase tracking-wider text-white/30 mb-1">
+                  Template Name
+                </p>
+                <input
+                  type="text"
+                  value={form.name}
+                  onChange={(e) => setForm((p) => ({ ...p, name: e.target.value }))}
+                  placeholder="e.g. Freelancer Invoice"
+                  className="w-full rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2 font-body text-sm text-white outline-none focus:border-[#8a00ff]/40 placeholder:text-white/20"
+                />
+              </div>
+              <div>
+                <p className="font-body text-[10px] uppercase tracking-wider text-white/30 mb-1">
+                  Category
+                </p>
+                <select
+                  value={form.category}
+                  onChange={(e) =>
+                    setForm((p) => ({ ...p, category: e.target.value as MemoTemplateCategory }))
+                  }
+                  className="w-full rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2 font-body text-sm text-white outline-none focus:border-[#8a00ff]/40"
+                >
+                  {MEMO_TEMPLATE_CATEGORIES.map((c) => (
+                    <option key={c} value={c} className="bg-[#0a0a1a]">
+                      {c}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <div>
+              <p className="font-body text-[10px] uppercase tracking-wider text-white/30 mb-1">
+                Memo Text — use {"{{variableName}}"} for placeholders
+              </p>
+              <textarea
+                value={form.body}
+                onChange={(e) => setForm((p) => ({ ...p, body: e.target.value }))}
+                placeholder="Invoice {{invoiceNumber}} - {{amount}} {{asset}}"
+                rows={2}
+                className="w-full rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2 font-body text-sm text-white outline-none focus:border-[#8a00ff]/40 placeholder:text-white/20"
+              />
+              <div className="mt-2">
+                <VariableChips body={form.body} />
+              </div>
+            </div>
+            <button
+              onClick={handleSave}
+              disabled={!form.name.trim() || !form.body.trim()}
+              className="flex items-center gap-2 rounded-xl bg-[#8a00ff] px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-[#7000dd] disabled:opacity-40"
+            >
+              <CheckCircle2 className="h-4 w-4" /> {editingId ? "Save Changes" : "Save Template"}
+            </button>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {visible.length === 0 ? (
+        <div className="glass-card flex flex-col items-center gap-3 py-16 text-center">
+          <FileText className="h-10 w-10 text-white/15" />
+          <p className="font-body text-white/40">No templates in this category yet.</p>
+        </div>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <AnimatePresence mode="popLayout">
+            {visible.map((t) => (
+              <MemoTemplateCard
+                key={t.id}
+                template={t}
+                onDuplicate={() => duplicateTemplate(t.id)}
+                onDelete={() => deleteTemplate(t.id)}
+                onEdit={() => startEdit(t)}
+                onUse={recordUsage}
+              />
+            ))}
+          </AnimatePresence>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/lib/memo-templates.test.ts
+++ b/frontend/lib/memo-templates.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_MEMO_TEMPLATES,
+  MEMO_TEMPLATE_CATEGORIES,
+  extractVariables,
+  substituteVariables,
+  isFullySubstituted,
+} from "@/lib/memo-templates";
+
+describe("memo-templates", () => {
+  describe("default template library", () => {
+    it("ships at least 10 default templates", () => {
+      expect(DEFAULT_MEMO_TEMPLATES.length).toBeGreaterThanOrEqual(10);
+    });
+
+    it("marks every default template as isDefault", () => {
+      expect(DEFAULT_MEMO_TEMPLATES.every((t) => t.isDefault)).toBe(true);
+    });
+
+    it("gives every default template a unique id", () => {
+      const ids = DEFAULT_MEMO_TEMPLATES.map((t) => t.id);
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it("only uses categories from MEMO_TEMPLATE_CATEGORIES", () => {
+      for (const t of DEFAULT_MEMO_TEMPLATES) {
+        expect(MEMO_TEMPLATE_CATEGORIES).toContain(t.category);
+      }
+    });
+
+    it("gives every default template at least one variable placeholder", () => {
+      for (const t of DEFAULT_MEMO_TEMPLATES) {
+        expect(extractVariables(t.body).length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe("extractVariables", () => {
+    it("extracts a single placeholder", () => {
+      expect(extractVariables("Invoice {{invoiceNumber}}")).toEqual(["invoiceNumber"]);
+    });
+
+    it("extracts multiple distinct placeholders in order", () => {
+      expect(extractVariables("{{a}} then {{b}} then {{a}}")).toEqual(["a", "b"]);
+    });
+
+    it("returns an empty array when there are no placeholders", () => {
+      expect(extractVariables("Plain memo text")).toEqual([]);
+    });
+
+    it("tolerates whitespace inside braces", () => {
+      expect(extractVariables("{{ amount }}")).toEqual(["amount"]);
+    });
+  });
+
+  describe("substituteVariables", () => {
+    it("replaces a single known variable", () => {
+      expect(substituteVariables("Invoice {{invoiceNumber}}", { invoiceNumber: "INV-1" })).toBe(
+        "Invoice INV-1",
+      );
+    });
+
+    it("replaces multiple variables", () => {
+      const result = substituteVariables("{{amount}} {{asset}}", { amount: "500", asset: "USDC" });
+      expect(result).toBe("500 USDC");
+    });
+
+    it("trims whitespace from provided values", () => {
+      expect(substituteVariables("{{name}}", { name: "  Jane  " })).toBe("Jane");
+    });
+
+    it("leaves a placeholder untouched when no value is provided", () => {
+      expect(substituteVariables("Invoice {{invoiceNumber}}", {})).toBe("Invoice {{invoiceNumber}}");
+    });
+
+    it("leaves a placeholder untouched when the provided value is blank", () => {
+      expect(substituteVariables("{{name}}", { name: "   " })).toBe("{{name}}");
+    });
+
+    it("is a no-op on text with no placeholders", () => {
+      expect(substituteVariables("Plain memo", { unused: "x" })).toBe("Plain memo");
+    });
+  });
+
+  describe("isFullySubstituted", () => {
+    it("is true when no placeholders remain", () => {
+      expect(isFullySubstituted("Invoice INV-1")).toBe(true);
+    });
+
+    it("is false when a placeholder remains", () => {
+      expect(isFullySubstituted("Invoice {{invoiceNumber}}")).toBe(false);
+    });
+
+    it("gives consistent answers across repeated calls (no shared regex state)", () => {
+      // Regression check: a naive implementation using a shared global
+      // RegExp's .test() would give different answers on repeated calls
+      // because .test() mutates the regex's lastIndex.
+      const withPlaceholder = "{{a}}";
+      const without = "plain text";
+      expect(isFullySubstituted(withPlaceholder)).toBe(false);
+      expect(isFullySubstituted(without)).toBe(true);
+      expect(isFullySubstituted(withPlaceholder)).toBe(false);
+      expect(isFullySubstituted(without)).toBe(true);
+    });
+  });
+});

--- a/frontend/lib/memo-templates.ts
+++ b/frontend/lib/memo-templates.ts
@@ -1,0 +1,206 @@
+// frontend/lib/memo-templates.ts
+// Issue #1366 — Payment Memo Templates
+//
+// Domain types, default template library, and variable-substitution logic
+// for reusable payment memo text (e.g. Stellar transaction memos, which are
+// capped at 28-32 bytes — see StreamMemoInput.tsx).
+
+export type MemoTemplateCategory =
+  | "Invoice"
+  | "Payroll"
+  | "Vendor Payment"
+  | "Milestone"
+  | "Subscription"
+  | "Reimbursement"
+  | "Grant"
+  | "Bonus"
+  | "Refund"
+  | "Donation"
+  | "General";
+
+export const MEMO_TEMPLATE_CATEGORIES: MemoTemplateCategory[] = [
+  "Invoice",
+  "Payroll",
+  "Vendor Payment",
+  "Milestone",
+  "Subscription",
+  "Reimbursement",
+  "Grant",
+  "Bonus",
+  "Refund",
+  "Donation",
+  "General",
+];
+
+export interface MemoTemplate {
+  id: string;
+  name: string;
+  category: MemoTemplateCategory;
+  /** Template text containing `{{variableName}}` placeholders. */
+  body: string;
+  /** Built-in templates ship read-only; users duplicate them to customize. */
+  isDefault: boolean;
+  usageCount: number;
+  createdAt: string;
+}
+
+/** A variable reference known to the picker UI, e.g. `{{invoiceNumber}}`. */
+export interface MemoVariable {
+  key: string;
+  label: string;
+  example: string;
+}
+
+export const MEMO_VARIABLES: MemoVariable[] = [
+  { key: "invoiceNumber", label: "Invoice Number", example: "INV-2026-045" },
+  { key: "recipientName", label: "Recipient Name", example: "Jane Doe" },
+  { key: "senderName", label: "Sender Name", example: "Acme Inc" },
+  { key: "amount", label: "Amount", example: "500" },
+  { key: "asset", label: "Asset", example: "USDC" },
+  { key: "date", label: "Date", example: "2026-07-24" },
+  { key: "period", label: "Period", example: "July 2026" },
+  { key: "milestoneName", label: "Milestone Name", example: "Q3 Launch" },
+  { key: "referenceId", label: "Reference ID", example: "REF-8842" },
+];
+
+// ─── Default template library (≥ 10, per acceptance criteria) ───────────────
+
+export const DEFAULT_MEMO_TEMPLATES: MemoTemplate[] = [
+  {
+    id: "default-invoice-payment",
+    name: "Invoice Payment",
+    category: "Invoice",
+    body: "Invoice {{invoiceNumber}} - {{amount}} {{asset}}",
+    isDefault: true,
+    usageCount: 0,
+    createdAt: "2026-01-01T00:00:00.000Z",
+  },
+  {
+    id: "default-payroll",
+    name: "Payroll Run",
+    category: "Payroll",
+    body: "Payroll {{period}} - {{recipientName}}",
+    isDefault: true,
+    usageCount: 0,
+    createdAt: "2026-01-01T00:00:00.000Z",
+  },
+  {
+    id: "default-vendor-payment",
+    name: "Vendor Payment",
+    category: "Vendor Payment",
+    body: "Vendor payment {{referenceId}}",
+    isDefault: true,
+    usageCount: 0,
+    createdAt: "2026-01-01T00:00:00.000Z",
+  },
+  {
+    id: "default-milestone",
+    name: "Milestone Payment",
+    category: "Milestone",
+    body: "Milestone: {{milestoneName}}",
+    isDefault: true,
+    usageCount: 0,
+    createdAt: "2026-01-01T00:00:00.000Z",
+  },
+  {
+    id: "default-subscription-renewal",
+    name: "Subscription Renewal",
+    category: "Subscription",
+    body: "Subscription renewal {{period}}",
+    isDefault: true,
+    usageCount: 0,
+    createdAt: "2026-01-01T00:00:00.000Z",
+  },
+  {
+    id: "default-reimbursement",
+    name: "Expense Reimbursement",
+    category: "Reimbursement",
+    body: "Reimbursement {{referenceId}}",
+    isDefault: true,
+    usageCount: 0,
+    createdAt: "2026-01-01T00:00:00.000Z",
+  },
+  {
+    id: "default-grant",
+    name: "Grant Disbursement",
+    category: "Grant",
+    body: "Grant disbursement {{date}}",
+    isDefault: true,
+    usageCount: 0,
+    createdAt: "2026-01-01T00:00:00.000Z",
+  },
+  {
+    id: "default-bonus",
+    name: "Bonus Payment",
+    category: "Bonus",
+    body: "Bonus {{period}} - {{recipientName}}",
+    isDefault: true,
+    usageCount: 0,
+    createdAt: "2026-01-01T00:00:00.000Z",
+  },
+  {
+    id: "default-refund",
+    name: "Refund",
+    category: "Refund",
+    body: "Refund for {{referenceId}}",
+    isDefault: true,
+    usageCount: 0,
+    createdAt: "2026-01-01T00:00:00.000Z",
+  },
+  {
+    id: "default-donation",
+    name: "Donation",
+    category: "Donation",
+    body: "Donation from {{senderName}}",
+    isDefault: true,
+    usageCount: 0,
+    createdAt: "2026-01-01T00:00:00.000Z",
+  },
+  {
+    id: "default-general-payment",
+    name: "General Payment",
+    category: "General",
+    body: "Payment: {{referenceId}}",
+    isDefault: true,
+    usageCount: 0,
+    createdAt: "2026-01-01T00:00:00.000Z",
+  },
+];
+
+// ─── Variable substitution ───────────────────────────────────────────────────
+
+const PLACEHOLDER_RE = /\{\{\s*([a-zA-Z0-9_]+)\s*\}\}/g;
+
+/**
+ * Returns the ordered, de-duplicated list of variable keys a template body
+ * references, e.g. "Invoice {{invoiceNumber}}" -> ["invoiceNumber"].
+ */
+export function extractVariables(body: string): string[] {
+  const found: string[] = [];
+  for (const match of body.matchAll(PLACEHOLDER_RE)) {
+    const key = match[1];
+    if (!found.includes(key)) found.push(key);
+  }
+  return found;
+}
+
+/**
+ * Replaces `{{key}}` placeholders with the matching value from `values`.
+ * Placeholders with no provided value (missing key, or blank/whitespace-only
+ * value) are left in place so the caller can see what's still unfilled.
+ */
+export function substituteVariables(body: string, values: Record<string, string>): string {
+  return body.replace(PLACEHOLDER_RE, (match, key: string) => {
+    const value = values[key];
+    return value && value.trim() ? value.trim() : match;
+  });
+}
+
+/** True once every placeholder in `body` has been replaced by substituteVariables. */
+export function isFullySubstituted(body: string): boolean {
+  // Uses extractVariables (matchAll, which doesn't mutate PLACEHOLDER_RE's
+  // lastIndex) rather than PLACEHOLDER_RE.test() directly — a shared global
+  // regex's lastIndex persists between .test() calls, which would make this
+  // give wrong answers on repeated calls.
+  return extractVariables(body).length === 0;
+}

--- a/frontend/lib/use-memo-templates.test.ts
+++ b/frontend/lib/use-memo-templates.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { useMemoTemplates } from "@/lib/use-memo-templates";
+import { DEFAULT_MEMO_TEMPLATES } from "@/lib/memo-templates";
+
+describe("useMemoTemplates", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("seeds the default template library on first load", async () => {
+    const { result } = renderHook(() => useMemoTemplates());
+    await waitFor(() => expect(result.current.templates.length).toBeGreaterThanOrEqual(10));
+    expect(result.current.templates.every((t) => t.isDefault)).toBe(true);
+  });
+
+  it("creates a custom template and persists it to localStorage", async () => {
+    const { result } = renderHook(() => useMemoTemplates());
+    await waitFor(() => expect(result.current.templates.length).toBeGreaterThan(0));
+
+    act(() => {
+      result.current.createTemplate({ name: "My Template", category: "General", body: "{{a}}" });
+    });
+
+    await waitFor(() =>
+      expect(result.current.templates.some((t) => t.name === "My Template")).toBe(true),
+    );
+
+    const created = result.current.templates.find((t) => t.name === "My Template")!;
+    expect(created.isDefault).toBe(false);
+    expect(created.usageCount).toBe(0);
+
+    const stored = JSON.parse(localStorage.getItem("stellarstream_memo_templates") ?? "[]");
+    expect(stored.some((t: { name: string }) => t.name === "My Template")).toBe(true);
+  });
+
+  it("does not delete a default template", async () => {
+    const { result } = renderHook(() => useMemoTemplates());
+    await waitFor(() => expect(result.current.templates.length).toBeGreaterThan(0));
+
+    const before = result.current.templates.length;
+    const defaultTemplate = result.current.templates.find((t) => t.isDefault)!;
+
+    act(() => {
+      result.current.deleteTemplate(defaultTemplate.id);
+    });
+
+    expect(result.current.templates.length).toBe(before);
+    expect(result.current.templates.some((t) => t.id === defaultTemplate.id)).toBe(true);
+  });
+
+  it("deletes a custom template", async () => {
+    const { result } = renderHook(() => useMemoTemplates());
+    await waitFor(() => expect(result.current.templates.length).toBeGreaterThan(0));
+
+    let createdId = "";
+    act(() => {
+      createdId = result.current.createTemplate({ name: "Deletable", category: "General", body: "{{a}}" }).id;
+    });
+    await waitFor(() => expect(result.current.templates.some((t) => t.id === createdId)).toBe(true));
+
+    act(() => {
+      result.current.deleteTemplate(createdId);
+    });
+
+    await waitFor(() => expect(result.current.templates.some((t) => t.id === createdId)).toBe(false));
+  });
+
+  it("does not modify a default template via updateTemplate", async () => {
+    const { result } = renderHook(() => useMemoTemplates());
+    await waitFor(() => expect(result.current.templates.length).toBeGreaterThan(0));
+
+    const defaultTemplate = result.current.templates.find((t) => t.isDefault)!;
+    const originalBody = defaultTemplate.body;
+
+    act(() => {
+      result.current.updateTemplate(defaultTemplate.id, { body: "tampered" });
+    });
+
+    const stillDefault = result.current.templates.find((t) => t.id === defaultTemplate.id)!;
+    expect(stillDefault.body).toBe(originalBody);
+  });
+
+  it("updates a custom template", async () => {
+    const { result } = renderHook(() => useMemoTemplates());
+    await waitFor(() => expect(result.current.templates.length).toBeGreaterThan(0));
+
+    let createdId = "";
+    act(() => {
+      createdId = result.current.createTemplate({ name: "Editable", category: "General", body: "old" }).id;
+    });
+    await waitFor(() => expect(result.current.templates.some((t) => t.id === createdId)).toBe(true));
+
+    act(() => {
+      result.current.updateTemplate(createdId, { body: "new" });
+    });
+
+    await waitFor(() =>
+      expect(result.current.templates.find((t) => t.id === createdId)?.body).toBe("new"),
+    );
+  });
+
+  it("duplicates a template as a non-default copy", async () => {
+    const { result } = renderHook(() => useMemoTemplates());
+    await waitFor(() => expect(result.current.templates.length).toBeGreaterThan(0));
+
+    const source = result.current.templates.find((t) => t.isDefault)!;
+    const beforeCount = result.current.templates.length;
+
+    act(() => {
+      result.current.duplicateTemplate(source.id);
+    });
+
+    await waitFor(() => expect(result.current.templates.length).toBe(beforeCount + 1));
+    const copy = result.current.templates.find((t) => t.name === `${source.name} (copy)`);
+    expect(copy).toBeDefined();
+    expect(copy!.isDefault).toBe(false);
+  });
+
+  it("increments usageCount via recordUsage", async () => {
+    const { result } = renderHook(() => useMemoTemplates());
+    await waitFor(() => expect(result.current.templates.length).toBeGreaterThan(0));
+
+    const target = result.current.templates[0];
+
+    act(() => {
+      result.current.recordUsage(target.id);
+    });
+
+    await waitFor(() =>
+      expect(result.current.templates.find((t) => t.id === target.id)?.usageCount).toBe(
+        (target.usageCount ?? 0) + 1,
+      ),
+    );
+  });
+
+  it("round-trips templates through exportTemplates/importTemplates", async () => {
+    const { result } = renderHook(() => useMemoTemplates());
+    await waitFor(() => expect(result.current.templates.length).toBeGreaterThan(0));
+
+    const exported = result.current.exportTemplates();
+    const parsed = JSON.parse(exported);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed.length).toBe(result.current.templates.length);
+
+    const beforeCount = result.current.templates.length;
+    let importResult: { imported: number; skipped: number; error?: string } | undefined;
+    act(() => {
+      importResult = result.current.importTemplates(exported);
+    });
+
+    expect(importResult?.error).toBeUndefined();
+    expect(importResult?.imported).toBe(beforeCount);
+    await waitFor(() => expect(result.current.templates.length).toBe(beforeCount * 2));
+  });
+
+  it("importTemplates rejects invalid JSON", async () => {
+    const { result } = renderHook(() => useMemoTemplates());
+    await waitFor(() => expect(result.current.templates.length).toBeGreaterThan(0));
+
+    let importResult: { imported: number; skipped: number; error?: string } | undefined;
+    act(() => {
+      importResult = result.current.importTemplates("not json");
+    });
+
+    expect(importResult?.imported).toBe(0);
+    expect(importResult?.error).toBeTruthy();
+  });
+
+  it("importTemplates skips malformed entries but imports valid ones", async () => {
+    const { result } = renderHook(() => useMemoTemplates());
+    await waitFor(() => expect(result.current.templates.length).toBeGreaterThan(0));
+
+    const payload = JSON.stringify([
+      { name: "Valid", category: "General", body: "{{a}}" },
+      { name: "Missing body" },
+    ]);
+
+    let importResult: { imported: number; skipped: number; error?: string } | undefined;
+    act(() => {
+      importResult = result.current.importTemplates(payload);
+    });
+
+    expect(importResult?.imported).toBe(1);
+    expect(importResult?.skipped).toBe(1);
+  });
+
+  it("persists custom templates across separate hook instances (simulated reload)", async () => {
+    const first = renderHook(() => useMemoTemplates());
+    await waitFor(() => expect(first.result.current.templates.length).toBeGreaterThan(0));
+
+    act(() => {
+      first.result.current.createTemplate({ name: "Persisted", category: "General", body: "{{a}}" });
+    });
+    await waitFor(() =>
+      expect(first.result.current.templates.some((t) => t.name === "Persisted")).toBe(true),
+    );
+    first.unmount();
+
+    const second = renderHook(() => useMemoTemplates());
+    await waitFor(() =>
+      expect(second.result.current.templates.some((t) => t.name === "Persisted")).toBe(true),
+    );
+  });
+
+  it("has at least 10 default templates available on a fresh hook instance", async () => {
+    const { result } = renderHook(() => useMemoTemplates());
+    await waitFor(() =>
+      expect(result.current.templates.filter((t) => t.isDefault).length).toBe(
+        DEFAULT_MEMO_TEMPLATES.length,
+      ),
+    );
+    expect(DEFAULT_MEMO_TEMPLATES.length).toBeGreaterThanOrEqual(10);
+  });
+});

--- a/frontend/lib/use-memo-templates.ts
+++ b/frontend/lib/use-memo-templates.ts
@@ -1,0 +1,192 @@
+"use client";
+// frontend/lib/use-memo-templates.ts
+// Issue #1366 — Payment Memo Templates
+//
+// localStorage-backed CRUD for the memo template library. Unlike stream
+// templates (useTemplateLibrary), memo templates have no backend
+// counterpart — they're purely a client-side convenience for composing
+// payment memo text, so this hook is local-storage only.
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import {
+  DEFAULT_MEMO_TEMPLATES,
+  type MemoTemplate,
+  type MemoTemplateCategory,
+} from "./memo-templates";
+
+const KEY = "stellarstream_memo_templates";
+
+function loadLocal(): MemoTemplate[] {
+  if (typeof window === "undefined") return DEFAULT_MEMO_TEMPLATES;
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return DEFAULT_MEMO_TEMPLATES;
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : DEFAULT_MEMO_TEMPLATES;
+  } catch {
+    return DEFAULT_MEMO_TEMPLATES;
+  }
+}
+
+function saveLocal(templates: MemoTemplate[]) {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(KEY, JSON.stringify(templates));
+}
+
+export interface CreateMemoTemplateInput {
+  name: string;
+  category: MemoTemplateCategory;
+  body: string;
+}
+
+export interface ImportResult {
+  imported: number;
+  skipped: number;
+  error?: string;
+}
+
+export function useMemoTemplates() {
+  const [templates, setTemplates] = useState<MemoTemplate[]>(DEFAULT_MEMO_TEMPLATES);
+  const initialised = useRef(false);
+
+  useEffect(() => {
+    if (initialised.current) return;
+    initialised.current = true;
+
+    const existing = loadLocal();
+    setTemplates(existing);
+    // Seed storage on first-ever load so the defaults are visible/exportable
+    // even before the user creates anything of their own.
+    if (typeof window !== "undefined" && !localStorage.getItem(KEY)) {
+      saveLocal(existing);
+    }
+  }, []);
+
+  const createTemplate = useCallback((input: CreateMemoTemplateInput): MemoTemplate => {
+    const template: MemoTemplate = {
+      id: crypto.randomUUID(),
+      name: input.name.trim(),
+      category: input.category,
+      body: input.body,
+      isDefault: false,
+      usageCount: 0,
+      createdAt: new Date().toISOString(),
+    };
+    setTemplates((prev) => {
+      const next = [template, ...prev];
+      saveLocal(next);
+      return next;
+    });
+    return template;
+  }, []);
+
+  const updateTemplate = useCallback(
+    (id: string, patch: Partial<CreateMemoTemplateInput>) => {
+      setTemplates((prev) => {
+        const next = prev.map((t) =>
+          t.id === id && !t.isDefault ? { ...t, ...patch } : t,
+        );
+        saveLocal(next);
+        return next;
+      });
+    },
+    [],
+  );
+
+  const deleteTemplate = useCallback((id: string) => {
+    setTemplates((prev) => {
+      const target = prev.find((t) => t.id === id);
+      if (!target || target.isDefault) return prev; // defaults are protected
+      const next = prev.filter((t) => t.id !== id);
+      saveLocal(next);
+      return next;
+    });
+  }, []);
+
+  const duplicateTemplate = useCallback((id: string) => {
+    setTemplates((prev) => {
+      const src = prev.find((t) => t.id === id);
+      if (!src) return prev;
+      const copy: MemoTemplate = {
+        ...src,
+        id: crypto.randomUUID(),
+        name: `${src.name} (copy)`,
+        isDefault: false,
+        usageCount: 0,
+        createdAt: new Date().toISOString(),
+      };
+      const next = [copy, ...prev];
+      saveLocal(next);
+      return next;
+    });
+  }, []);
+
+  const recordUsage = useCallback((id: string) => {
+    setTemplates((prev) => {
+      const next = prev.map((t) =>
+        t.id === id ? { ...t, usageCount: (t.usageCount ?? 0) + 1 } : t,
+      );
+      saveLocal(next);
+      return next;
+    });
+  }, []);
+
+  const exportTemplates = useCallback((): string => {
+    return JSON.stringify(templates, null, 2);
+  }, [templates]);
+
+  const importTemplates = useCallback((json: string): ImportResult => {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(json);
+    } catch {
+      return { imported: 0, skipped: 0, error: "Invalid JSON" };
+    }
+
+    if (!Array.isArray(parsed)) {
+      return { imported: 0, skipped: 0, error: "Expected a JSON array of templates" };
+    }
+
+    const incoming = parsed.filter(
+      (t): t is MemoTemplate =>
+        !!t &&
+        typeof t === "object" &&
+        typeof (t as MemoTemplate).name === "string" &&
+        typeof (t as MemoTemplate).body === "string" &&
+        typeof (t as MemoTemplate).category === "string",
+    );
+    const skipped = parsed.length - incoming.length;
+
+    if (incoming.length === 0) {
+      return { imported: 0, skipped, error: skipped > 0 ? "No valid templates found" : undefined };
+    }
+
+    setTemplates((prev) => {
+      // Always mint fresh ids on import so we never clobber an existing
+      // template (local or default) that happens to share an id.
+      const imported = incoming.map((t) => ({
+        ...t,
+        id: crypto.randomUUID(),
+        isDefault: false,
+        usageCount: 0,
+        createdAt: new Date().toISOString(),
+      }));
+      const next = [...imported, ...prev];
+      saveLocal(next);
+      return next;
+    });
+
+    return { imported: incoming.length, skipped };
+  }, []);
+
+  return {
+    templates,
+    createTemplate,
+    updateTemplate,
+    deleteTemplate,
+    duplicateTemplate,
+    recordUsage,
+    exportTemplates,
+    importTemplates,
+  };
+}


### PR DESCRIPTION
# Pull Request: Payment Memo Templates

## 📋 Issue Reference
Closes #1366

## 🎯 Summary
Adds a customizable memo template library with variable substitution, template categories, and JSON import/export — surfaced as a new "Memo Templates" tab on the existing Templates page (`/dashboard/templates`), alongside the existing Stream Templates tab.

## ✅ Requirements Met
- [x] **Template library** — browse/manage templates in a new "Memo Templates" tab on the existing Templates page
- [x] **Variable placeholders** — `{{variableName}}` syntax (e.g. `Invoice {{invoiceNumber}} - {{amount}} {{asset}}`), with live variable-chip detection while composing
- [x] **Template categories** — 11 categories (Invoice, Payroll, Vendor Payment, Milestone, Subscription, Reimbursement, Grant, Bonus, Refund, Donation, General), filterable
- [x] **Import/export templates** — export the full library to a `.json` file; import validates and merges, skipping malformed entries
- [x] **Template CRUD implemented** — create, edit, duplicate, delete for user templates (the 11 built-ins are read-only — protected from edit/delete — but freely duplicatable into an editable copy)
- [x] **Variable substitution works** — "Use" panel on each template renders an input per variable it references, live-previews the filled-in memo, and copies the result to the clipboard
- [x] **At least 10 default templates** — ships 11

## 🚀 Features Implemented

### Core Logic
- **`frontend/lib/memo-templates.ts`** — types, the 11 default templates, and pure `extractVariables` / `substituteVariables` / `isFullySubstituted` helpers (fully unit tested, including a regression test for a `RegExp.lastIndex` footgun a naive implementation would hit)
- **`frontend/lib/use-memo-templates.ts`** — localStorage-backed CRUD hook (`createTemplate`, `updateTemplate`, `deleteTemplate`, `duplicateTemplate`, `recordUsage`, `exportTemplates`, `importTemplates`). Seeds the 11 defaults on first load. Client-side only — no backend endpoint, since this issue is scoped to the `frontend` label and (unlike stream templates) memo templates have no existing backend counterpart to build on.

### UI
- **`frontend/components/MemoTemplateLibrary.tsx`** — category filter chips, inline create/edit form with live variable-chip preview, a "Use" panel per template (variable inputs → live preview → copy to clipboard), duplicate/delete (delete guarded for built-ins), and import/export buttons
- **`frontend/app/dashboard/templates/page.tsx`** — added a tab switcher ("Stream Templates" / "Memo Templates") above the existing content; the memo tab renders `MemoTemplateLibrary`, the stream tab is untouched

## 🧪 Testing
- `frontend/lib/memo-templates.test.ts` — 17 tests: default-library invariants (≥10 templates, all `isDefault`, unique ids, valid categories, each has ≥1 variable), `extractVariables`, `substituteVariables`, `isFullySubstituted`
- `frontend/lib/use-memo-templates.test.ts` — 14 tests via `renderHook`: seeding, create/update/delete/duplicate, default-template protection, usage tracking, export/import round-trip, malformed-import handling, and persistence across a simulated reload (two separate hook instances sharing localStorage)
- All 31 pass under `npm test` (vitest)

## 📁 Files Changed
- `frontend/lib/memo-templates.ts` (new)
- `frontend/lib/memo-templates.test.ts` (new)
- `frontend/lib/use-memo-templates.ts` (new)
- `frontend/lib/use-memo-templates.test.ts` (new)
- `frontend/components/MemoTemplateLibrary.tsx` (new)
- `frontend/app/dashboard/templates/page.tsx` — added tab switcher, wired in the new component

## 🔧 Technical Notes
- Followed the existing `useTemplateLibrary`/`StreamTemplate` pattern (same `loadLocal`/`saveLocal` shape, same card/gallery visual language, same brand tokens) for consistency, but skipped its backend-first branch since there's no memo-template API to call
- Scope/placement (new tab vs. new page vs. inline-only) was confirmed up front rather than assumed
- Not included in this PR (kept out to match the issue's scope): wiring a template picker directly into `StreamMemoInput` / `BulkEditBar`'s memo field. The current UI is copy-to-clipboard from the library tab; direct in-field insertion would be a natural, small follow-up if wanted.

## ✔️ Verified Locally
- `npx tsc --noEmit` — no new errors introduced (pre-existing unrelated errors elsewhere in the codebase are untouched)
- `npx eslint` on all new/changed files — clean (one pre-existing unused-var lint warning in `templates/page.tsx` predates this change and is unrelated)
- `npx vitest run` — new tests pass 31/31; no regressions in previously-passing tests

## 📝 Checklist
- [x] Code follows project style guidelines
- [x] Self-review of the code completed
- [x] Changes are fully tested
- [x] TypeScript types are properly defined
- [x] No breaking changes introduced

**Labels**: [Feature] [Frontend]
