### PR TITLE
feat: webhook retry logic with dead letter queue and retry dashboard (#1348)

### DIFF
--- a/backend/WEBHOOK_RETRY.md
+++ b/backend/WEBHOOK_RETRY.md
@@ -1,0 +1,158 @@
+# Webhook Retry Logic & Dead Letter Queue
+
+Implements issue #1348. Covers how a failed webhook delivery is retried, when
+it is abandoned, and how to inspect and replay the queue.
+
+## Why the previous implementation delivered nothing
+
+`WebhookDelivery` carried a `webhookId` column but the Prisma schema declared no
+relation to `Webhook`. The dispatcher's queue query used
+`include: { webhook: true }`, which Prisma rejects for a model without that
+relation, so **every** call to `processDeliveries()` threw before sending a
+single request. The migration in
+`prisma/migrations/20260728120000_add_webhook_retry_dead_letter` adds the
+foreign key; the rest of this document describes the retry behaviour built on
+top of it.
+
+## Delivery lifecycle
+
+```
+                 ┌──────────┐
+  dispatch() ───▶│ pending  │◀──────────────┐
+                 └────┬─────┘               │
+                      │ claimed by worker   │ retryable failure,
+                      ▼                     │ budget remaining
+                 ┌────────────┐             │
+                 │ delivering │─────────────┘
+                 └────┬───┬───┘
+              2xx     │   │   permanent failure, or
+                      │   │   attempts == maxRetries
+                      ▼   ▼
+              ┌─────────┐ ┌─────────────┐
+              │ success │ │ dead_letter │──▶ manual retry ──▶ pending
+              └─────────┘ └─────────────┘
+```
+
+A claim left in `delivering` for longer than 5 minutes (a crashed worker) is
+returned to `pending` at the start of the next tick.
+
+## Backoff
+
+`src/lib/webhook-retry.ts` holds the policy as pure functions.
+
+| Attempt | Delay before next try |
+|--------:|-----------------------|
+| 1       | 1s                    |
+| 2       | 2s                    |
+| 3       | 4s                    |
+| 4       | 8s                    |
+| 5       | 16s                   |
+| n       | `1s × 2^(n-1)`, capped at 1h |
+
+Every delay carries ±20% jitter so a receiver coming back online is not hit by
+the entire queue in the same instant. A `Retry-After` header on a `429` or
+`503` overrides the computed delay, clamped to the same 1h ceiling so one
+misbehaving receiver cannot park the queue indefinitely.
+
+## Retryable vs permanent
+
+| Response                      | Treatment |
+|-------------------------------|-----------|
+| `2xx`                         | success |
+| `5xx`                         | retry |
+| `408`, `429`                  | retry |
+| other `4xx` (`400`, `404`, …) | dead letter immediately |
+| `3xx` surfacing as non-ok     | dead letter immediately |
+| network / TLS / timeout       | retry |
+
+Retrying an identical request against a `404` or `400` cannot succeed, so those
+skip the backoff ladder entirely and go straight to the dead letter queue.
+
+## Dead letter queue
+
+A delivery is dead lettered with a recorded `deadLetterReason`:
+
+- `retries_exhausted` — `attempts` reached `maxRetries`.
+- `non_retryable_response` — the receiver returned a permanent failure.
+
+Dead lettered rows keep their payload, attempt count, last status code and last
+error, and are never retried automatically.
+
+## Concurrency
+
+Deliveries are claimed before any HTTP request is made:
+
+```sql
+UPDATE "WebhookDelivery" SET status = 'delivering', "lockedBy" = $worker
+WHERE id IN (...) AND status = 'pending'
+```
+
+The `status = 'pending'` predicate makes the claim exclusive — a racing worker
+that selected the same rows updates zero of them and sends nothing. This lets
+several API instances (and the `dispatch()` fast path) run the queue
+concurrently without double-delivering. Up to 100 deliveries are claimed per
+tick and sent 10 at a time.
+
+## API
+
+All dashboard routes require admin credentials (`X-Admin-Key` or
+`Authorization: Bearer <ADMIN_API_KEY>`).
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET`  | `/api/v1/webhooks/deliveries/stats` | Queue counters, dead letter breakdown, success rate |
+| `GET`  | `/api/v1/webhooks/deliveries` | Paginated delivery log (`status`, `webhookId`, `eventType`, `limit`, `offset`) |
+| `GET`  | `/api/v1/webhooks/deliveries/:deliveryId` | Single delivery including payload |
+| `POST` | `/api/v1/webhooks/deliveries/:deliveryId/retry` | Requeue one delivery |
+| `POST` | `/api/v1/webhooks/deliveries/retry` | Bulk requeue by `deliveryIds` or `webhookId` |
+
+### Inspect the dead letter queue
+
+```bash
+curl -H "X-Admin-Key: $ADMIN_API_KEY" \
+  "http://localhost:3000/api/v1/webhooks/deliveries?status=dead_letter&limit=20"
+```
+
+### Retry a single delivery
+
+```bash
+curl -X POST -H "X-Admin-Key: $ADMIN_API_KEY" \
+  "http://localhost:3000/api/v1/webhooks/deliveries/del_abc123/retry"
+```
+
+### Drain one receiver's dead letter queue
+
+```bash
+curl -X POST -H "X-Admin-Key: $ADMIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"webhookId":"wh_abc123"}' \
+  "http://localhost:3000/api/v1/webhooks/deliveries/retry"
+```
+
+A manual retry preserves the historical `attempts` count for audit and extends
+`maxRetries` by a fresh allowance, so a requeued delivery is not dead lettered
+again on its first failure. In-flight and already-succeeded deliveries are
+rejected with `409`.
+
+## Configuration
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `WEBHOOK_WORKER_INTERVAL_MS` | `10000` | Queue poll interval |
+
+Constants that are not environment-tunable live at the top of
+`src/lib/webhook-retry.ts` (backoff curve, `DEFAULT_MAX_RETRIES`) and
+`src/services/webhook-dispatcher.service.ts` (batch size, concurrency, request
+timeout, stale-claim window).
+
+## Tests
+
+```bash
+npm run test -- webhook-retry webhook-dispatcher
+```
+
+- `src/__tests__/webhook-retry.test.ts` — backoff curve, cap, jitter bounds,
+  failure classification, `Retry-After` parsing, retry/dead-letter decisions.
+- `src/__tests__/webhook-dispatcher.service.test.ts` — delivery outcomes,
+  dead lettering, claim exclusivity, stale-claim reclaim, manual retry, and the
+  dashboard queries.

--- a/backend/prisma/migrations/20260728120000_add_webhook_retry_dead_letter/migration.sql
+++ b/backend/prisma/migrations/20260728120000_add_webhook_retry_dead_letter/migration.sql
@@ -1,0 +1,100 @@
+-- Migration: Webhook Retry Logic & Dead Letter Queue (Issue #1348)
+--
+-- 1. Adds the missing Webhook <- WebhookDelivery foreign key. Without it the
+--    dispatcher's `include: { webhook: true }` query fails at runtime, which
+--    meant no queued delivery was ever retried.
+-- 2. Adds per-attempt observability columns (status code, timestamps) backing
+--    the retry dashboard.
+-- 3. Adds claim columns (lockedAt / lockedBy) so concurrent workers cannot
+--    dispatch the same delivery twice.
+-- 4. Renames the terminal `failed` status to `dead_letter`.
+--
+-- The Webhook / WebhookDelivery tables were introduced by a loose SQL file
+-- (add_webhooks_dust_affiliates.sql) that `prisma migrate deploy` never
+-- applies, so both tables are created here when absent. Every statement is
+-- idempotent, making this migration safe against databases that already ran
+-- the loose file as well as against a freshly provisioned one.
+
+CREATE TABLE IF NOT EXISTS "Webhook" (
+  "id"          TEXT NOT NULL PRIMARY KEY,
+  "url"         TEXT NOT NULL,
+  "description" TEXT,
+  "eventType"   TEXT NOT NULL DEFAULT '*',
+  "secretKey"   TEXT NOT NULL DEFAULT '',
+  "isActive"    BOOLEAN NOT NULL DEFAULT true,
+  "createdAt"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "Webhook_url_key" ON "Webhook"("url");
+CREATE INDEX IF NOT EXISTS "Webhook_eventType_idx" ON "Webhook"("eventType");
+CREATE INDEX IF NOT EXISTS "Webhook_isActive_idx" ON "Webhook"("isActive");
+
+CREATE TABLE IF NOT EXISTS "WebhookDelivery" (
+  "id"          TEXT NOT NULL PRIMARY KEY,
+  "webhookId"   TEXT NOT NULL,
+  "eventType"   TEXT NOT NULL,
+  "payload"     JSONB NOT NULL,
+  "status"      TEXT NOT NULL DEFAULT 'pending',
+  "attempts"    INTEGER NOT NULL DEFAULT 0,
+  "maxRetries"  INTEGER NOT NULL DEFAULT 5,
+  "nextRetryAt" TIMESTAMP(3),
+  "lastError"   TEXT,
+  "createdAt"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS "WebhookDelivery_webhookId_status_idx"
+  ON "WebhookDelivery"("webhookId", "status");
+CREATE INDEX IF NOT EXISTS "WebhookDelivery_nextRetryAt_idx"
+  ON "WebhookDelivery"("nextRetryAt");
+CREATE INDEX IF NOT EXISTS "WebhookDelivery_createdAt_idx"
+  ON "WebhookDelivery"("createdAt");
+
+-- ── Retry / dead letter columns ──────────────────────────────────────────────
+
+ALTER TABLE "WebhookDelivery" ADD COLUMN IF NOT EXISTS "lastStatusCode" INTEGER;
+ALTER TABLE "WebhookDelivery" ADD COLUMN IF NOT EXISTS "lastAttemptAt" TIMESTAMP(3);
+ALTER TABLE "WebhookDelivery" ADD COLUMN IF NOT EXISTS "deliveredAt" TIMESTAMP(3);
+ALTER TABLE "WebhookDelivery" ADD COLUMN IF NOT EXISTS "deadLetteredAt" TIMESTAMP(3);
+ALTER TABLE "WebhookDelivery" ADD COLUMN IF NOT EXISTS "deadLetterReason" TEXT;
+ALTER TABLE "WebhookDelivery" ADD COLUMN IF NOT EXISTS "lockedAt" TIMESTAMP(3);
+ALTER TABLE "WebhookDelivery" ADD COLUMN IF NOT EXISTS "lockedBy" TEXT;
+
+-- Existing terminal failures become the initial dead letter queue contents.
+UPDATE "WebhookDelivery"
+SET "status" = 'dead_letter',
+    "deadLetteredAt" = COALESCE("deadLetteredAt", "updatedAt"),
+    "deadLetterReason" = COALESCE("deadLetterReason", 'retries_exhausted')
+WHERE "status" = 'failed';
+
+-- Deliveries left mid-flight have no claim owner; return them to the queue.
+UPDATE "WebhookDelivery"
+SET "status" = 'pending',
+    "nextRetryAt" = COALESCE("nextRetryAt", CURRENT_TIMESTAMP),
+    "lockedAt" = NULL,
+    "lockedBy" = NULL
+WHERE "status" = 'delivering';
+
+-- ── Foreign key ──────────────────────────────────────────────────────────────
+
+-- Drop orphaned deliveries first, otherwise the constraint cannot validate on
+-- databases that accumulated rows while the relation was missing.
+DELETE FROM "WebhookDelivery" wd
+WHERE NOT EXISTS (
+  SELECT 1 FROM "Webhook" w WHERE w."id" = wd."webhookId"
+);
+
+ALTER TABLE "WebhookDelivery"
+  DROP CONSTRAINT IF EXISTS "WebhookDelivery_webhookId_fkey";
+
+ALTER TABLE "WebhookDelivery"
+  ADD CONSTRAINT "WebhookDelivery_webhookId_fkey"
+  FOREIGN KEY ("webhookId") REFERENCES "Webhook"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+CREATE INDEX IF NOT EXISTS "WebhookDelivery_status_nextRetryAt_idx"
+  ON "WebhookDelivery"("status", "nextRetryAt");
+
+CREATE INDEX IF NOT EXISTS "WebhookDelivery_status_lockedAt_idx"
+  ON "WebhookDelivery"("status", "lockedAt");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -205,27 +205,45 @@ model Webhook {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
+  deliveries WebhookDelivery[]
+
   @@index([eventType])
   @@index([isActive])
 }
 
 // Webhook delivery attempts for retry logic
 model WebhookDelivery {
-  id          String   @id @default(cuid())
-  webhookId   String
-  eventType   String
-  payload     Json
-  status      String   @default("pending") // pending, success, failed
-  attempts    Int      @default(0)
-  maxRetries  Int      @default(5)
-  nextRetryAt DateTime?
-  lastError   String?
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  id               String    @id @default(cuid())
+  webhookId        String
+  eventType        String
+  payload          Json
+  // pending | delivering | success | dead_letter
+  status           String    @default("pending")
+  attempts         Int       @default(0)
+  maxRetries       Int       @default(5)
+  nextRetryAt      DateTime?
+  lastError        String?
+  lastStatusCode   Int?
+  lastAttemptAt    DateTime?
+  deliveredAt      DateTime?
+  // Set when the delivery lands in the dead letter queue, either by exhausting
+  // maxRetries or by receiving a non-retryable response.
+  deadLetteredAt   DateTime?
+  deadLetterReason String?
+  // Claim fields — a worker marks rows `delivering` before sending so that
+  // concurrent workers never dispatch the same delivery twice.
+  lockedAt         DateTime?
+  lockedBy         String?
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
+
+  webhook Webhook @relation(fields: [webhookId], references: [id], onDelete: Cascade)
 
   @@index([webhookId, status])
   @@index([nextRetryAt])
   @@index([createdAt])
+  @@index([status, nextRetryAt])
+  @@index([status, lockedAt])
 }
 
 // Tracks the last synced blockchain ledger sequence

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1217,4 +1217,3 @@ model ExportAuditLog {
   @@index([createdAt])
   @@index([userId, createdAt(sort: Desc)])
 }
-}

--- a/backend/src/__jest__/webhook-dispatcher-signature.test.ts
+++ b/backend/src/__jest__/webhook-dispatcher-signature.test.ts
@@ -6,27 +6,40 @@ describe("WebhookDispatcherService signatures", () => {
   it("sends StellarStream signature, timestamp, and nonce headers on webhook deliveries", async () => {
     const updateMock = jest.fn(async () => undefined);
 
+    const claimedDelivery = {
+      id: "delivery_1",
+      webhookId: "wh_1",
+      attempts: 0,
+      maxRetries: 5,
+      payload: {
+        eventType: "split.completed",
+        splitId: "42",
+        txHash: "tx_42",
+        timestamp: "2026-03-29T00:00:00.000Z",
+      },
+      webhook: {
+        id: "wh_1",
+        url: "https://example.com/webhook",
+        secretKey: "super-secret",
+      },
+    };
+
+    // processDeliveries claims rows before sending: stale-reclaim updateMany,
+    // candidate findMany, claiming updateMany, then a findMany for the rows won.
+    const findManyMock = jest
+      .fn()
+      .mockResolvedValueOnce([{ id: claimedDelivery.id }])
+      .mockResolvedValueOnce([claimedDelivery]);
+    const updateManyMock = jest
+      .fn()
+      .mockResolvedValueOnce({ count: 0 })
+      .mockResolvedValueOnce({ count: 1 });
+
     jest.doMock("../generated/client/index.js", () => ({
       PrismaClient: jest.fn().mockImplementation(() => ({
         webhookDelivery: {
-          findMany: jest.fn(async () => [
-            {
-              id: "delivery_1",
-              attempts: 0,
-              maxRetries: 5,
-              payload: {
-                eventType: "split.completed",
-                splitId: "42",
-                txHash: "tx_42",
-                timestamp: "2026-03-29T00:00:00.000Z",
-              },
-              webhook: {
-                id: "wh_1",
-                url: "https://example.com/webhook",
-                secretKey: "super-secret",
-              },
-            },
-          ]),
+          findMany: findManyMock,
+          updateMany: updateManyMock,
           update: updateMock,
         },
       })),
@@ -76,7 +89,15 @@ describe("WebhookDispatcherService signatures", () => {
     }
     expect(updateMock).toHaveBeenCalledWith({
       where: { id: "delivery_1" },
-      data: { status: "success", attempts: 1 },
+      data: expect.objectContaining({
+        status: "success",
+        attempts: 1,
+        lastStatusCode: 200,
+        lastError: null,
+        nextRetryAt: null,
+        lockedAt: null,
+        lockedBy: null,
+      }),
     });
   });
 

--- a/backend/src/__tests__/webhook-dispatcher.service.test.ts
+++ b/backend/src/__tests__/webhook-dispatcher.service.test.ts
@@ -1,0 +1,618 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { deliveryTable, webhookTable } = vi.hoisted(() => ({
+  deliveryTable: {
+    create: vi.fn(),
+    findMany: vi.fn(),
+    findFirst: vi.fn(),
+    findUnique: vi.fn(),
+    update: vi.fn(),
+    updateMany: vi.fn(),
+    count: vi.fn(),
+    groupBy: vi.fn(),
+  },
+  webhookTable: {
+    create: vi.fn(),
+    update: vi.fn(),
+    findMany: vi.fn(),
+  },
+}));
+
+vi.mock("../generated/client/index.js", () => ({
+  PrismaClient: class {
+    webhookDelivery = deliveryTable;
+    webhook = webhookTable;
+  },
+}));
+
+vi.mock("../logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    event: vi.fn(),
+  },
+}));
+
+import { WebhookDispatcherService } from "../services/webhook-dispatcher.service.js";
+import { ConflictError, NotFoundError } from "../lib/app-error.js";
+import { MAX_RETRY_DELAY_MS } from "../lib/webhook-retry.js";
+
+const WEBHOOK = {
+  id: "wh_1",
+  url: "https://receiver.example.com/hook",
+  secretKey: "super-secret",
+};
+
+function claimedDelivery(overrides: Record<string, unknown> = {}): any {
+  return {
+    id: "del_1",
+    webhookId: WEBHOOK.id,
+    eventType: "stream.created",
+    attempts: 0,
+    maxRetries: 5,
+    payload: { eventType: "stream.created", txHash: "tx_1" },
+    webhook: WEBHOOK,
+    ...overrides,
+  };
+}
+
+/**
+ * processDeliveries issues, in order: the stale-claim updateMany, a candidate
+ * findMany, the claiming updateMany, then a findMany for the claimed rows.
+ */
+function primeClaim(deliveries: any[]): void {
+  deliveryTable.updateMany.mockResolvedValueOnce({ count: 0 }); // stale reclaim
+  deliveryTable.findMany.mockResolvedValueOnce(
+    deliveries.map((d) => ({ id: d.id })),
+  );
+  deliveryTable.updateMany.mockResolvedValueOnce({ count: deliveries.length });
+  deliveryTable.findMany.mockResolvedValueOnce(deliveries);
+}
+
+function response(status: number, headers: Record<string, string> = {}): any {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: String(status),
+    headers: {
+      get: (name: string) => headers[name.toLowerCase()] ?? null,
+    },
+  };
+}
+
+/** Data passed to the most recent webhookDelivery.update call. */
+function lastUpdateData(): any {
+  const calls = deliveryTable.update.mock.calls as any[][];
+  return calls[calls.length - 1][0].data;
+}
+
+let service: WebhookDispatcherService;
+
+beforeEach(() => {
+  // resetAllMocks (not clearAllMocks) so a mockResolvedValueOnce queue left
+  // over from a previous test can never leak into the next one.
+  vi.resetAllMocks();
+  deliveryTable.create.mockResolvedValue({});
+  deliveryTable.update.mockResolvedValue({});
+  deliveryTable.updateMany.mockResolvedValue({ count: 0 });
+  deliveryTable.findMany.mockResolvedValue([]);
+  deliveryTable.findFirst.mockResolvedValue(null);
+  deliveryTable.findUnique.mockResolvedValue(null);
+  deliveryTable.count.mockResolvedValue(0);
+  deliveryTable.groupBy.mockResolvedValue([]);
+  webhookTable.findMany.mockResolvedValue([]);
+  service = new WebhookDispatcherService();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// ═══════════════════════════════════════════════════════════════
+// Delivery outcomes
+// ═══════════════════════════════════════════════════════════════
+
+describe("processDeliveries", () => {
+  it("marks a 2xx delivery as succeeded", async () => {
+    primeClaim([claimedDelivery()]);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response(200)));
+
+    await service.processDeliveries();
+
+    const data = lastUpdateData();
+    expect(data.status).toBe("success");
+    expect(data.attempts).toBe(1);
+    expect(data.deliveredAt).toBeInstanceOf(Date);
+    expect(data.nextRetryAt).toBeNull();
+    expect(data.lastError).toBeNull();
+    // The claim must be released so the row is not seen as in-flight.
+    expect(data.lockedAt).toBeNull();
+    expect(data.lockedBy).toBeNull();
+  });
+
+  it("signs the request and sends the documented headers", async () => {
+    primeClaim([claimedDelivery()]);
+    const fetchMock = vi.fn().mockResolvedValue(response(200));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await service.processDeliveries();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(WEBHOOK.url);
+    expect(init.method).toBe("POST");
+    expect(init.headers["X-StellarStream-Signature"]).toMatch(/^sha256=[0-9a-f]{64}$/);
+    expect(init.headers["X-StellarStream-Timestamp"]).toBeTruthy();
+    expect(init.headers["X-StellarStream-Nonce"]).toMatch(/^[0-9a-f]{32}$/);
+    expect(init.headers["X-Webhook-ID"]).toBe(WEBHOOK.id);
+
+    const verified = WebhookDispatcherService.verifySignature(
+      init.body,
+      init.headers["X-StellarStream-Signature"],
+      WEBHOOK.secretKey,
+      init.headers["X-StellarStream-Timestamp"],
+      init.headers["X-StellarStream-Nonce"],
+    );
+    expect(verified).toBe(true);
+  });
+
+  it("returns a 5xx delivery to the queue with a future retry time", async () => {
+    primeClaim([claimedDelivery()]);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response(503)));
+
+    const before = Date.now();
+    await service.processDeliveries();
+
+    const data = lastUpdateData();
+    expect(data.status).toBe("pending");
+    expect(data.attempts).toBe(1);
+    expect(data.lastStatusCode).toBe(503);
+    expect(data.lastError).toBe("HTTP 503");
+    expect(data.nextRetryAt.getTime()).toBeGreaterThan(before);
+    expect(data.lockedAt).toBeNull();
+  });
+
+  it("retries a network failure", async () => {
+    primeClaim([claimedDelivery()]);
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ECONNREFUSED")));
+
+    await service.processDeliveries();
+
+    const data = lastUpdateData();
+    expect(data.status).toBe("pending");
+    expect(data.lastStatusCode).toBeNull();
+    expect(data.lastError).toBe("ECONNREFUSED");
+  });
+
+  it("backs off further on later attempts", async () => {
+    primeClaim([claimedDelivery({ attempts: 3 })]);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response(500)));
+
+    const before = Date.now();
+    await service.processDeliveries();
+
+    const data = lastUpdateData();
+    expect(data.attempts).toBe(4);
+    // Attempt 4 backs off ~8s; the jitter floor is 80% of that.
+    expect(data.nextRetryAt.getTime() - before).toBeGreaterThan(6_000);
+  });
+
+  it("honours a Retry-After header on a 429", async () => {
+    primeClaim([claimedDelivery()]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(response(429, { "retry-after": "120" })),
+    );
+
+    const before = Date.now();
+    await service.processDeliveries();
+
+    const data = lastUpdateData();
+    expect(data.status).toBe("pending");
+    const delay = data.nextRetryAt.getTime() - before;
+    expect(delay).toBeGreaterThanOrEqual(119_000);
+    expect(delay).toBeLessThanOrEqual(121_000);
+  });
+
+  it("never schedules beyond the maximum backoff window", async () => {
+    primeClaim([claimedDelivery({ attempts: 40, maxRetries: 100 })]);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response(500)));
+
+    const before = Date.now();
+    await service.processDeliveries();
+
+    const data = lastUpdateData();
+    expect(data.nextRetryAt.getTime() - before).toBeLessThanOrEqual(MAX_RETRY_DELAY_MS);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// Dead letter queue
+// ═══════════════════════════════════════════════════════════════
+
+describe("dead letter queue", () => {
+  it("dead letters immediately on a non-retryable 4xx", async () => {
+    primeClaim([claimedDelivery()]);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response(404)));
+
+    await service.processDeliveries();
+
+    const data = lastUpdateData();
+    expect(data.status).toBe("dead_letter");
+    expect(data.deadLetterReason).toBe("non_retryable_response");
+    expect(data.attempts).toBe(1);
+    expect(data.nextRetryAt).toBeNull();
+    expect(data.deadLetteredAt).toBeInstanceOf(Date);
+  });
+
+  it("dead letters once the retry budget is exhausted", async () => {
+    primeClaim([claimedDelivery({ attempts: 4, maxRetries: 5 })]);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response(500)));
+
+    await service.processDeliveries();
+
+    const data = lastUpdateData();
+    expect(data.status).toBe("dead_letter");
+    expect(data.deadLetterReason).toBe("retries_exhausted");
+    expect(data.attempts).toBe(5);
+    expect(data.lastStatusCode).toBe(500);
+  });
+
+  it("dead letters a delivery whose receiver has been removed", async () => {
+    primeClaim([claimedDelivery({ webhook: null })]);
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await service.processDeliveries();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    const data = lastUpdateData();
+    expect(data.status).toBe("dead_letter");
+    expect(data.deadLetterReason).toBe("non_retryable_response");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// Claiming / concurrency
+// ═══════════════════════════════════════════════════════════════
+
+describe("delivery claiming", () => {
+  it("claims rows conditionally on them still being pending", async () => {
+    primeClaim([claimedDelivery()]);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response(200)));
+
+    await service.processDeliveries();
+
+    const claimCall = deliveryTable.updateMany.mock.calls[1][0];
+    expect(claimCall.where.status).toBe("pending");
+    expect(claimCall.where.id).toEqual({ in: ["del_1"] });
+    expect(claimCall.data.status).toBe("delivering");
+    expect(claimCall.data.lockedBy).toEqual(expect.any(String));
+  });
+
+  it("sends nothing when a competing worker won the claim", async () => {
+    deliveryTable.updateMany.mockResolvedValueOnce({ count: 0 }); // stale reclaim
+    deliveryTable.findMany.mockResolvedValueOnce([{ id: "del_1" }]);
+    deliveryTable.updateMany.mockResolvedValueOnce({ count: 0 }); // claim lost
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await service.processDeliveries();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(deliveryTable.update).not.toHaveBeenCalled();
+  });
+
+  it("does no work when nothing is due", async () => {
+    deliveryTable.updateMany.mockResolvedValueOnce({ count: 0 });
+    deliveryTable.findMany.mockResolvedValueOnce([]);
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await service.processDeliveries();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns claims abandoned by a crashed worker to the queue", async () => {
+    deliveryTable.updateMany.mockResolvedValueOnce({ count: 3 }); // stale reclaim
+    deliveryTable.findMany.mockResolvedValueOnce([]);
+    vi.stubGlobal("fetch", vi.fn());
+
+    await service.processDeliveries();
+
+    const reclaimCall = deliveryTable.updateMany.mock.calls[0][0];
+    expect(reclaimCall.where.status).toBe("delivering");
+    expect(reclaimCall.where.lockedAt.lt).toBeInstanceOf(Date);
+    expect(reclaimCall.data.status).toBe("pending");
+    expect(reclaimCall.data.lockedBy).toBeNull();
+  });
+
+  it("delivers every claimed row in a batch", async () => {
+    primeClaim([
+      claimedDelivery({ id: "del_1" }),
+      claimedDelivery({ id: "del_2" }),
+      claimedDelivery({ id: "del_3" }),
+    ]);
+    const fetchMock = vi.fn().mockResolvedValue(response(200));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await service.processDeliveries();
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(deliveryTable.update).toHaveBeenCalledTimes(3);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// Manual retry
+// ═══════════════════════════════════════════════════════════════
+
+describe("retryDelivery", () => {
+  it("requeues a dead lettered delivery with a fresh budget", async () => {
+    deliveryTable.findUnique.mockResolvedValue({
+      id: "del_1",
+      status: "dead_letter",
+      attempts: 5,
+      maxRetries: 5,
+    });
+    deliveryTable.update.mockResolvedValue({
+      id: "del_1",
+      webhookId: WEBHOOK.id,
+      eventType: "stream.created",
+      status: "pending",
+      attempts: 5,
+      maxRetries: 10,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const result = await service.retryDelivery("del_1");
+
+    const data = deliveryTable.update.mock.calls[0][0].data;
+    expect(data.status).toBe("pending");
+    expect(data.maxRetries).toBe(10); // 5 already made + 5 fresh
+    expect(data.deadLetteredAt).toBeNull();
+    expect(data.deadLetterReason).toBeNull();
+    expect(data.nextRetryAt).toBeInstanceOf(Date);
+    expect(result.status).toBe("pending");
+  });
+
+  it("accepts a custom retry allowance", async () => {
+    deliveryTable.findUnique.mockResolvedValue({
+      id: "del_1",
+      status: "dead_letter",
+      attempts: 5,
+    });
+    deliveryTable.update.mockResolvedValue({
+      id: "del_1",
+      status: "pending",
+      attempts: 5,
+      maxRetries: 6,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await service.retryDelivery("del_1", { extraAttempts: 1 });
+
+    expect(deliveryTable.update.mock.calls[0][0].data.maxRetries).toBe(6);
+  });
+
+  it("rejects an unknown delivery", async () => {
+    deliveryTable.findUnique.mockResolvedValue(null);
+
+    await expect(service.retryDelivery("nope")).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it("refuses to retry an in-flight delivery", async () => {
+    deliveryTable.findUnique.mockResolvedValue({
+      id: "del_1",
+      status: "delivering",
+      attempts: 1,
+    });
+
+    await expect(service.retryDelivery("del_1")).rejects.toBeInstanceOf(ConflictError);
+    expect(deliveryTable.update).not.toHaveBeenCalled();
+  });
+
+  it("refuses to retry a delivery that already succeeded", async () => {
+    deliveryTable.findUnique.mockResolvedValue({
+      id: "del_1",
+      status: "success",
+      attempts: 1,
+    });
+
+    await expect(service.retryDelivery("del_1")).rejects.toBeInstanceOf(ConflictError);
+  });
+});
+
+describe("retryDeadLetterQueue", () => {
+  it("requires a selector", async () => {
+    await expect(service.retryDeadLetterQueue({})).rejects.toThrow(
+      /deliveryIds or webhookId/,
+    );
+  });
+
+  it("drains a webhook's dead letter queue", async () => {
+    deliveryTable.findMany.mockResolvedValueOnce([{ id: "del_1" }, { id: "del_2" }]);
+    deliveryTable.findUnique.mockResolvedValue({
+      id: "del_x",
+      status: "dead_letter",
+      attempts: 5,
+    });
+    deliveryTable.update.mockResolvedValue({
+      id: "del_x",
+      status: "pending",
+      attempts: 5,
+      maxRetries: 10,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const result = await service.retryDeadLetterQueue({ webhookId: WEBHOOK.id });
+
+    expect(deliveryTable.findMany.mock.calls[0][0].where).toMatchObject({
+      status: "dead_letter",
+      webhookId: WEBHOOK.id,
+    });
+    expect(result.retried).toBe(2);
+    expect(result.deliveryIds).toEqual(["del_1", "del_2"]);
+  });
+
+  it("counts only the rows that actually requeued", async () => {
+    deliveryTable.findMany.mockResolvedValueOnce([{ id: "del_1" }, { id: "del_2" }]);
+    deliveryTable.findUnique
+      .mockResolvedValueOnce({ id: "del_1", status: "dead_letter", attempts: 5 })
+      .mockResolvedValueOnce(null);
+    deliveryTable.update.mockResolvedValue({
+      id: "del_1",
+      status: "pending",
+      attempts: 5,
+      maxRetries: 10,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const result = await service.retryDeadLetterQueue({
+      deliveryIds: ["del_1", "del_2"],
+    });
+
+    expect(result.retried).toBe(1);
+    expect(result.deliveryIds).toEqual(["del_1"]);
+  });
+
+  it("is a no-op when the queue is empty", async () => {
+    deliveryTable.findMany.mockResolvedValueOnce([]);
+
+    const result = await service.retryDeadLetterQueue({ webhookId: WEBHOOK.id });
+
+    expect(result).toEqual({ retried: 0, deliveryIds: [] });
+    expect(deliveryTable.update).not.toHaveBeenCalled();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// Dashboard
+// ═══════════════════════════════════════════════════════════════
+
+describe("getDeliveryStats", () => {
+  it("aggregates per-status counts, dead letter reasons and success rate", async () => {
+    deliveryTable.groupBy
+      .mockResolvedValueOnce([
+        { status: "pending", _count: { _all: 4 } },
+        { status: "delivering", _count: { _all: 1 } },
+        { status: "success", _count: { _all: 90 } },
+        { status: "dead_letter", _count: { _all: 10 } },
+      ])
+      .mockResolvedValueOnce([
+        { deadLetterReason: "retries_exhausted", _count: { _all: 7 } },
+        { deadLetterReason: "non_retryable_response", _count: { _all: 3 } },
+      ]);
+    deliveryTable.count.mockResolvedValue(2);
+    deliveryTable.findFirst.mockResolvedValue({ createdAt: new Date("2026-07-28T09:00:00Z") });
+
+    const stats = await service.getDeliveryStats();
+
+    expect(stats.counts).toEqual({
+      pending: 4,
+      delivering: 1,
+      success: 90,
+      dead_letter: 10,
+    });
+    expect(stats.total).toBe(105);
+    expect(stats.deadLetterByReason).toEqual({
+      retries_exhausted: 7,
+      non_retryable_response: 3,
+    });
+    expect(stats.dueNow).toBe(2);
+    expect(stats.successRate).toBeCloseTo(0.9);
+    expect(stats.oldestPendingAt).toEqual(new Date("2026-07-28T09:00:00Z"));
+  });
+
+  it("reports a zero success rate on an empty queue rather than NaN", async () => {
+    deliveryTable.groupBy.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+    deliveryTable.count.mockResolvedValue(0);
+    deliveryTable.findFirst.mockResolvedValue(null);
+
+    const stats = await service.getDeliveryStats();
+
+    expect(stats.successRate).toBe(0);
+    expect(stats.total).toBe(0);
+    expect(stats.oldestPendingAt).toBeNull();
+  });
+});
+
+describe("listDeliveries", () => {
+  it("applies filters and clamps the page size", async () => {
+    deliveryTable.findMany.mockResolvedValueOnce([
+      {
+        id: "del_1",
+        webhookId: WEBHOOK.id,
+        webhook: { url: WEBHOOK.url },
+        eventType: "stream.created",
+        status: "dead_letter",
+        attempts: 5,
+        maxRetries: 5,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+    deliveryTable.count.mockResolvedValue(1);
+
+    const result = await service.listDeliveries({
+      status: "dead_letter",
+      webhookId: WEBHOOK.id,
+      limit: 5_000,
+    });
+
+    const query = deliveryTable.findMany.mock.calls[0][0];
+    expect(query.where).toEqual({ status: "dead_letter", webhookId: WEBHOOK.id });
+    expect(query.take).toBe(200); // clamped from 5000
+    expect(result.total).toBe(1);
+    expect(result.deliveries[0].webhookUrl).toBe(WEBHOOK.url);
+  });
+
+  it("defaults to an unfiltered first page", async () => {
+    deliveryTable.findMany.mockResolvedValueOnce([]);
+    deliveryTable.count.mockResolvedValue(0);
+
+    const result = await service.listDeliveries();
+
+    const query = deliveryTable.findMany.mock.calls[0][0];
+    expect(query.where).toEqual({});
+    expect(query.take).toBe(50);
+    expect(query.skip).toBe(0);
+    expect(result.deliveries).toEqual([]);
+  });
+});
+
+describe("getDelivery", () => {
+  it("includes the original payload", async () => {
+    const payload = { eventType: "stream.created", txHash: "tx_1" };
+    deliveryTable.findUnique.mockResolvedValue({
+      id: "del_1",
+      webhookId: WEBHOOK.id,
+      webhook: { url: WEBHOOK.url },
+      eventType: "stream.created",
+      status: "dead_letter",
+      attempts: 5,
+      maxRetries: 5,
+      payload,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const delivery = await service.getDelivery("del_1");
+
+    expect(delivery.payload).toEqual(payload);
+    expect(delivery.webhookUrl).toBe(WEBHOOK.url);
+  });
+
+  it("rejects an unknown delivery", async () => {
+    deliveryTable.findUnique.mockResolvedValue(null);
+
+    await expect(service.getDelivery("nope")).rejects.toBeInstanceOf(NotFoundError);
+  });
+});

--- a/backend/src/__tests__/webhook-retry.test.ts
+++ b/backend/src/__tests__/webhook-retry.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+import {
+  BASE_RETRY_DELAY_MS,
+  DELIVERY_STATUSES,
+  MAX_RETRY_DELAY_MS,
+  classifyResponseStatus,
+  classifyTransportError,
+  computeBackoffDelayMs,
+  decideRetry,
+  parseRetryAfterMs,
+} from "../lib/webhook-retry.js";
+
+// Removes jitter so the exponential curve itself can be asserted exactly.
+const noJitter = { jitterRatio: 0 };
+
+describe("computeBackoffDelayMs", () => {
+  it("doubles the delay on each successive attempt", () => {
+    expect(computeBackoffDelayMs(1, noJitter)).toBe(BASE_RETRY_DELAY_MS);
+    expect(computeBackoffDelayMs(2, noJitter)).toBe(BASE_RETRY_DELAY_MS * 2);
+    expect(computeBackoffDelayMs(3, noJitter)).toBe(BASE_RETRY_DELAY_MS * 4);
+    expect(computeBackoffDelayMs(4, noJitter)).toBe(BASE_RETRY_DELAY_MS * 8);
+    expect(computeBackoffDelayMs(5, noJitter)).toBe(BASE_RETRY_DELAY_MS * 16);
+  });
+
+  it("caps the delay at MAX_RETRY_DELAY_MS", () => {
+    expect(computeBackoffDelayMs(50, noJitter)).toBe(MAX_RETRY_DELAY_MS);
+    expect(computeBackoffDelayMs(1000, noJitter)).toBe(MAX_RETRY_DELAY_MS);
+  });
+
+  it("never returns Infinity or NaN for a very large attempt count", () => {
+    const delay = computeBackoffDelayMs(Number.MAX_SAFE_INTEGER, noJitter);
+    expect(Number.isFinite(delay)).toBe(true);
+    expect(delay).toBe(MAX_RETRY_DELAY_MS);
+  });
+
+  it("treats attempt values below 1 as the first attempt", () => {
+    expect(computeBackoffDelayMs(0, noJitter)).toBe(BASE_RETRY_DELAY_MS);
+    expect(computeBackoffDelayMs(-5, noJitter)).toBe(BASE_RETRY_DELAY_MS);
+  });
+
+  it("applies jitter symmetrically around the exponential value", () => {
+    const base = BASE_RETRY_DELAY_MS * 4; // attempt 3
+
+    // random() === 0 maps to the bottom of the jitter band, 1 to the top.
+    const low = computeBackoffDelayMs(3, { jitterRatio: 0.2, random: () => 0 });
+    const high = computeBackoffDelayMs(3, { jitterRatio: 0.2, random: () => 0.999999 });
+    const mid = computeBackoffDelayMs(3, { jitterRatio: 0.2, random: () => 0.5 });
+
+    expect(low).toBe(Math.round(base * 0.8));
+    expect(high).toBeCloseTo(base * 1.2, -1);
+    expect(mid).toBe(base);
+  });
+
+  it("keeps jittered delays within [0, maxDelayMs]", () => {
+    for (let attempt = 1; attempt <= 40; attempt++) {
+      for (const random of [() => 0, () => 0.5, () => 0.9999]) {
+        const delay = computeBackoffDelayMs(attempt, { random });
+        expect(delay).toBeGreaterThanOrEqual(0);
+        expect(delay).toBeLessThanOrEqual(MAX_RETRY_DELAY_MS);
+      }
+    }
+  });
+
+  it("honours custom base and cap", () => {
+    expect(
+      computeBackoffDelayMs(3, { baseDelayMs: 100, maxDelayMs: 250, jitterRatio: 0 }),
+    ).toBe(250);
+  });
+});
+
+describe("classifyResponseStatus", () => {
+  it("treats server errors as retryable", () => {
+    for (const status of [500, 502, 503, 504, 599]) {
+      expect(classifyResponseStatus(status)).toBe("retryable");
+    }
+  });
+
+  it("treats timeout and rate limit responses as retryable", () => {
+    expect(classifyResponseStatus(408)).toBe("retryable");
+    expect(classifyResponseStatus(429)).toBe("retryable");
+  });
+
+  it("treats other client errors as permanent", () => {
+    for (const status of [400, 401, 403, 404, 410, 422]) {
+      expect(classifyResponseStatus(status)).toBe("permanent");
+    }
+  });
+
+  it("treats unfollowed redirects as permanent", () => {
+    expect(classifyResponseStatus(301)).toBe("permanent");
+  });
+
+  it("classifies transport failures as retryable", () => {
+    expect(classifyTransportError()).toBe("retryable");
+  });
+});
+
+describe("parseRetryAfterMs", () => {
+  const now = new Date("2026-07-28T12:00:00.000Z");
+
+  it("parses delay-seconds", () => {
+    expect(parseRetryAfterMs("30", now)).toBe(30_000);
+    expect(parseRetryAfterMs("0", now)).toBe(0);
+  });
+
+  it("parses an HTTP date", () => {
+    expect(parseRetryAfterMs("Tue, 28 Jul 2026 12:01:00 GMT", now)).toBe(60_000);
+  });
+
+  it("clamps a past date to zero", () => {
+    expect(parseRetryAfterMs("Tue, 28 Jul 2026 11:00:00 GMT", now)).toBe(0);
+  });
+
+  it("caps an absurdly distant value so one receiver cannot park the queue", () => {
+    expect(parseRetryAfterMs("999999999", now)).toBe(MAX_RETRY_DELAY_MS);
+  });
+
+  it("clamps a negative delay-seconds to retry-immediately", () => {
+    expect(parseRetryAfterMs("-5", now)).toBe(0);
+  });
+
+  it("returns null for absent or unparseable values", () => {
+    expect(parseRetryAfterMs(null, now)).toBeNull();
+    expect(parseRetryAfterMs(undefined, now)).toBeNull();
+    expect(parseRetryAfterMs("", now)).toBeNull();
+    expect(parseRetryAfterMs("   ", now)).toBeNull();
+    expect(parseRetryAfterMs("soon", now)).toBeNull();
+  });
+});
+
+describe("decideRetry", () => {
+  it("schedules another attempt while the budget remains", () => {
+    const decision = decideRetry({
+      attempts: 1,
+      maxRetries: 5,
+      failureKind: "retryable",
+      backoff: noJitter,
+    });
+
+    expect(decision).toEqual({ action: "retry", delayMs: BASE_RETRY_DELAY_MS });
+  });
+
+  it("dead letters once attempts reach maxRetries", () => {
+    expect(
+      decideRetry({ attempts: 5, maxRetries: 5, failureKind: "retryable" }),
+    ).toEqual({ action: "dead_letter", reason: "retries_exhausted" });
+  });
+
+  it("dead letters immediately on a permanent failure, budget notwithstanding", () => {
+    expect(
+      decideRetry({ attempts: 1, maxRetries: 5, failureKind: "permanent" }),
+    ).toEqual({ action: "dead_letter", reason: "non_retryable_response" });
+  });
+
+  it("prefers a Retry-After hint over the exponential delay", () => {
+    const decision = decideRetry({
+      attempts: 3,
+      maxRetries: 5,
+      failureKind: "retryable",
+      retryAfterMs: 7_500,
+      backoff: noJitter,
+    });
+
+    expect(decision).toEqual({ action: "retry", delayMs: 7_500 });
+  });
+
+  it("falls back to backoff when Retry-After is absent", () => {
+    const decision = decideRetry({
+      attempts: 2,
+      maxRetries: 5,
+      failureKind: "retryable",
+      retryAfterMs: null,
+      backoff: noJitter,
+    });
+
+    expect(decision).toEqual({ action: "retry", delayMs: BASE_RETRY_DELAY_MS * 2 });
+  });
+
+  it("respects a Retry-After of zero rather than treating it as missing", () => {
+    const decision = decideRetry({
+      attempts: 2,
+      maxRetries: 5,
+      failureKind: "retryable",
+      retryAfterMs: 0,
+      backoff: noJitter,
+    });
+
+    expect(decision).toEqual({ action: "retry", delayMs: 0 });
+  });
+});
+
+describe("DELIVERY_STATUSES", () => {
+  it("declares the full lifecycle", () => {
+    expect([...DELIVERY_STATUSES]).toEqual([
+      "pending",
+      "delivering",
+      "success",
+      "dead_letter",
+    ]);
+  });
+});

--- a/backend/src/api/webhooks.routes.ts
+++ b/backend/src/api/webhooks.routes.ts
@@ -2,9 +2,38 @@ import { Router, Request, Response } from "express";
 import { WebhookDispatcherService } from "../services/webhook-dispatcher.service.js";
 import { logger } from "../logger.js";
 import { requireAdmin } from "../middleware/requireAdmin.js";
+import asyncHandler from "../utils/asyncHandler.js";
+import { ValidationError } from "../lib/app-error.js";
+import { DELIVERY_STATUSES, type DeliveryStatus } from "../lib/webhook-retry.js";
 
 const router = Router();
 const webhookService = new WebhookDispatcherService();
+
+function parseStatus(value: unknown): DeliveryStatus | undefined {
+  if (value === undefined || value === "") return undefined;
+
+  if (typeof value !== "string" || !DELIVERY_STATUSES.includes(value as DeliveryStatus)) {
+    throw new ValidationError(
+      `status must be one of: ${DELIVERY_STATUSES.join(", ")}`,
+      { details: { status: value } },
+    );
+  }
+
+  return value as DeliveryStatus;
+}
+
+function parseNumber(value: unknown, field: string): number | undefined {
+  if (value === undefined || value === "") return undefined;
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new ValidationError(`${field} must be a non-negative number`, {
+      details: { [field]: value },
+    });
+  }
+
+  return parsed;
+}
 
 /**
  * @swagger
@@ -160,6 +189,206 @@ router.post("/test", async (req: Request, res: Response) => {
     res.status(500).json({ error: "Failed to test webhook" });
   }
 });
+
+/**
+ * @swagger
+ * /api/v1/webhooks/deliveries/stats:
+ *   get:
+ *     summary: Webhook delivery queue statistics
+ *     description: Aggregate counters backing the retry dashboard — per-status totals, dead letter breakdown by reason, deliveries due for retry now, and the overall success rate. Admin only.
+ *     tags: [Webhooks]
+ *     responses:
+ *       200:
+ *         description: Delivery statistics
+ *         content:
+ *           application/json:
+ *             example:
+ *               success: true
+ *               data:
+ *                 counts: { pending: 4, delivering: 1, success: 812, dead_letter: 7 }
+ *                 total: 824
+ *                 deadLetterByReason: { retries_exhausted: 5, non_retryable_response: 2 }
+ *                 dueNow: 2
+ *                 oldestPendingAt: "2026-07-28T09:12:44.000Z"
+ *                 successRate: 0.9914
+ *       403:
+ *         description: Admin credentials required
+ */
+router.get(
+  "/deliveries/stats",
+  requireAdmin,
+  asyncHandler(async (_req: Request, res: Response) => {
+    const stats = await webhookService.getDeliveryStats();
+    res.json({ success: true, data: stats });
+  })
+);
+
+/**
+ * @swagger
+ * /api/v1/webhooks/deliveries:
+ *   get:
+ *     summary: List webhook deliveries
+ *     description: Paginated delivery log for the retry dashboard. Filter by status to inspect the dead letter queue. Admin only.
+ *     tags: [Webhooks]
+ *     parameters:
+ *       - in: query
+ *         name: status
+ *         schema:
+ *           type: string
+ *           enum: [pending, delivering, success, dead_letter]
+ *       - in: query
+ *         name: webhookId
+ *         schema: { type: string }
+ *       - in: query
+ *         name: eventType
+ *         schema: { type: string }
+ *       - in: query
+ *         name: limit
+ *         schema: { type: integer, default: 50, maximum: 200 }
+ *       - in: query
+ *         name: offset
+ *         schema: { type: integer, default: 0 }
+ *     responses:
+ *       200:
+ *         description: Matching deliveries
+ *       400:
+ *         description: Invalid filter value
+ *       403:
+ *         description: Admin credentials required
+ */
+router.get(
+  "/deliveries",
+  requireAdmin,
+  asyncHandler(async (req: Request, res: Response) => {
+    const result = await webhookService.listDeliveries({
+      status: parseStatus(req.query.status),
+      webhookId: typeof req.query.webhookId === "string" ? req.query.webhookId : undefined,
+      eventType: typeof req.query.eventType === "string" ? req.query.eventType : undefined,
+      limit: parseNumber(req.query.limit, "limit"),
+      offset: parseNumber(req.query.offset, "offset"),
+    });
+
+    res.json({ success: true, data: result });
+  })
+);
+
+/**
+ * @swagger
+ * /api/v1/webhooks/deliveries/{deliveryId}:
+ *   get:
+ *     summary: Inspect a single webhook delivery
+ *     description: Returns the full delivery record including the original payload and the last recorded error. Admin only.
+ *     tags: [Webhooks]
+ *     parameters:
+ *       - in: path
+ *         name: deliveryId
+ *         required: true
+ *         schema: { type: string }
+ *     responses:
+ *       200:
+ *         description: Delivery record
+ *       403:
+ *         description: Admin credentials required
+ *       404:
+ *         description: Delivery not found
+ */
+router.get(
+  "/deliveries/:deliveryId",
+  requireAdmin,
+  asyncHandler(async (req: Request, res: Response) => {
+    const delivery = await webhookService.getDelivery(req.params.deliveryId);
+    res.json({ success: true, data: delivery });
+  })
+);
+
+/**
+ * @swagger
+ * /api/v1/webhooks/deliveries/{deliveryId}/retry:
+ *   post:
+ *     summary: Manually retry a webhook delivery
+ *     description: Requeues a dead lettered delivery for immediate re-delivery with a fresh retry budget. Admin only.
+ *     tags: [Webhooks]
+ *     parameters:
+ *       - in: path
+ *         name: deliveryId
+ *         required: true
+ *         schema: { type: string }
+ *     responses:
+ *       200:
+ *         description: Delivery requeued
+ *       403:
+ *         description: Admin credentials required
+ *       404:
+ *         description: Delivery not found
+ *       409:
+ *         description: Delivery is in flight or already succeeded
+ */
+router.post(
+  "/deliveries/:deliveryId/retry",
+  requireAdmin,
+  asyncHandler(async (req: Request, res: Response) => {
+    const delivery = await webhookService.retryDelivery(req.params.deliveryId);
+
+    res.json({
+      success: true,
+      data: delivery,
+      message: "Delivery requeued for immediate retry",
+    });
+  })
+);
+
+/**
+ * @swagger
+ * /api/v1/webhooks/deliveries/retry:
+ *   post:
+ *     summary: Bulk retry dead lettered deliveries
+ *     description: Requeues dead lettered deliveries, either by explicit id list or by draining a single webhook's dead letter queue. Admin only.
+ *     tags: [Webhooks]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               deliveryIds:
+ *                 type: array
+ *                 items: { type: string }
+ *               webhookId:
+ *                 type: string
+ *               limit:
+ *                 type: integer
+ *     responses:
+ *       200:
+ *         description: Deliveries requeued
+ *       400:
+ *         description: Neither deliveryIds nor webhookId supplied
+ *       403:
+ *         description: Admin credentials required
+ */
+router.post(
+  "/deliveries/retry",
+  requireAdmin,
+  asyncHandler(async (req: Request, res: Response) => {
+    const { deliveryIds, webhookId, limit } = req.body ?? {};
+
+    if (deliveryIds !== undefined && !Array.isArray(deliveryIds)) {
+      throw new ValidationError("deliveryIds must be an array of delivery ids");
+    }
+
+    const result = await webhookService.retryDeadLetterQueue({
+      deliveryIds,
+      webhookId,
+      limit: parseNumber(limit, "limit"),
+    });
+
+    res.json({
+      success: true,
+      data: result,
+      message: `Requeued ${result.retried} deliveries`,
+    });
+  })
+);
 
 /**
  * POST /api/v1/webhooks/:webhookId/rotate-secret

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -29,7 +29,7 @@ import { scheduleSnapshotMaintenance } from "./services/snapshot.scheduler.js";
 import { StaleStreamCleanupWorker } from "./stale-stream-cleanup.worker.js";
 import { DataIntegrityWorker } from "./data-integrity.worker.js";
 import { YieldAccrualWorker } from "./yield-accrual.worker.js";
-import { startWebhookWorker } from "./webhook-dispatcher.worker.js";
+import { startWebhookWorker, stopWebhookWorker } from "./webhook-dispatcher.worker.js";
 import { XlmBufferMonitorWorker } from "./xlm-buffer-monitor.worker.js";
 import { EventWatcherClient } from "./services/event-watcher-client.service.js";
 import { bigintSerializer } from "./middleware/bigintSerializer.js";
@@ -317,6 +317,7 @@ function shutdown(signal: string): void {
   dataIntegrityWorker.stop();
   yieldAccrualWorker.stop();
   xlmBufferMonitor.stop();
+  stopWebhookWorker();
   bridgeObserver.stop();
   ttlMonitor.stop();
   eventWatcherClient.stopListening();

--- a/backend/src/lib/webhook-retry.ts
+++ b/backend/src/lib/webhook-retry.ts
@@ -1,0 +1,179 @@
+/**
+ * Webhook retry policy (Issue #1348)
+ *
+ * Pure helpers describing *when* and *whether* a failed webhook delivery is
+ * retried. Keeping the policy free of Prisma and fetch makes the backoff curve
+ * and the retryable/permanent classification directly unit-testable, and lets
+ * the dispatcher stay focused on I/O.
+ */
+
+/** Delivery lifecycle states persisted on WebhookDelivery.status. */
+export const DELIVERY_STATUSES = [
+  "pending",
+  "delivering",
+  "success",
+  "dead_letter",
+] as const;
+
+export type DeliveryStatus = (typeof DELIVERY_STATUSES)[number];
+
+/** Why a delivery ended up in the dead letter queue. */
+export type DeadLetterReason = "retries_exhausted" | "non_retryable_response";
+
+export type FailureKind = "retryable" | "permanent";
+
+// ─── Backoff configuration ───────────────────────────────────────────────────
+
+/** Delay before the first retry. Doubles on every subsequent attempt. */
+export const BASE_RETRY_DELAY_MS = 1_000;
+
+/** Upper bound on a single backoff interval. */
+export const MAX_RETRY_DELAY_MS = 60 * 60 * 1000;
+
+/** Attempts allowed per delivery before it is dead lettered. */
+export const DEFAULT_MAX_RETRIES = 5;
+
+/**
+ * Fraction of the computed delay applied as random jitter, in both directions.
+ * Spreads retries out so a receiver coming back online is not hit by every
+ * queued delivery in the same instant.
+ */
+export const RETRY_JITTER_RATIO = 0.2;
+
+/**
+ * A receiver may ask for a longer wait via Retry-After, but we cap how far it
+ * can push a delivery out so a misbehaving endpoint cannot park the queue.
+ */
+export const MAX_RETRY_AFTER_MS = MAX_RETRY_DELAY_MS;
+
+export interface BackoffOptions {
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+  jitterRatio?: number;
+  /** Injectable for deterministic tests. Must return a value in [0, 1). */
+  random?: () => number;
+}
+
+/**
+ * Exponential backoff with symmetric jitter.
+ *
+ * `attempt` is the 1-based count of attempts already made, so the delay after
+ * the first failure is `baseDelayMs`, then 2x, 4x, ... capped at `maxDelayMs`.
+ */
+export function computeBackoffDelayMs(
+  attempt: number,
+  options: BackoffOptions = {},
+): number {
+  const {
+    baseDelayMs = BASE_RETRY_DELAY_MS,
+    maxDelayMs = MAX_RETRY_DELAY_MS,
+    jitterRatio = RETRY_JITTER_RATIO,
+    random = Math.random,
+  } = options;
+
+  const normalizedAttempt = Math.max(1, Math.floor(attempt));
+
+  // Exponent is clamped before the shift so a large attempt count cannot
+  // overflow into Infinity on the way to the cap.
+  const exponent = Math.min(normalizedAttempt - 1, 32);
+  const exponential = baseDelayMs * 2 ** exponent;
+  const capped = Math.min(exponential, maxDelayMs);
+
+  const jitterSpan = capped * jitterRatio;
+  const jitter = (random() * 2 - 1) * jitterSpan;
+
+  return Math.max(0, Math.min(Math.round(capped + jitter), maxDelayMs));
+}
+
+// ─── Failure classification ──────────────────────────────────────────────────
+
+/**
+ * Statuses below 400 that still count as a failed delivery (an unfollowed
+ * redirect, say) are permanent: retrying an identical request cannot help.
+ */
+export function classifyResponseStatus(status: number): FailureKind {
+  if (status >= 500) return "retryable";
+  if (status === 408 || status === 429) return "retryable";
+  return "permanent";
+}
+
+/**
+ * Transport-level failures (DNS, TCP reset, TLS, our own timeout abort) are
+ * always assumed transient — there is no response to inspect.
+ */
+export function classifyTransportError(): FailureKind {
+  return "retryable";
+}
+
+// ─── Retry-After ─────────────────────────────────────────────────────────────
+
+/**
+ * Parse an RFC 9110 Retry-After value, accepting both delay-seconds and an
+ * HTTP date. Returns null when the header is absent or unparseable, in which
+ * case the caller falls back to exponential backoff.
+ */
+export function parseRetryAfterMs(
+  headerValue: string | null | undefined,
+  now: Date = new Date(),
+): number | null {
+  if (!headerValue) return null;
+
+  const trimmed = headerValue.trim();
+  if (trimmed === "") return null;
+
+  // A negative delay-seconds is nonsensical but well-defined once clamped:
+  // it means "retry immediately".
+  if (/^-?\d+$/.test(trimmed)) {
+    const seconds = Number(trimmed);
+    if (!Number.isFinite(seconds)) return null;
+    return clampRetryAfter(seconds * 1000);
+  }
+
+  const target = Date.parse(trimmed);
+  if (!Number.isFinite(target)) return null;
+
+  return clampRetryAfter(target - now.getTime());
+}
+
+function clampRetryAfter(delayMs: number): number {
+  return Math.max(0, Math.min(Math.round(delayMs), MAX_RETRY_AFTER_MS));
+}
+
+// ─── Scheduling decision ─────────────────────────────────────────────────────
+
+export interface RetryDecisionInput {
+  /** Attempts already made, including the one that just failed. */
+  attempts: number;
+  maxRetries: number;
+  failureKind: FailureKind;
+  /** Delay requested by the receiver via Retry-After, when present. */
+  retryAfterMs?: number | null;
+  backoff?: BackoffOptions;
+}
+
+export type RetryDecision =
+  | { action: "retry"; delayMs: number }
+  | { action: "dead_letter"; reason: DeadLetterReason };
+
+/**
+ * Single source of truth for what happens after a failed attempt: schedule
+ * another try, or move the delivery to the dead letter queue.
+ */
+export function decideRetry(input: RetryDecisionInput): RetryDecision {
+  const { attempts, maxRetries, failureKind, retryAfterMs, backoff } = input;
+
+  if (failureKind === "permanent") {
+    return { action: "dead_letter", reason: "non_retryable_response" };
+  }
+
+  if (attempts >= maxRetries) {
+    return { action: "dead_letter", reason: "retries_exhausted" };
+  }
+
+  const delayMs =
+    retryAfterMs !== null && retryAfterMs !== undefined
+      ? retryAfterMs
+      : computeBackoffDelayMs(attempts, backoff);
+
+  return { action: "retry", delayMs };
+}

--- a/backend/src/services/webhook-dispatcher.service.ts
+++ b/backend/src/services/webhook-dispatcher.service.ts
@@ -1,6 +1,17 @@
 import { PrismaClient } from "../generated/client/index.js";
-import { createHmac, randomBytes, timingSafeEqual } from "crypto";
+import { createHmac, randomBytes, randomUUID, timingSafeEqual } from "crypto";
 import { logger } from "../logger.js";
+import { ConflictError, NotFoundError, ValidationError } from "../lib/app-error.js";
+import {
+  DEFAULT_MAX_RETRIES,
+  classifyResponseStatus,
+  classifyTransportError,
+  decideRetry,
+  parseRetryAfterMs,
+  type DeadLetterReason,
+  type DeliveryStatus,
+  type FailureKind,
+} from "../lib/webhook-retry.js";
 
 const prisma = new PrismaClient();
 
@@ -18,10 +29,97 @@ export interface WebhookPayload {
   [key: string]: unknown;
 }
 
-const RETRY_DELAYS = [1000, 5000, 30000, 300000, 900000]; // 1s, 5s, 30s, 5m, 15m
 const WEBHOOK_REPLAY_WINDOW_MS = 5 * 60 * 1000;
+const DELIVERY_TIMEOUT_MS = 10_000;
+
+/** Deliveries claimed per processing tick. */
+const DELIVERY_BATCH_SIZE = 100;
+
+/** Concurrent in-flight HTTP requests per tick. */
+const DELIVERY_CONCURRENCY = 10;
+
+/**
+ * A claim older than this is treated as abandoned (worker crashed mid-flight)
+ * and returned to the queue. Comfortably above DELIVERY_TIMEOUT_MS so a slow
+ * receiver is never double-dispatched.
+ */
+const STALE_CLAIM_MS = 5 * 60 * 1000;
+
+/** Truncation bound for receiver error text persisted on the delivery row. */
+const MAX_ERROR_LENGTH = 1_000;
+
+// ─── Dashboard types ─────────────────────────────────────────────────────────
+
+export interface DeliveryRecord {
+  id: string;
+  webhookId: string;
+  webhookUrl?: string;
+  eventType: string;
+  status: DeliveryStatus;
+  attempts: number;
+  maxRetries: number;
+  nextRetryAt: Date | null;
+  lastError: string | null;
+  lastStatusCode: number | null;
+  lastAttemptAt: Date | null;
+  deliveredAt: Date | null;
+  deadLetteredAt: Date | null;
+  deadLetterReason: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface ListDeliveriesFilters {
+  status?: DeliveryStatus;
+  webhookId?: string;
+  eventType?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface ListDeliveriesResult {
+  deliveries: DeliveryRecord[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface DeliveryStats {
+  counts: Record<DeliveryStatus, number>;
+  total: number;
+  deadLetterByReason: Record<string, number>;
+  dueNow: number;
+  oldestPendingAt: Date | null;
+  successRate: number;
+}
+
+export interface RetryResult {
+  retried: number;
+  deliveryIds: string[];
+}
+
+interface ClaimedDelivery {
+  id: string;
+  webhookId: string;
+  attempts: number;
+  maxRetries: number;
+  payload: unknown;
+  /** Null only if the receiver was deleted between claim and send. */
+  webhook: { id: string; url: string; secretKey: string } | null;
+}
+
+interface AttemptOutcome {
+  ok: boolean;
+  statusCode: number | null;
+  error: string | null;
+  failureKind: FailureKind;
+  retryAfterMs: number | null;
+}
 
 export class WebhookDispatcherService {
+  /** Identifies this process when claiming deliveries. */
+  private readonly workerId = `${process.pid}-${randomUUID()}`;
+
   /**
    * Register a new webhook for external developers
    */
@@ -107,41 +205,202 @@ export class WebhookDispatcherService {
         payload,
         status: "pending",
         attempts: 0,
-        maxRetries: 5,
+        maxRetries: DEFAULT_MAX_RETRIES,
         nextRetryAt: new Date(),
       },
     });
   }
 
+  // ─── Delivery processing ───────────────────────────────────────────────────
+
   /**
-   * Process pending webhook deliveries with exponential backoff
+   * Claim and deliver every due webhook delivery.
+   *
+   * Rows are claimed with a conditional updateMany before any HTTP request is
+   * made, so overlapping worker ticks (or several API instances) can run this
+   * concurrently without delivering the same event twice.
    */
   async processDeliveries(): Promise<void> {
-    const pending = await (prisma as any).webhookDelivery.findMany({
+    await this.reclaimStaleDeliveries();
+
+    const claimed = await this.claimDueDeliveries();
+    if (claimed.length === 0) return;
+
+    for (let i = 0; i < claimed.length; i += DELIVERY_CONCURRENCY) {
+      const batch = claimed.slice(i, i + DELIVERY_CONCURRENCY);
+
+      // One delivery blowing up (a DB hiccup while recording the outcome) must
+      // not abandon the rest of the batch. Rows left claimed are picked back up
+      // by reclaimStaleDeliveries.
+      await Promise.all(
+        batch.map((delivery) =>
+          this.attemptDelivery(delivery).catch((error) =>
+            logger.error("Unhandled webhook delivery failure", error, {
+              deliveryId: delivery.id,
+            }),
+          ),
+        ),
+      );
+    }
+  }
+
+  /**
+   * Return deliveries whose claim outlived STALE_CLAIM_MS to the queue. Without
+   * this a worker crash would strand rows in `delivering` forever.
+   */
+  private async reclaimStaleDeliveries(): Promise<number> {
+    const cutoff = new Date(Date.now() - STALE_CLAIM_MS);
+
+    const { count } = await (prisma as any).webhookDelivery.updateMany({
+      where: { status: "delivering", lockedAt: { lt: cutoff } },
+      data: {
+        status: "pending",
+        lockedAt: null,
+        lockedBy: null,
+        nextRetryAt: new Date(),
+      },
+    });
+
+    if (count > 0) {
+      logger.warn(`Reclaimed ${count} stale webhook deliveries`);
+    }
+
+    return count;
+  }
+
+  private async claimDueDeliveries(): Promise<ClaimedDelivery[]> {
+    const candidates = await (prisma as any).webhookDelivery.findMany({
       where: {
         status: "pending",
         nextRetryAt: { lte: new Date() },
       },
-      include: { webhook: true },
-      take: 100,
+      select: { id: true },
+      orderBy: { nextRetryAt: "asc" },
+      take: DELIVERY_BATCH_SIZE,
     });
 
-    for (const delivery of pending) {
-      await this.attemptDelivery(delivery);
-    }
+    if (candidates.length === 0) return [];
+
+    const candidateIds = candidates.map((row: { id: string }) => row.id);
+    const claimedAt = new Date();
+
+    // The `status: "pending"` predicate is what makes the claim exclusive: a
+    // racing worker that selected the same ids updates zero rows here.
+    const { count } = await (prisma as any).webhookDelivery.updateMany({
+      where: { id: { in: candidateIds }, status: "pending" },
+      data: { status: "delivering", lockedAt: claimedAt, lockedBy: this.workerId },
+    });
+
+    if (count === 0) return [];
+
+    return (prisma as any).webhookDelivery.findMany({
+      where: {
+        id: { in: candidateIds },
+        status: "delivering",
+        lockedBy: this.workerId,
+      },
+      include: { webhook: true },
+    });
   }
 
   /**
    * Attempt to deliver a webhook with HMAC signature
    */
-  private async attemptDelivery(delivery: any): Promise<void> {
+  private async attemptDelivery(delivery: ClaimedDelivery): Promise<void> {
     const webhook = delivery.webhook;
-    const body = JSON.stringify(delivery.payload);
+
+    // A delivery whose webhook row vanished can never succeed. The FK makes
+    // this unreachable in practice, but the queue must not spin on it.
+    if (!webhook) {
+      await this.deadLetter(
+        { id: delivery.id, webhookId: delivery.webhookId, attempts: delivery.attempts },
+        "non_retryable_response",
+        { statusCode: null, error: "Webhook receiver no longer exists" },
+      );
+      return;
+    }
+
+    const outcome = await this.sendWebhook(webhook, delivery.payload);
+    const attempts = delivery.attempts + 1;
+    const now = new Date();
+
+    if (outcome.ok) {
+      await (prisma as any).webhookDelivery.update({
+        where: { id: delivery.id },
+        data: {
+          status: "success",
+          attempts,
+          lastAttemptAt: now,
+          lastStatusCode: outcome.statusCode,
+          lastError: null,
+          nextRetryAt: null,
+          deliveredAt: now,
+          lockedAt: null,
+          lockedBy: null,
+        },
+      });
+      logger.info(`Webhook delivered: ${webhook.id}`, {
+        deliveryId: delivery.id,
+        attempts,
+      });
+      return;
+    }
+
+    const decision = decideRetry({
+      attempts,
+      maxRetries: delivery.maxRetries,
+      failureKind: outcome.failureKind,
+      retryAfterMs: outcome.retryAfterMs,
+    });
+
+    if (decision.action === "dead_letter") {
+      await this.deadLetter(
+        { id: delivery.id, webhookId: delivery.webhookId, attempts },
+        decision.reason,
+        { statusCode: outcome.statusCode, error: outcome.error },
+      );
+      return;
+    }
+
+    const nextRetryAt = new Date(now.getTime() + decision.delayMs);
+
+    await (prisma as any).webhookDelivery.update({
+      where: { id: delivery.id },
+      data: {
+        status: "pending",
+        attempts,
+        nextRetryAt,
+        lastAttemptAt: now,
+        lastStatusCode: outcome.statusCode,
+        lastError: outcome.error,
+        lockedAt: null,
+        lockedBy: null,
+      },
+    });
+
+    logger.warn(`Webhook delivery failed, retry scheduled`, {
+      deliveryId: delivery.id,
+      webhookId: webhook.id,
+      attempts,
+      maxRetries: delivery.maxRetries,
+      delayMs: decision.delayMs,
+      nextRetryAt: nextRetryAt.toISOString(),
+      statusCode: outcome.statusCode,
+      error: outcome.error,
+    });
+  }
+
+  /** Perform the signed HTTP POST and classify the result. */
+  private async sendWebhook(
+    webhook: { id: string; url: string; secretKey: string },
+    payload: unknown,
+  ): Promise<AttemptOutcome> {
+    const body = JSON.stringify(payload);
     const timestamp = new Date().toISOString();
     const nonce = this.generateNonce();
     const signature = this.signPayload(body, webhook.secretKey, timestamp, nonce);
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 10000);
+    const timeoutId = setTimeout(() => controller.abort(), DELIVERY_TIMEOUT_MS);
 
     try {
       const response = await fetch(webhook.url, {
@@ -159,54 +418,289 @@ export class WebhookDispatcherService {
         body,
         signal: controller.signal,
       });
-      clearTimeout(timeoutId);
 
       if (response.ok) {
-        await (prisma as any).webhookDelivery.update({
-          where: { id: delivery.id },
-          data: { status: "success", attempts: delivery.attempts + 1 },
-        });
-        logger.info(`Webhook delivered: ${webhook.id}`);
-      } else {
-        await this.scheduleRetry(delivery, `HTTP ${response.status}`);
+        return {
+          ok: true,
+          statusCode: response.status,
+          error: null,
+          failureKind: "retryable",
+          retryAfterMs: null,
+        };
       }
+
+      const failureKind = classifyResponseStatus(response.status);
+
+      return {
+        ok: false,
+        statusCode: response.status,
+        error: truncate(`HTTP ${response.status}`),
+        failureKind,
+        retryAfterMs:
+          failureKind === "retryable"
+            ? parseRetryAfterMs(response.headers?.get?.("retry-after"))
+            : null,
+      };
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        ok: false,
+        statusCode: null,
+        error: truncate(message),
+        failureKind: classifyTransportError(),
+        retryAfterMs: null,
+      };
+    } finally {
       clearTimeout(timeoutId);
-      const errorMsg = error instanceof Error ? error.message : String(error);
-      await this.scheduleRetry(delivery, errorMsg);
     }
+  }
+
+  /** Move a delivery into the dead letter queue. */
+  private async deadLetter(
+    delivery: { id: string; webhookId: string; attempts: number },
+    reason: DeadLetterReason,
+    outcome: { statusCode: number | null; error: string | null },
+  ): Promise<void> {
+    const now = new Date();
+
+    await (prisma as any).webhookDelivery.update({
+      where: { id: delivery.id },
+      data: {
+        status: "dead_letter",
+        attempts: delivery.attempts,
+        nextRetryAt: null,
+        lastAttemptAt: now,
+        lastStatusCode: outcome.statusCode,
+        lastError: outcome.error,
+        deadLetteredAt: now,
+        deadLetterReason: reason,
+        lockedAt: null,
+        lockedBy: null,
+      },
+    });
+
+    logger.error("Webhook delivery dead lettered", {
+      deliveryId: delivery.id,
+      webhookId: delivery.webhookId,
+      attempts: delivery.attempts,
+      reason,
+      statusCode: outcome.statusCode,
+      error: outcome.error,
+    });
+  }
+
+  // ─── Retry dashboard ───────────────────────────────────────────────────────
+
+  /** Paginated delivery listing backing the retry dashboard. */
+  async listDeliveries(filters: ListDeliveriesFilters = {}): Promise<ListDeliveriesResult> {
+    const limit = clampLimit(filters.limit);
+    const offset = Math.max(0, Math.floor(filters.offset ?? 0));
+
+    const where: Record<string, unknown> = {};
+    if (filters.status) where.status = filters.status;
+    if (filters.webhookId) where.webhookId = filters.webhookId;
+    if (filters.eventType) where.eventType = filters.eventType;
+
+    const [rows, total] = await Promise.all([
+      (prisma as any).webhookDelivery.findMany({
+        where,
+        include: { webhook: { select: { url: true } } },
+        orderBy: { createdAt: "desc" },
+        take: limit,
+        skip: offset,
+      }),
+      (prisma as any).webhookDelivery.count({ where }),
+    ]);
+
+    return {
+      deliveries: rows.map(toDeliveryRecord),
+      total,
+      limit,
+      offset,
+    };
+  }
+
+  async getDelivery(deliveryId: string): Promise<DeliveryRecord & { payload: unknown }> {
+    const row = await (prisma as any).webhookDelivery.findUnique({
+      where: { id: deliveryId },
+      include: { webhook: { select: { url: true } } },
+    });
+
+    if (!row) {
+      throw new NotFoundError("WebhookDelivery", deliveryId);
+    }
+
+    return { ...toDeliveryRecord(row), payload: row.payload };
+  }
+
+  /** Aggregate counters for the dashboard header. */
+  async getDeliveryStats(): Promise<DeliveryStats> {
+    const [grouped, deadLetterGrouped, dueNow, oldestPending] = await Promise.all([
+      (prisma as any).webhookDelivery.groupBy({
+        by: ["status"],
+        _count: { _all: true },
+      }),
+      (prisma as any).webhookDelivery.groupBy({
+        by: ["deadLetterReason"],
+        where: { status: "dead_letter" },
+        _count: { _all: true },
+      }),
+      (prisma as any).webhookDelivery.count({
+        where: { status: "pending", nextRetryAt: { lte: new Date() } },
+      }),
+      (prisma as any).webhookDelivery.findFirst({
+        where: { status: "pending" },
+        orderBy: { createdAt: "asc" },
+        select: { createdAt: true },
+      }),
+    ]);
+
+    const counts: Record<DeliveryStatus, number> = {
+      pending: 0,
+      delivering: 0,
+      success: 0,
+      dead_letter: 0,
+    };
+
+    let total = 0;
+    for (const row of grouped as { status: string; _count: { _all: number } }[]) {
+      const count = row._count._all;
+      total += count;
+      if (row.status in counts) {
+        counts[row.status as DeliveryStatus] = count;
+      }
+    }
+
+    const deadLetterByReason: Record<string, number> = {};
+    for (const row of deadLetterGrouped as {
+      deadLetterReason: string | null;
+      _count: { _all: number };
+    }[]) {
+      deadLetterByReason[row.deadLetterReason ?? "unknown"] = row._count._all;
+    }
+
+    const settled = counts.success + counts.dead_letter;
+
+    return {
+      counts,
+      total,
+      deadLetterByReason,
+      dueNow,
+      oldestPendingAt: oldestPending?.createdAt ?? null,
+      successRate: settled === 0 ? 0 : counts.success / settled,
+    };
+  }
+
+  // ─── Manual retry ──────────────────────────────────────────────────────────
+
+  /**
+   * Requeue a dead lettered delivery for immediate re-delivery.
+   *
+   * The attempt counter is preserved for audit, so `maxRetries` is extended by
+   * a fresh allowance — otherwise the requeued row would be dead lettered again
+   * on its first failure.
+   */
+  async retryDelivery(
+    deliveryId: string,
+    options: { extraAttempts?: number } = {},
+  ): Promise<DeliveryRecord> {
+    const extraAttempts = options.extraAttempts ?? DEFAULT_MAX_RETRIES;
+
+    const existing = await (prisma as any).webhookDelivery.findUnique({
+      where: { id: deliveryId },
+    });
+
+    if (!existing) {
+      throw new NotFoundError("WebhookDelivery", deliveryId);
+    }
+
+    if (existing.status === "delivering") {
+      throw new ConflictError("Delivery is currently in flight and cannot be retried", {
+        details: { deliveryId, status: existing.status },
+      });
+    }
+
+    if (existing.status === "success") {
+      throw new ConflictError("Delivery already succeeded and cannot be retried", {
+        details: { deliveryId, status: existing.status },
+      });
+    }
+
+    const updated = await (prisma as any).webhookDelivery.update({
+      where: { id: deliveryId },
+      data: {
+        status: "pending",
+        nextRetryAt: new Date(),
+        maxRetries: existing.attempts + extraAttempts,
+        deadLetteredAt: null,
+        deadLetterReason: null,
+        lockedAt: null,
+        lockedBy: null,
+      },
+      include: { webhook: { select: { url: true } } },
+    });
+
+    logger.info("Webhook delivery manually requeued", {
+      deliveryId,
+      attempts: existing.attempts,
+      maxRetries: updated.maxRetries,
+    });
+
+    return toDeliveryRecord(updated);
   }
 
   /**
-   * Schedule retry with exponential backoff
+   * Bulk requeue. Pass explicit ids, or a webhookId to drain that receiver's
+   * entire dead letter queue.
    */
-  private async scheduleRetry(delivery: any, error: string): Promise<void> {
-    const nextAttempt = delivery.attempts + 1;
+  async retryDeadLetterQueue(
+    selector: { deliveryIds?: string[]; webhookId?: string; limit?: number } = {},
+  ): Promise<RetryResult> {
+    const { deliveryIds, webhookId } = selector;
+    const limit = clampLimit(selector.limit);
 
-    if (nextAttempt >= delivery.maxRetries) {
-      await (prisma as any).webhookDelivery.update({
-        where: { id: delivery.id },
-        data: {
-          status: "failed",
-          attempts: nextAttempt,
-          lastError: error,
-        },
-      });
-      logger.warn(`Webhook delivery failed after ${nextAttempt} attempts: ${delivery.webhookId}`);
-    } else {
-      const delayMs = RETRY_DELAYS[nextAttempt - 1] || 900000;
-      const nextRetryAt = new Date(Date.now() + delayMs);
-
-      await (prisma as any).webhookDelivery.update({
-        where: { id: delivery.id },
-        data: {
-          attempts: nextAttempt,
-          nextRetryAt,
-          lastError: error,
-        },
-      });
+    if (!deliveryIds?.length && !webhookId) {
+      throw new ValidationError("Provide deliveryIds or webhookId to retry");
     }
+
+    const where: Record<string, unknown> = { status: "dead_letter" };
+    if (deliveryIds?.length) where.id = { in: deliveryIds };
+    if (webhookId) where.webhookId = webhookId;
+
+    const targets = await (prisma as any).webhookDelivery.findMany({
+      where,
+      select: { id: true },
+      take: limit,
+    });
+
+    if (targets.length === 0) {
+      return { retried: 0, deliveryIds: [] };
+    }
+
+    const ids: string[] = targets.map((row: { id: string }) => row.id);
+
+    // Requeued rows keep their attempt history; retryDelivery tops the retry
+    // allowance up per row so each gets a full fresh budget.
+    const results = await Promise.all(
+      ids.map((id: string): Promise<string | null> =>
+        this.retryDelivery(id).then(
+          () => id,
+          (error: unknown) => {
+            logger.warn("Failed to requeue webhook delivery", { deliveryId: id, error });
+            return null;
+          },
+        ),
+      ),
+    );
+
+    const requeued = results.filter((id: string | null): id is string => id !== null);
+
+    logger.info(`Requeued ${requeued.length} dead lettered webhook deliveries`);
+
+    return { retried: requeued.length, deliveryIds: requeued };
   }
+
+  // ─── Signing ───────────────────────────────────────────────────────────────
 
   /**
    * Generate HMAC-SHA256 signature
@@ -282,4 +776,36 @@ export class WebhookDispatcherService {
       timingSafeEqual(expectedBuffer, actualBuffer)
     );
   }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function truncate(value: string): string {
+  return value.length > MAX_ERROR_LENGTH ? value.slice(0, MAX_ERROR_LENGTH) : value;
+}
+
+function clampLimit(limit: number | undefined, fallback = 50, max = 200): number {
+  if (limit === undefined || !Number.isFinite(limit)) return fallback;
+  return Math.min(Math.max(1, Math.floor(limit)), max);
+}
+
+function toDeliveryRecord(row: Record<string, any>): DeliveryRecord {
+  return {
+    id: row.id,
+    webhookId: row.webhookId,
+    webhookUrl: row.webhook?.url,
+    eventType: row.eventType,
+    status: row.status,
+    attempts: row.attempts,
+    maxRetries: row.maxRetries,
+    nextRetryAt: row.nextRetryAt ?? null,
+    lastError: row.lastError ?? null,
+    lastStatusCode: row.lastStatusCode ?? null,
+    lastAttemptAt: row.lastAttemptAt ?? null,
+    deliveredAt: row.deliveredAt ?? null,
+    deadLetteredAt: row.deadLetteredAt ?? null,
+    deadLetterReason: row.deadLetterReason ?? null,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
 }

--- a/backend/src/webhook-dispatcher.worker.ts
+++ b/backend/src/webhook-dispatcher.worker.ts
@@ -3,18 +3,54 @@ import { logger } from "./logger.js";
 
 const webhookService = new WebhookDispatcherService();
 
+const DEFAULT_POLL_INTERVAL_MS = 10_000;
+
+let timer: NodeJS.Timeout | null = null;
+let running = false;
+
+function resolvePollIntervalMs(): number {
+  const configured = Number(process.env.WEBHOOK_WORKER_INTERVAL_MS);
+  return Number.isFinite(configured) && configured > 0
+    ? configured
+    : DEFAULT_POLL_INTERVAL_MS;
+}
+
 /**
- * Background worker to process webhook deliveries with retry logic
- * Runs every 10 seconds
+ * Background worker that drains the webhook delivery queue, applying
+ * exponential backoff and dead lettering exhausted deliveries.
+ *
+ * Ticks are guarded by a re-entrancy flag: a slow batch never overlaps with the
+ * next interval, which would otherwise let two ticks contend for the same rows.
  */
 export async function startWebhookWorker(): Promise<void> {
-  logger.info("Starting webhook dispatcher worker");
+  const intervalMs = resolvePollIntervalMs();
 
-  setInterval(async () => {
+  logger.info(`Starting webhook dispatcher worker (every ${intervalMs}ms)`);
+
+  timer = setInterval(async () => {
+    if (running) {
+      logger.debug("Webhook dispatcher tick skipped, previous run still active");
+      return;
+    }
+
+    running = true;
     try {
       await webhookService.processDeliveries();
     } catch (error) {
       logger.error("Error in webhook dispatcher worker", error);
+    } finally {
+      running = false;
     }
-  }, 10000); // Process every 10 seconds
+  }, intervalMs);
+
+  // Do not hold the event loop open on shutdown.
+  timer.unref?.();
+}
+
+export function stopWebhookWorker(): void {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+    logger.info("Webhook dispatcher worker stopped");
+  }
 }


### PR DESCRIPTION
## Issue Reference
Closes #1348

## Summary
Adds intelligent retry for failed webhook deliveries: exponential backoff with jitter, a dead letter queue, and admin endpoints for inspecting and replaying failures.

**The retry pipeline was not running at all before this PR.** `WebhookDelivery` carried a `webhookId` column but the schema declared no relation to `Webhook`, while the dispatcher queued deliveries with `include: { webhook: true }`. Prisma rejects that include for a model without the relation, so every `processDeliveries()` call threw before sending a single request. The migration adds the foreign key; everything else is built on top of it.

## Acceptance Criteria
- [x] **Retries working with backoff** - exponential + jitter, replacing the fixed delay array
- [x] **Failed webhooks tracked** - `dead_letter` status with reason, status code, error and attempt timestamps
- [x] **Manual retry option** - single and bulk endpoints
- [x] **Dead letter queue**
- [x] **Retry dashboard** - queue stats, filterable delivery log, per-delivery detail

## Implementation

### Backoff (`src/lib/webhook-retry.ts`)
Policy is isolated as pure functions so the curve and the failure classification are directly unit-testable.

| Attempt | Delay |
|--------:|-------|
| 1 | 1s |
| 2 | 2s |
| 3 | 4s |
| 4 | 8s |
| n | `1s * 2^(n-1)`, capped at 1h |

- +/-20% jitter so a recovering receiver is not hit by the whole queue at once.
- `Retry-After` on 429/503 overrides the computed delay, clamped to the same 1h ceiling so one receiver cannot park the queue.
- 5xx, 408, 429 and transport errors retry. Other 4xx dead letter immediately - an identical retry cannot succeed.

### Dead letter queue
Terminal `failed` becomes `dead_letter`, tagged with `deadLetterReason` (`retries_exhausted` | `non_retryable_response`) plus the last status code, error and attempt timestamps. Dead lettered rows keep their payload and are never retried automatically.

### Concurrency
Deliveries are claimed before any HTTP request:

```sql
UPDATE "WebhookDelivery" SET status = 'delivering', "lockedBy" = $worker
WHERE id IN (...) AND status = 'pending'
```

The `status = 'pending'` predicate makes the claim exclusive - a racing worker updates zero rows and sends nothing. This lets several API instances and the `dispatch()` fast path run the queue concurrently without double-delivering. Claims abandoned by a crashed worker are reclaimed after 5 minutes. Batches of 100 per tick, 10 concurrent sends, per-delivery error isolation.

### API (admin-only, `/api/v1/webhooks`)
| Method | Path | Purpose |
|--------|------|---------|
| `GET` | `/deliveries/stats` | Queue counters, dead letter breakdown, success rate |
| `GET` | `/deliveries` | Filterable, paginated delivery log |
| `GET` | `/deliveries/:id` | Single delivery including payload |
| `POST` | `/deliveries/:id/retry` | Requeue one delivery |
| `POST` | `/deliveries/retry` | Bulk requeue by ids or `webhookId` |

Manual retry preserves the historical `attempts` count for audit and extends `maxRetries` by a fresh allowance, so a requeued delivery is not dead lettered again on its first failure. In-flight and already-succeeded deliveries are rejected with `409`.

### Worker
Re-entrancy guard so a slow batch never overlaps the next tick, configurable interval via `WEBHOOK_WORKER_INTERVAL_MS`, and wired into graceful shutdown.

## Testing
**55 new tests, all passing.**

- `src/__tests__/webhook-retry.test.ts` - backoff curve, cap, jitter bounds, overflow safety, failure classification, `Retry-After` parsing, retry/dead-letter decisions.
- `src/__tests__/webhook-dispatcher.service.test.ts` - delivery outcomes, dead lettering, claim exclusivity (including losing a race), stale-claim reclaim, manual retry, dashboard queries.
- `src/__jest__/webhook-dispatcher-signature.test.ts` - updated for the new claim flow; signature assertions unchanged.

Verified on this branch: **0 type errors and 0 lint errors in every file touched.**

## Files Changed
**New**
- `src/lib/webhook-retry.ts` - retry policy
- `src/__tests__/webhook-retry.test.ts`, `src/__tests__/webhook-dispatcher.service.test.ts`
- `prisma/migrations/20260728120000_add_webhook_retry_dead_letter/migration.sql`
- `WEBHOOK_RETRY.md` - behaviour, API and configuration reference

**Modified**
- `src/services/webhook-dispatcher.service.ts` - claim-based processing, backoff, dead lettering, dashboard queries
- `src/api/webhooks.routes.ts` - five admin endpoints with Swagger docs
- `src/webhook-dispatcher.worker.ts` - re-entrancy guard, configurable interval, stop hook
- `src/index.ts` - worker wired into graceful shutdown
- `prisma/schema.prisma` - relation, retry/dead-letter columns, claim columns, indexes

## Notes for reviewers

**The migration is deliberately defensive.** CI runs `prisma migrate deploy` against a fresh Postgres, but `Webhook`/`WebhookDelivery` only exist in `add_webhooks_dust_affiliates.sql` - a loose file in `prisma/migrations/` that `migrate deploy` never applies. The migration therefore creates both tables when absent before altering them, and every statement is idempotent, so it works on a fresh database and on one that already ran the loose file. It has not been executed against a live Postgres yet.

**Second commit is an unrelated one-character fix.** `0fcec47` left a stray `}` after the `ExportAuditLog` model, so `schema.prisma` fails validation with `P1012` and `prisma generate` errors - which blocks every backend CI step on `main` today. It is isolated in its own commit and can be dropped or split out.

**Pre-existing issues found while verifying, not addressed here:**
1. `src/generated/client` has unresolved merge conflict markers in 7 committed files, including `index.d.ts` and `index.js`. These produce 198 `TS1185` errors and also block `prisma generate` from overwriting them.
2. Lockfile pins CLI `prisma@5.22.0` against `@prisma/client@7.9.1` - incompatible in both directions (the v5 CLI needs `generator-build/`, which v7 does not ship; the v7 CLI rejects `url = env(...)` in the datasource). Resolving it means deciding whether the repo targets Prisma 5 or 7.

Both look worth their own issues.
