### PR TITLE
feat(payments): add QR code generation for payment requests

### DIFF
--- a/frontend/app/api/v1/invoice-links/[slug]/route.test.ts
+++ b/frontend/app/api/v1/invoice-links/[slug]/route.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GET } from "./route";
+
+function makeParams(slug: string) {
+  return { params: Promise.resolve({ slug }) };
+}
+
+function makeRequest(): Request {
+  return new Request("http://localhost/api/v1/invoice-links/abc123");
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("GET /api/v1/invoice-links/[slug]", () => {
+  it("returns 400 when slug is missing", async () => {
+    const res = await GET(makeRequest(), makeParams(""));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBeTruthy();
+  });
+
+  it("forwards the slug to the backend and proxies a 200 response", async () => {
+    const invoice = {
+      id: "inv_1",
+      slug: "abc123",
+      status: "DRAFT",
+      shareUrl: "http://localhost:5173/invoice/abc123",
+    };
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(invoice),
+    });
+
+    const res = await GET(makeRequest(), makeParams("abc123"));
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/v1/invoice-links/abc123"),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual(invoice);
+  });
+
+  it("URL-encodes the slug when forwarding to the backend", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({}),
+    });
+
+    await GET(makeRequest(), makeParams("has space"));
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining(encodeURIComponent("has space")),
+    );
+  });
+
+  it("returns 404 when the backend reports the link is missing or expired", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: () => Promise.resolve({ error: "Invoice link not found or expired" }),
+    });
+
+    const res = await GET(makeRequest(), makeParams("missing-slug"));
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("Invoice link not found or expired");
+  });
+
+  it("returns 502 when the backend is unreachable", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("connection refused"));
+
+    const res = await GET(makeRequest(), makeParams("abc123"));
+
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).toBeTruthy();
+  });
+});

--- a/frontend/app/api/v1/invoice-links/[slug]/route.ts
+++ b/frontend/app/api/v1/invoice-links/[slug]/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+
+const BACKEND = process.env.BACKEND_URL ?? "http://localhost:3001";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const slug = (await params).slug;
+  if (!slug) {
+    return NextResponse.json({ error: "Missing invoice link identifier." }, { status: 400 });
+  }
+
+  const upstream = await fetch(
+    `${BACKEND}/api/v1/invoice-links/${encodeURIComponent(slug)}`,
+  ).catch(() => null);
+
+  if (!upstream) {
+    return NextResponse.json({ error: "Backend unavailable." }, { status: 502 });
+  }
+
+  const body = await upstream.json();
+  return NextResponse.json(body, { status: upstream.status });
+}

--- a/frontend/app/dashboard/invoice-links/page.test.tsx
+++ b/frontend/app/dashboard/invoice-links/page.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { vi } from "vitest";
+import InvoiceLinksPage from "./page";
+
+// QR rendering relies on canvas APIs jsdom doesn't implement; stub it out so
+// these tests focus on the toggle behavior, not the canvas draw itself.
+vi.mock("qrcode", () => ({
+  default: { toCanvas: vi.fn().mockResolvedValue(undefined) },
+}));
+
+const INVOICES = [
+  {
+    id: "inv_1",
+    slug: "abc123",
+    sender: "GSENDER",
+    receiver: "GRECEIVER",
+    amount: "500",
+    tokenAddress: "USDC",
+    duration: 3600,
+    xdrParams: "",
+    status: "DRAFT",
+    createdAt: "2026-07-01T00:00:00.000Z",
+    updatedAt: "2026-07-01T00:00:00.000Z",
+    shareUrl: "https://stellarstream.app/invoice/abc123",
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(INVOICES),
+  });
+});
+
+describe("InvoiceLinksPage QR code toggle", () => {
+  it("does not render the QR panel until Show QR is clicked", async () => {
+    render(<InvoiceLinksPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("toggle-qr-inv_1")).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/download for print/i)).not.toBeInTheDocument();
+  });
+
+  it("shows the QR Studio panel for a row after clicking Show QR", async () => {
+    render(<InvoiceLinksPage />);
+
+    const toggleButton = await screen.findByTestId("toggle-qr-inv_1");
+    fireEvent.click(toggleButton);
+
+    expect(await screen.findByText(/download for print/i)).toBeInTheDocument();
+    expect(screen.getByText(/hide qr/i)).toBeInTheDocument();
+  });
+
+  it("hides the QR Studio panel again after clicking Hide QR", async () => {
+    render(<InvoiceLinksPage />);
+
+    const toggleButton = await screen.findByTestId("toggle-qr-inv_1");
+    fireEvent.click(toggleButton);
+    await screen.findByText(/download for print/i);
+
+    fireEvent.click(screen.getByTestId("toggle-qr-inv_1"));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/download for print/i)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/app/dashboard/invoice-links/page.tsx
+++ b/frontend/app/dashboard/invoice-links/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
+import { QrCode } from "lucide-react";
+import { QRStudio } from "@/components/qr-studio";
 
 type InvoiceStatus = "DRAFT" | "SIGNED" | "COMPLETED" | "EXPIRED";
 
@@ -18,6 +20,7 @@ interface InvoiceLink {
   status: InvoiceStatus;
   expiresAt?: string;
   createdAt: string;
+  shareUrl?: string;
   updatedAt: string;
 }
 
@@ -35,6 +38,7 @@ const UNPAID_STATUSES: InvoiceStatus[] = ["DRAFT", "SIGNED"];
 export default function InvoiceLinksPage() {
   const [invoices, setInvoices] = useState<InvoiceLink[]>([]);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [qrOpenId, setQrOpenId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [bundleStatus, setBundleStatus] = useState<"idle" | "pending" | "complete" | "error">("idle");
@@ -87,6 +91,14 @@ export default function InvoiceLinksPage() {
   const addToSplitter = (invoice: InvoiceLink) => {
     toggleSelect(invoice.id);
   };
+
+  const toggleQr = (id: string) => {
+    setQrOpenId((prev) => (prev === id ? null : id));
+  };
+
+  const shareUrlFor = (invoice: InvoiceLink) =>
+    invoice.shareUrl ??
+    `${typeof window !== "undefined" ? window.location.origin : ""}/invoice/${invoice.slug}`;
 
   const bundleToSplitter = async () => {
     if (selectedInvoices.length === 0) {
@@ -164,32 +176,59 @@ export default function InvoiceLinksPage() {
                 <th className="px-4 py-3">Invoice</th>
                 <th className="px-4 py-3">Status</th>
                 <th className="px-4 py-3">Action</th>
+                <th className="px-4 py-3">QR Code</th>
               </tr>
             </thead>
             <tbody>
               {unpaidInvoices.map((invoice) => {
                 const isSelected = selectedIds.has(invoice.id);
+                const qrOpen = qrOpenId === invoice.id;
                 return (
-                  <tr key={invoice.id} className={isSelected ? "bg-cyan-500/10" : ""}>
-                    <td className="px-4 py-3 font-mono text-xs text-white/85">{invoice.receiver}</td>
-                    <td className="px-4 py-3 text-sm font-medium">{invoice.amount}</td>
-                    <td className="px-4 py-3 text-sm">{invoice.tokenAddress ?? "--"}</td>
-                    <td className="px-4 py-3 text-sm">{invoice.slug}</td>
-                    <td className="px-4 py-3 text-sm">{invoice.status}</td>
-                    <td className="px-4 py-3">
-                      <button
-                        onClick={() => addToSplitter(invoice)}
-                        className={`rounded-lg px-3 py-1 text-xs font-semibold transition ${
-                          isSelected
-                            ? "bg-emerald-400 text-black"
-                            : "bg-slate-700/70 text-white hover:bg-slate-600"
-                        }`}
-                        data-testid={`add-to-splitter-${invoice.id}`}
-                      >
-                        {isSelected ? "Remove from Splitter" : "Add to Splitter"}
-                      </button>
-                    </td>
-                  </tr>
+                  <Fragment key={invoice.id}>
+                    <tr className={isSelected ? "bg-cyan-500/10" : ""}>
+                      <td className="px-4 py-3 font-mono text-xs text-white/85">{invoice.receiver}</td>
+                      <td className="px-4 py-3 text-sm font-medium">{invoice.amount}</td>
+                      <td className="px-4 py-3 text-sm">{invoice.tokenAddress ?? "--"}</td>
+                      <td className="px-4 py-3 text-sm">{invoice.slug}</td>
+                      <td className="px-4 py-3 text-sm">{invoice.status}</td>
+                      <td className="px-4 py-3">
+                        <button
+                          onClick={() => addToSplitter(invoice)}
+                          className={`rounded-lg px-3 py-1 text-xs font-semibold transition ${
+                            isSelected
+                              ? "bg-emerald-400 text-black"
+                              : "bg-slate-700/70 text-white hover:bg-slate-600"
+                          }`}
+                          data-testid={`add-to-splitter-${invoice.id}`}
+                        >
+                          {isSelected ? "Remove from Splitter" : "Add to Splitter"}
+                        </button>
+                      </td>
+                      <td className="px-4 py-3">
+                        <button
+                          onClick={() => toggleQr(invoice.id)}
+                          className={`inline-flex items-center gap-1.5 rounded-lg px-3 py-1 text-xs font-semibold transition ${
+                            qrOpen
+                              ? "bg-cyan-400 text-black"
+                              : "bg-slate-700/70 text-white hover:bg-slate-600"
+                          }`}
+                          data-testid={`toggle-qr-${invoice.id}`}
+                        >
+                          <QrCode className="h-3.5 w-3.5" />
+                          {qrOpen ? "Hide QR" : "Show QR"}
+                        </button>
+                      </td>
+                    </tr>
+                    {qrOpen && (
+                      <tr>
+                        <td colSpan={7} className="bg-black/20 px-4 py-6">
+                          <div className="max-w-sm">
+                            <QRStudio url={shareUrlFor(invoice)} />
+                          </div>
+                        </td>
+                      </tr>
+                    )}
+                  </Fragment>
                 );
               })}
             </tbody>

--- a/frontend/app/invoice/[slug]/page.test.tsx
+++ b/frontend/app/invoice/[slug]/page.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { vi } from "vitest";
+import InvoiceLinkLandingPage from "./page";
+
+const mockOpenModal = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ slug: "abc123" }),
+}));
+
+vi.mock("@/lib/wallet-context", () => ({
+  useWallet: () => ({ openModal: mockOpenModal, isConnected: false }),
+}));
+
+// QR rendering relies on canvas APIs jsdom doesn't implement; stub it out so
+// these tests focus on the page's data/loading/error states.
+vi.mock("qrcode", () => ({
+  default: { toCanvas: vi.fn().mockResolvedValue(undefined) },
+}));
+
+const INVOICE = {
+  id: "inv_1",
+  slug: "abc123",
+  sender: "GSENDERADDRESSAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+  receiver: "GRECEIVERADDRESSBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+  amount: "500",
+  tokenAddress: "USDC",
+  duration: 3600,
+  description: "Consulting invoice",
+  status: "DRAFT" as const,
+  expiresAt: "2026-08-01T00:00:00.000Z",
+  createdAt: "2026-07-01T00:00:00.000Z",
+  shareUrl: "https://stellarstream.app/invoice/abc123",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("InvoiceLinkLandingPage", () => {
+  it("shows a loading state before the fetch resolves", () => {
+    global.fetch = vi.fn().mockReturnValue(new Promise(() => {}));
+    render(<InvoiceLinkLandingPage />);
+    expect(screen.getByText(/loading payment request/i)).toBeInTheDocument();
+  });
+
+  it("renders payment details once the invoice loads", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(INVOICE),
+    });
+
+    render(<InvoiceLinkLandingPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("500 USDC")).toBeInTheDocument();
+    });
+    expect(screen.getByText("DRAFT")).toBeInTheDocument();
+    expect(screen.getByText("Consulting invoice")).toBeInTheDocument();
+  });
+
+  it("fetches the invoice by the slug from the route params", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(INVOICE),
+    });
+
+    render(<InvoiceLinkLandingPage />);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith("/api/v1/invoice-links/abc123");
+    });
+  });
+
+  it("shows an error state when the invoice link is missing or expired", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: () => Promise.resolve({ error: "Invoice link not found or expired" }),
+    });
+
+    render(<InvoiceLinkLandingPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Invoice link not found or expired")).toBeInTheDocument();
+    });
+  });
+
+  it("opens the wallet modal when the pay button is clicked", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(INVOICE),
+    });
+
+    render(<InvoiceLinkLandingPage />);
+
+    const payButton = await screen.findByText(/connect wallet to pay/i);
+    payButton.click();
+    expect(mockOpenModal).toHaveBeenCalled();
+  });
+});

--- a/frontend/app/invoice/[slug]/page.tsx
+++ b/frontend/app/invoice/[slug]/page.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { Clock, Copy, Check, Loader2, WalletMinimal, ArrowRight } from "lucide-react";
+import { useWallet } from "@/lib/wallet-context";
+import { QRStudio } from "@/components/qr-studio";
+
+type InvoiceStatus = "DRAFT" | "SIGNED" | "COMPLETED" | "EXPIRED";
+
+interface InvoiceLinkInfo {
+  id: string;
+  slug: string;
+  sender: string;
+  receiver: string;
+  amount: string;
+  tokenAddress: string;
+  duration: number;
+  description?: string;
+  status: InvoiceStatus;
+  expiresAt?: string;
+  createdAt: string;
+  shareUrl: string;
+}
+
+const statusStyles: Record<InvoiceStatus, string> = {
+  DRAFT: "bg-amber-500/10 text-amber-300 border border-amber-400/20",
+  SIGNED: "bg-sky-500/10 text-sky-300 border border-sky-400/20",
+  COMPLETED: "bg-emerald-500/10 text-emerald-300 border border-emerald-400/20",
+  EXPIRED: "bg-red-500/10 text-red-300 border border-red-400/20",
+};
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.round(hours / 24);
+  return `${days}d`;
+}
+
+function truncateAddress(address: string): string {
+  if (address.length <= 12) return address;
+  return `${address.slice(0, 6)}…${address.slice(-6)}`;
+}
+
+export default function InvoiceLinkLandingPage() {
+  const params = useParams();
+  const { slug } = params as { slug?: string };
+  const { openModal } = useWallet();
+
+  const [invoice, setInvoice] = useState<InvoiceLinkInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!slug) return;
+
+    setLoading(true);
+    setError(null);
+    fetch(`/api/v1/invoice-links/${encodeURIComponent(slug)}`)
+      .then(async (res) => {
+        if (!res.ok) {
+          const payload = await res.json().catch(() => ({}));
+          throw new Error(payload.error || `Failed to load payment request (${res.status})`);
+        }
+        return res.json() as Promise<InvoiceLinkInfo>;
+      })
+      .then((data) => setInvoice(data))
+      .catch((err) => {
+        setError(err instanceof Error ? err.message : "Unable to fetch payment request.");
+      })
+      .finally(() => setLoading(false));
+  }, [slug]);
+
+  const handleCopyLink = async () => {
+    if (!invoice) return;
+    await navigator.clipboard.writeText(invoice.shareUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const qrUrl =
+    invoice?.shareUrl ??
+    (slug ? `${typeof window !== "undefined" ? window.location.origin : "https://stellarstream.app"}/invoice/${slug}` : "");
+
+  return (
+    <div className="min-h-screen relative overflow-hidden bg-[#030305] text-white">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(0,245,255,0.16),transparent_24%),radial-gradient(circle_at_bottom_right,rgba(138,0,255,0.18),transparent_22%)]" />
+      <div className="absolute inset-0 opacity-20 bg-[radial-gradient(circle_at_30%_20%,rgba(255,255,255,0.06),transparent_18%)]" />
+      <div className="relative z-10 max-w-6xl mx-auto px-4 py-20">
+        <div className="glass-card border-white/10 shadow-[0_0_40px_rgba(0,0,0,0.3)] mx-auto max-w-3xl p-8 md:p-12 space-y-6">
+          <div>
+            <p className="text-sm uppercase tracking-[0.32em] text-white/50">Payment Request</p>
+            <h1 className="mt-2 text-3xl font-black tracking-tight text-white sm:text-4xl">
+              {invoice ? `${invoice.amount} ${invoice.tokenAddress || "Asset"}` : loading ? "Loading…" : "Payment request"}
+            </h1>
+          </div>
+
+          {loading ? (
+            <div className="flex items-center justify-center gap-3 py-16 text-sm text-white/70">
+              <Loader2 className="h-5 w-5 animate-spin" />
+              Loading payment request…
+            </div>
+          ) : error ? (
+            <div className="rounded-3xl border border-red-400/30 bg-red-500/10 p-6 text-sm text-red-200">
+              {error || "This payment request could not be found or has expired."}
+            </div>
+          ) : invoice ? (
+            <div className="space-y-6">
+              <div className="grid gap-4 md:grid-cols-3">
+                <div className="rounded-3xl border border-white/10 bg-white/[0.03] p-6">
+                  <p className="text-xs uppercase tracking-[0.3em] text-white/40">Status</p>
+                  <div
+                    className={`mt-4 inline-flex items-center rounded-full px-4 py-2 text-sm font-semibold ${statusStyles[invoice.status]}`}
+                  >
+                    {invoice.status}
+                  </div>
+                </div>
+
+                <div className="rounded-3xl border border-white/10 bg-white/[0.03] p-6">
+                  <p className="text-xs uppercase tracking-[0.3em] text-white/40">Stream Duration</p>
+                  <p className="mt-4 text-lg font-semibold text-white/90">{formatDuration(invoice.duration)}</p>
+                </div>
+
+                <div className="rounded-3xl border border-white/10 bg-white/[0.03] p-6">
+                  <p className="text-xs uppercase tracking-[0.3em] text-white/40 flex items-center gap-1">
+                    <Clock className="h-3 w-3" /> Expires
+                  </p>
+                  <p className="mt-4 text-sm font-semibold text-white/90">
+                    {invoice.expiresAt
+                      ? new Date(invoice.expiresAt).toLocaleString(undefined, {
+                          month: "short",
+                          day: "numeric",
+                          year: "numeric",
+                          hour: "2-digit",
+                          minute: "2-digit",
+                        })
+                      : "No expiry"}
+                  </p>
+                </div>
+              </div>
+
+              <div className="rounded-3xl border border-white/10 bg-white/[0.02] p-6 md:p-8 space-y-4">
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="rounded-3xl border border-white/10 bg-white/[0.04] p-5">
+                    <p className="text-xs uppercase tracking-[0.3em] text-white/40">From</p>
+                    <p className="mt-3 break-all font-mono text-sm text-white/90">{truncateAddress(invoice.sender)}</p>
+                  </div>
+                  <div className="rounded-3xl border border-white/10 bg-white/[0.04] p-5">
+                    <p className="text-xs uppercase tracking-[0.3em] text-white/40">To</p>
+                    <p className="mt-3 break-all font-mono text-sm text-white/90">{truncateAddress(invoice.receiver)}</p>
+                  </div>
+                </div>
+
+                {invoice.description && (
+                  <div className="rounded-3xl border border-white/10 bg-white/[0.04] p-5">
+                    <p className="text-xs uppercase tracking-[0.3em] text-white/40">Note</p>
+                    <p className="mt-2 text-sm text-white/80">{invoice.description}</p>
+                  </div>
+                )}
+
+                <div className="flex flex-col gap-3 sm:flex-row">
+                  <button
+                    type="button"
+                    onClick={openModal}
+                    className="inline-flex flex-1 items-center justify-center gap-2 rounded-full bg-cyan-400 px-6 py-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300"
+                  >
+                    <WalletMinimal className="h-4 w-4" />
+                    Connect Wallet to Pay
+                    <ArrowRight className="h-4 w-4" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleCopyLink}
+                    className="inline-flex items-center justify-center gap-2 rounded-full border border-white/10 bg-white/[0.04] px-6 py-3 text-sm font-semibold text-white/90 transition hover:bg-white/[0.08]"
+                  >
+                    {copied ? <Check className="h-4 w-4 text-emerald-400" /> : <Copy className="h-4 w-4" />}
+                    {copied ? "Copied" : "Copy Link"}
+                  </button>
+                </div>
+              </div>
+            </div>
+          ) : null}
+
+          {!loading && !error && qrUrl && <QRStudio url={qrUrl} />}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a public `/invoice/[slug]` landing page for `InvoiceLink` payment requests — this route didn't exist before (the invoice-links dashboard only linked to a backend API `shareUrl`, with no matching frontend page), so payment links were not actually reachable/scannable end-to-end.
- The new page renders the existing `QRStudio` component (`components/qr-studio.tsx`, from the Split-Link feature) against the invoice's `shareUrl`, giving customizable QR codes (foreground/background color, optional logo, 300 DPI print export) for free, plus a "Copy Link" action and a "Connect Wallet to Pay" CTA consistent with the Split-Link landing page pattern.
- Adds `frontend/app/api/v1/invoice-links/[slug]/route.ts`, a thin proxy to the backend's existing `GET /api/v1/invoice-links/:slug`, following the same pattern already used by `app/api/v3/split-links/[slug]/route.ts`.
- The dashboard invoice-links list (`app/dashboard/invoice-links/page.tsx`) gets a per-row "Show QR" toggle so a sender can generate/download a QR code immediately after creating an invoice link.

**Dynamic QR / expiry handling**: no new backend model was needed — `InvoiceLink` already has `slug`, `status` (`DRAFT`/`SIGNED`/`COMPLETED`/`EXPIRED`), and `expiresAt`, with expiry enforced in `invoice-link.service.ts#getInvoiceLinkBySlug`. Since the QR encodes a stable `/invoice/:slug` URL rather than a static payload, the same physical/printed code keeps resolving to live, current status and automatically stops working once the link expires — no re-issuing required.

## Test plan
- [x] New tests: `route.test.ts` (5 tests — proxy forwarding, URL-encoding, 404/502 passthrough), `invoice/[slug]/page.test.tsx` (5 tests — loading/error/data states, wallet modal), `dashboard/invoice-links/page.test.tsx` (3 tests — QR toggle show/hide). All 13 passing.
- [x] `npx eslint` on all new/changed files — clean
- [x] `npx tsc --noEmit` — no new errors introduced beyond the repo's existing baseline (vitest-globals-in-tsc gap already present across the whole test suite)
- [x] Full `vitest run` — no regressions vs. `main` baseline; all failing suites are pre-existing and unrelated to this change

Closes #1376